### PR TITLE
openHAB bind mounts, Samba improvements

### DIFF
--- a/includes/smb.conf
+++ b/includes/smb.conf
@@ -26,18 +26,18 @@
 ## Browsing/Identification ###
 
 # Change this to the workgroup/NT-domain name your Samba server will part of
-   workgroup = WORKGROUP
+  workgroup = WORKGROUP
 
 # Windows Internet Name Serving Support Section:
 # WINS Support - Tells the NMBD component of Samba to enable its WINS Server
-   wins support = yes
+  wins support = yes
 
 # WINS Server - Tells the NMBD components of Samba to be a WINS Client
 # Note: Samba can be either a WINS Server, or a WINS Client, but NOT both
 ;   wins server = w.x.y.z
 
 # This will prevent nmbd to search for NetBIOS names through DNS.
-   dns proxy = no
+  dns proxy = no
 
 #### Networking ####
 
@@ -59,10 +59,10 @@
 
 # This tells Samba to use a separate log file for each machine
 # that connects
-   log file = /var/log/samba/log.%m
+  log file = /var/log/samba/log.%m
 
 # Cap the size of the individual log files (in KiB).
-   max log size = 1000
+  max log size = 1000
 
 # If you want Samba to only log through syslog then set the following
 # parameter to 'yes'.
@@ -71,10 +71,10 @@
 # We want Samba to log a minimum amount of information to syslog. Everything
 # should go to /var/log/samba/log.{smbd,nmbd} instead. If you want to log
 # through syslog you should set the following parameter to something higher.
-   syslog = 0
+  syslog = 0
 
 # Do something sensible when Samba crashes: mail the admin a backtrace
-   panic action = /usr/share/samba/panic-action %d
+;   panic action = /usr/share/samba/panic-action %d
 
 
 ####### Authentication #######
@@ -88,33 +88,32 @@
 # Running as "active directory domain controller" will require first
 # running "samba-tool domain provision" to wipe databases and create a
 # new domain.
-   server role = standalone server
+  server role = standalone server
 
 # If you are using encrypted passwords, Samba will need to know what
 # password database type you are using.
-   passdb backend = tdbsam
-
-   obey pam restrictions = yes
+  passdb backend = tdbsam
+  obey pam restrictions = yes
 
 # This boolean parameter controls whether Samba attempts to sync the Unix
 # password with the SMB password when the encrypted SMB password in the
 # passdb is changed.
-   unix password sync = yes
+  unix password sync = yes
 
 # For Unix password sync to work on a Debian GNU/Linux system, the following
 # parameters must be set (thanks to Ian Kahan <<kahan@informatik.tu-muenchen.de> for
 # sending the correct chat script for the passwd program in Debian Sarge).
-   passwd program = /usr/bin/passwd %u
-   passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
+  passwd program = /usr/bin/passwd %u
+  passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
 
 # This boolean controls whether PAM will be used for password changes
 # when requested by an SMB client instead of the program listed in
 # 'passwd program'. The default is 'no'.
-   pam password change = yes
+  pam password change = yes
 
 # This option controls how unsuccessful authentication attempts are mapped
 # to anonymous connections
-   map to guest = bad user
+  map to guest = bad user
 
 ########## Domains ###########
 
@@ -180,53 +179,17 @@
 
 # Allow users who've been granted usershare privileges to create
 # public shares, not just authenticated ones
-   usershare allow guests = yes
+;   usershare allow guests = yes
 
 #======================= Share Definitions =======================
 
