### PR TITLE
Amanda fixes

### DIFF
--- a/includes/amanda.conf_template
+++ b/includes/amanda.conf_template
@@ -6,6 +6,7 @@ runspercycle 7						# Run 7 times every 14 days
 tapecycle %TAPES tapes					# Dump to this number of different tapes during the cycle
 runtapes 1
 tpchanger %TPCHANGER
+taper-parallel-write 2
 autolabel "openHABian-%CONFIG-%%%" empty
 changerfile "%CONFDIR/storagestate"			# The tape-changer or SD- or disk slot or S3 state file
 tapelist "%CONFDIR/tapelist"				# The tapelist file

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1319,12 +1319,11 @@ create_backup_config() {
       if ! (whiptail --title "Storage container creation" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then return 0; fi
   fi
   # create virtual 'tapes'
-  ln -s ${storage}/slots ${storage}/slots/drive0
+  ln -s ${storage}/slots ${storage}/slots/drive0;ln -s ${storage}/slots ${storage}/slots/drive1		# taper-parallel-write 2 so we need 2 virtual drives
   counter=1
   while [ ${counter} -le ${tapes} ]; do
       if [ "${config}" = "openhab-dir" ]; then
           mkdir -p ${storage}/slots/slot${counter}
-	  ln -s ${storage}/slots ${storage}/slots/drive${counter}	# not sure how many virtual drives we need beyond drive0
 
           tpchanger="\"chg-disk:${storage}/slots\"    # The tape-changer glue script"
           tapetype="DIRECTORY"
@@ -1347,9 +1346,10 @@ create_backup_config() {
       let counter+=1
   done
 
-  if [ -n "$INTERACTIVE" ]; then
-      adminmail=$(whiptail --title "Admin reports" --inputbox "Enter the EMail address to send backup reports to. Note: Mail relaying is not enabled in openHABian yet." 10 60 3>&1 1>&2 2>&3)
-  fi
+# no mailer configured for now
+#  if [ -n "$INTERACTIVE" ]; then
+#     adminmail=$(whiptail --title "Admin reports" --inputbox "Enter the EMail address to send backup reports to. Note: Mail relaying is not enabled in openHABian yet." 10 60 3>&1 1>&2 2>&3)
+#  fi
 
   /bin/grep -v ${config} /etc/cron.d/amanda; /usr/bin/touch /etc/cron.d/amanda
   

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1346,7 +1346,7 @@ create_backup_config() {
   done
 
   if [ -n "$INTERACTIVE" ]; then
-      adminmail=$(whiptail --title "Admin reports" --inputbox "Enter the EMail address to send backup reports to." 10 60 3>&1 1>&2 2>&3)
+      adminmail=$(whiptail --title "Admin reports" --inputbox "Enter the EMail address to send backup reports to. Note: Mail relaying is not enabled in openHABian yet." 10 60 3>&1 1>&2 2>&3)
   fi
 
   /bin/grep -v ${config} /etc/cron.d/amanda; /usr/bin/touch /etc/cron.d/amanda
@@ -1380,7 +1380,13 @@ create_backup_config() {
 
   hostname=`/bin/hostname`
   if [ "${config}" = "openhab-local-SD" -o "${config}" = "openhab-dir" ]; then
-      echo "${hostname}	/dev/mmcblk0    	        amraw" >${confdir}/disklist
+      # don't backup SD by default as this can cause problems for large cards
+      if [ -n "$INTERACTIVE" ]; then
+          if (whiptail --title "Backup raw SD card ?" --yes-button "Backup SD" --no-button "Do not backup SD" --yesno "Do you want to create raw disk backups of your SD card ? Only recommended if it's 8GB or less, otherwise this can take too long. You can always add/remove this by editing ${confdir}/disklist." 15 80) then 
+	      echo "${hostname}	/dev/mmcblk0    	        amraw" >${confdir}/disklist
+	  fi   
+      fi
+      
       echo "${hostname}	/etc/openhab2			user-tar" >>${confdir}/disklist
       echo "${hostname}	/var/lib/openhab2		user-tar" >>${confdir}/disklist
   else
@@ -1450,7 +1456,7 @@ amanda_setup() {
   fi
 
   if [ -n "$INTERACTIVE" ]; then
-    if (whiptail --title "Create Amazon AWS based backup" --yes-button "Yes" --no-button "No" --yesno "Setup a backup mechanism based on Amazon Web Services. You can get 5 GB of S3 cloud storage for free on https://aws.amazon.com/. See also http://wiki.zmanda.com/index.php/How_To:Backup_to_Amazon_S3" 15 80) then
+    if (whiptail --title "Create Amazon S3 based backup" --yes-button "Yes" --no-button "No" --yesno "Setup a backup mechanism based on Amazon Web Services. You can get 5 GB of S3 cloud storage for free on https://aws.amazon.com/. See also http://wiki.zmanda.com/index.php/How_To:Backup_to_Amazon_S3" 15 80) then
         config=openhab-AWS
         S3accesskey=$(whiptail --title "S3 access key" --inputbox "Enter the S3 access key you obtained at S3 setup time:" 10 60 3>&1 1>&2 2>&3)
         S3secretkey=$(whiptail --title "S3 secret key" --inputbox "Enter the S3 secret key you obtained at S3 setup time:" 10 60 3>&1 1>&2 2>&3)

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1323,6 +1323,7 @@ create_backup_config() {
   while [ ${counter} -le ${tapes} ]; do
       if [ "${config}" = "openhab-dir" ]; then
           mkdir -p ${storage}/slots/slot${counter}
+	  ln -s ${storage}/slots ${storage}/slots/drive0
 
           tpchanger="\"chg-disk:${storage}/slots\"    # The tape-changer glue script"
           tapetype="DIRECTORY"

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1318,12 +1318,13 @@ create_backup_config() {
   if [ -n "$INTERACTIVE" ]; then
       if ! (whiptail --title "Storage container creation" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then return 0; fi
   fi
-  # create 'tapes'
+  # create virtual 'tapes'
+  ln -s ${storage}/slots ${storage}/slots/drive0
   counter=1
   while [ ${counter} -le ${tapes} ]; do
       if [ "${config}" = "openhab-dir" ]; then
           mkdir -p ${storage}/slots/slot${counter}
-	  ln -s ${storage}/slots ${storage}/slots/drive0
+	  ln -s ${storage}/slots ${storage}/slots/drive${counter}	# not sure how many virtual drives we need beyond drive0
 
           tpchanger="\"chg-disk:${storage}/slots\"    # The tape-changer glue script"
           tapetype="DIRECTORY"


### PR DESCRIPTION
Ask if raw SD partition is to be backed up rather than default. Warning given not to dump large SDs (>8GB) as this leads to long (some hours, potentially) backup runs on first initialization which is confusing users.

Create drive0 and drive1 links for virtual tape drives (Amanda expects to have these).


Signed-off-by: Markus Storm markus.storm@gmx.net (github: mstormi)