-;[homes]
-;   comment = Home Directories
-;   browseable = no
-
-# By default, the home directories are exported read-only. Change the
-# next parameter to 'no' if you want to be able to write to them.
-;   read only = yes
-
-# File creation mask is set to 0700 for security reasons. If you want to
-# create files with group=rw permissions, set next parameter to 0775.
-;   create mask = 0700
-
-# Directory creation mask is set to 0700 for security reasons. If you want to
-# create dirs. with group=rw permissions, set next parameter to 0775.
-;   directory mask = 0700
-
-# By default, \\server\username shares can be connected to by anyone
-# with access to the samba server.
-# The following parameter makes sure that only "username" can connect
-# to \\server\username
-# This might need tweaking when using external authentication schemes
-;   valid users = %S
-
-# Un-comment the following and create the netlogon directory for Domain Logons
-# (you need to configure Samba to act as a domain controller too.)
-;[netlogon]
-;   comment = Network Logon Service
-;   path = /home/samba/netlogon
-;   guest ok = yes
-;   read only = yes
-
-# Un-comment the following and create the profiles directory to store
-# users profiles (see the "logon path" option above)
-# (you need to configure Samba to act as a domain controller too.)
-# The path below should be writable by all users so that their
-# profile directory may be created the first time they log on
-;[profiles]
-;   comment = Users profiles
-;   path = /home/samba/profiles
-;   guest ok = no
-;   browseable = no
-;   create mask = 0600
-;   directory mask = 0700
+[homes]
+  comment = Home Directories
+  browseable = no
+  valid users = %S
+  writeable = yes
+  create mask = 0700
+  directory mask = 0700
 
 [printers]
    comment = All Printers
@@ -254,65 +217,64 @@
 # to the drivers directory for these users to have write rights in it
 ;   write list = root, @lpadmin
 
+#=================== Custom Share Definitions ====================
 
-;[var-www]
-;  comment=webserver files
-;  path=/var/www
-;  browseable=Yes
-;  writeable=Yes
-;  only guest=no
-;  public=no
-;  create mask=0777
-;  directory mask=0777
-
-;[opt]
-;  comment=opt folder
-;  path=/opt
-;  browseable=Yes
-;  writeable=Yes
-;  only guest=no
-;  public=no
-;  create mask=0777
-;  directory mask=0777
-
-[openHAB-log]
-  comment=openHAB2 log files
-  path=/var/log/openhab2
-  browseable=Yes
-  writeable=Yes
-  only guest=no
+[openHAB-share]
+  comment=openHAB2 combined folders
+  path=/srv
+  writeable=yes
   public=no
-  create mask=0777
-  directory mask=0777
-
-[openHAB-sys]
-  comment=openHAB2 application
-  path=/usr/share/openhab2
-  browseable=Yes
-  writeable=Yes
-  only guest=no
-  public=no
-  create mask=0777
-  directory mask=0777
-
-[openHAB-userdata]
-  comment=openHAB2 userdata
-  path=/var/lib/openhab2
-  browseable=Yes
-  writeable=Yes
-  only guest=no
-  public=no
-  create mask=0777
-  directory mask=0777
+  create mask=0664
+  directory mask=0775
 
 [openHAB-conf]
   comment=openHAB2 site configuration
   path=/etc/openhab2
-  browseable=Yes
-  writeable=Yes
-  only guest=no
+  writeable=yes
   public=no
-  create mask=0777
-  directory mask=0777
+  create mask=0664
+  directory mask=0775
+
+;[openHAB-userdata]
+;  comment=openHAB2 userdata
+;  path=/var/lib/openhab2
+;  writeable=yes
+;  public=no
+;  create mask=0664
+;  directory mask=0775
+
+;[openHAB-sys]
+;  comment=openHAB2 application
+;  path=/usr/share/openhab2
+;  writeable=yes
+;  public=no
+;  create mask=0664
+;  directory mask=0775
+
+;[openHAB-log]
+;  comment=openHAB2 log files
+;  path=/var/log/openhab2
+;  writeable=yes
+;  public=no
+;  create mask=0664
+;  directory mask=0775
+
+;[var-www]
+;  comment=webserver files
+;  path=/var/www
+;  writeable=yes
+;  only guest=no
+;  public=no
+;  create mask=0664
+;  directory mask=0775
+
+;[opt]
+;  comment=opt folder
+;  path=/opt
+;  writeable=yes
+;  only guest=no
+;  public=no
+;  create mask=0664
+;  directory mask=0775
 
 # vim: filetype=samba

--- a/includes/smb.conf
+++ b/includes/smb.conf
@@ -226,6 +226,8 @@
   public=no
   create mask=0664
   directory mask=0775
+  veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/._*/
+  delete veto files = yes
 
 [openHAB-conf]
   comment=openHAB2 site configuration

--- a/includes/srv_readme.txt
+++ b/includes/srv_readme.txt
@@ -1,12 +1,12 @@
 openHAB Shortcut Folders
 
-Please be aware, that this folder only contains links (bind mounts) to all
-relevant openHAB folders, which are located elsewhere on the file system,
-compare http://docs.openhab.org/installation/linux.html#file-locations
+This folder contains links (bind mounts) to all relevant openHAB folders, which
+are located elsewhere on the file system. Compare the folder structure:
+http://docs.openhab.org/installation/linux.html#file-locations
 
-You can access the folder via Samba network share and should have write access
+You can access this folder via Samba network share and should have write access
 to all subdirectories. The only exception is the 'openhab2-sys' folder, which
-you should not need to write to.
+you should not need to write to and was left out for security reasons.
 
 A few hints:
 

--- a/includes/srv_readme.txt
+++ b/includes/srv_readme.txt
@@ -1,7 +1,7 @@
 openHAB Shortcut Folders
 
 This folder contains links (bind mounts) to all relevant openHAB folders, which
-are located elsewhere on the file system. Compare the folder structure:
+are located elsewhere on the file system. Compare the actual folder structure:
 http://docs.openhab.org/installation/linux.html#file-locations
 
 You can access this folder via Samba network share and should have write access
@@ -14,13 +14,18 @@ A few hints:
   http://docs.openhab.org/installation/linux.html#mounting-locally
 
 - Using the 'openhab-etc' subdirectory with the SmartHome Designer requires the
-  folder to be mounted (Windows).
+  main folder to be mounted (Windows).
   http://docs.openhab.org/installation/designer.html#network-preparations
 
 - The content of the subdirectories should be backed up on a regular basis,
   if you ever need to restore files from a backup, please be careful which
-  files to overwrite and make sure to correct the permissions.
+  files you overwrite and make sure to correct the permissions.
   http://docs.openhab.org/installation/linux.html#backup-and-restore
+
+- If you ever have access right problems (e.g. missing write permissions) or
+  have restored files and need to make sure they have the right set of owner,
+  group and permissions, please execute the "Fix Permissions" menu entry from
+  the openHABian Configuation Tool.
 
 Enjoy your openHAB experience with openHABian
 http://docs.openhab.org/installation/openhabian.html

--- a/includes/srv_readme.txt
+++ b/includes/srv_readme.txt
@@ -1,0 +1,26 @@
+openHAB Shortcut Folders
+
+Please be aware, that this folder only contains links (bind mounts) to all
+relevant openHAB folders, which are located elsewhere on the file system,
+compare http://docs.openhab.org/installation/linux.html#file-locations
+
+You can access the folder via Samba network share and should have write access
+to all subdirectories. The only exception is the 'openhab2-sys' folder, which
+you should not need to write to.
+
+A few hints:
+
+- You might want to mount this folder locally:
+  http://docs.openhab.org/installation/linux.html#mounting-locally
+
+- Using the 'openhab-etc' subdirectory with the SmartHome Designer requires the
+  folder to be mounted (Windows).
+  http://docs.openhab.org/installation/designer.html#network-preparations
+
+- The content of the subdirectories should be backed up on a regular basis,
+  if you ever need to restore files from a backup, please be careful which
+  files to overwrite and make sure to correct the permissions.
+  http://docs.openhab.org/installation/linux.html#backup-and-restore
+
+Enjoy your openHAB experience with openHABian
+http://docs.openhab.org/installation/openhabian.html

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -276,7 +276,7 @@ needed_packages() {
   # Install avahi-daemon - hostname based discovery on local networks
   # Install python/python-pip - for python packages
   echo -n "$(timestamp) [openHABian] Installing additional needed packages... "
-  cond_redirect apt update
+  #cond_redirect apt update
   cond_redirect apt -y install apt-transport-https bc sysstat avahi-daemon python python-pip
   if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
 }

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1165,11 +1165,24 @@ openhabian_update() {
     git -C $SCRIPTDIR remote set-url origin https://github.com/openhab/openhabian.git
   fi
   echo -n "$(timestamp) [openHABian] Updating myself... "
+  read -t 1 -n 1 key
+  if [ "$key" != "" ]; then
+    echo -e "\nRemote git branches available:"
+    git -C $SCRIPTDIR branch -r
+    read -e -p "Please enter the branch to checkout: " branch
+    branch="${branch#origin/}"
+    if ! git -C $SCRIPTDIR branch -r | grep -q "origin/$branch"; then
+      echo "FAILED - The custom branch does not exist."
+      return 1
+    fi
+  else
+    branch="master"
+  fi
   shorthash_before=$(git -C $SCRIPTDIR log --pretty=format:'%h' -n 1)
   git -C $SCRIPTDIR fetch --quiet origin || FAILED=1
-  git -C $SCRIPTDIR reset --quiet --hard origin/master || FAILED=1
+  git -C $SCRIPTDIR reset --quiet --hard "origin/$branch" || FAILED=1
   git -C $SCRIPTDIR clean --quiet --force -x -d || FAILED=1
-  git -C $SCRIPTDIR checkout --quiet master || FAILED=1
+  git -C $SCRIPTDIR checkout --quiet "$branch" || FAILED=1
   if [ $FAILED -eq 1 ]; then
     echo "FAILED - There was a problem fetching the latest changes for the openHABian configuration tool. Please check your internet connection and try again later..."
     return 1

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -507,9 +507,12 @@ permissions_corrections() {
   cond_redirect adduser $username tty
   #
   openhab_folders=(/etc/openhab2 /var/lib/openhab2 /var/log/openhab2 /usr/share/openhab2/addons)
-  cond_redirect chown -R openhab:$username /opt ${openhab_folders[@]}
-  cond_redirect chmod -R g+w /opt ${openhab_folders[@]}
+  cond_redirect chown openhab:$username /srv /srv/README.txt
   cond_redirect chmod ugo+w /srv /srv/README.txt
+  cond_redirect chown -R openhab:openhab /usr/share/openhab2
+  cond_redirect chown -R openhab:$username /opt ${openhab_folders[@]}
+  cond_redirect chmod -R ug+wX /opt ${openhab_folders[@]}
+  cond_redirect chown -R $username:$username /home/$username
   echo "OK"
 }
 

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -517,11 +517,14 @@ misc_system_settings() {
   echo -n "$(timestamp) [openHABian] Applying multiple useful system settings (permissions, java cap, ...)... "
   cond_redirect setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' $(realpath /usr/bin/java)
   if is_pine64; then cond_redirect dpkg --add-architecture armhf; fi
+  # user home note
+  echo -e "This is your linux user's \"home\" folder.\nPlace personal files, programs or scripts here." > /home/$username/README.txt
   # prepare SSH key file for the end user
   mkdir /home/$username/.ssh
   chmod 700 /home/$username/.ssh
   touch /home/$username/.ssh/authorized_keys
   chmod 600 /home/$username/.ssh/authorized_keys
+  chown -R $username:$username /home/$username/.ssh
   echo "OK"
 }
 


### PR DESCRIPTION
Make accessing the RPi files easier:
* All openHAB folders are now bind mounted subdirectories to `/srv/` #113 
* Folder includes README for clarity
* The folder is shared via samba
* Samba now also shares the user home
* Widened the write permissions of the user to everything besides /usr/share/openhab2 (user shouldn't need that)
* Changed a few samba details while I was at it

Also in here:
* Added an empty ~/.ssh/authorized_keys for ease of use
* Security: The initial user password is now removed from openhabian.conf after setup
* Hostname function is now also called during setup, in case the user set a hostname via config file beforehand

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)