### PR TITLE
point to Amanda docs in install menu

### DIFF
--- a/docs/openhabian-amanda.md
+++ b/docs/openhabian-amanda.md
@@ -209,7 +209,7 @@ a lot less data and you need to estimate it by adding up the size of the config 
 file. If you don't have any idea, enter 1024 (= 1 GByte). You can change it in the Amanda config file at any later time.
 * "Backup raw SD card ?" (not asked if you selected AWS S3 storage)
 Answer "yes" if you want to create raw disk backups of your SD card. This is only recommended if your SD card is 8GB or less in
-size, otherwise the backup can take too long. You can always add/remove this by editing ${confdir}/disklist at a later time.
+size, otherwise the backup can take too long. You can always add/remove this by editing `${confdir}/disklist` at a later time.
 
 All of your input will be used to create the initial Amanda config files, but you are free to change them later on.
 HEADS UP: if you re-run the install routine, it will OVERWRITE the config files at any time so if you make changes there,
@@ -217,7 +217,7 @@ remember these changes and store them elsewhere, too.
 Once you're done installing openHABian and Amanda, proceed to the usage guide chapter below.
 
 Finally, another HEADS UP: The first thing you should do after your first backup run ended successfully is to create a clone of
-your active server SD card by restoring the backup to a blank SD card as shown below as a amfetchdump example for recovery of a
+your active server SD card by restoring the backup to a blank SD card as shown below as an `amfetchdump` example for recovery of a
 raw device's contents. `/dev/mmcblk0` is the Pi's internal SD reader device, and from an Amanda perspective, this is a raw
 device to be backed up to have that same name.
 You will have two Amanda config directories (located in `/etc/amanda`) called `openhab-dir` and `openhab-AWS` if you choose to

--- a/includes/amanda.conf_template
+++ b/includes/amanda.conf_template
@@ -4,7 +4,7 @@ netusage 10000 Kbps					# Bandwidth limit, 10M
 dumpcycle 2 weeks					# Backup cycle is 14 days
 runspercycle 7						# Run 7 times every 14 days
 tapecycle %TAPES tapes					# Dump to this number of different tapes during the cycle
-runtapes 1
+runtapes 10						# number of virtual containers to use at most per backup run
 tpchanger %TPCHANGER
 taper-parallel-write 2
 autolabel "openHABian-%CONFIG-%%%" empty
@@ -19,7 +19,7 @@ define tapetype SD {
     length %SIZE mbytes					# actual Bucket size 5GB (Amazon default for free S3)
 }
 define tapetype DIRECTORY {				# Define our tape behaviour
-	length %SIZE mbytes				# Every tape is 100GB in size
+	length %SIZE mbytes				# size of every virtual container (= max. usage per directory)
 }
 define tapetype AWS {
     comment "S3 Bucket"

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1809,8 +1809,8 @@ show_main_menu() {
 
   elif [[ "$choice" == "50"* ]]; then
     choice2=$(whiptail --title "Welcome to the openHABian Configuration Tool $(get_git_revision)" --menu "Setup Options" 10 116 3 --cancel-button Back --ok-button Execute \
-    "50 | Amanda Backup documentation"           "Read this before installing the Amanda backup software" \
-    "51 | Amanda Backup"           "Set up a backup solution on top of Amanda" \
+    "50 | Amanda Backup documentation"    "Read this before installing the Amanda backup software" \
+    "51 | Amanda Backup"                  "Set up Amanda to backup your openHAB config and openHABian box" \
     3>&1 1>&2 2>&3)
     if [ $? -eq 1 ] || [ $? -eq 255 ]; then return 0; fi
     case "$choice2" in

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1428,7 +1428,7 @@ amanda_setup() {
   backupuser="backup"
 
 
-  cond_redirect apt install amanda-common amanda-server amanda-client
+  cond_redirect apt -y install amanda-common amanda-server amanda-client || FAILED=1
 
   matched=false
   canceled=false

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1414,12 +1414,14 @@ create_backup_config() {
 
 amanda_setup() {
 
-  introtext="This will setup a backup mechanism to allow for saving your openHAB setup and modifications to either a set of SD cards, USB attached or Amazon cloud storage.\nYou can add your own files/directories to be backed up, and you can store and create clones of your openHABian SD card to have an all-ready replacement in case of card failures."
+  querytext="So you are about to install the Amanda backup solution.\nDocumentation is available at the previous openHABian menu point,\nat /opt/openhabian/docs/openhabian-amanda.md or at https://github.com/openhab/openhabian/blob/master/docs/openhabian-amanda.md\nHave you read this document ?"
+  introtext="This will setup a backup mechanism to allow for saving your openHAB setup and modifications to either USB attached or Amazon cloud storage.\nYou can add your own files/directories to be backed up, and you can store and create clones of your openHABian SD card to have an all-ready replacement in case of card failures."
   failtext="Sadly there was a problem setting up the selected option. Please report this problem in the openHAB community forum or as a openHABian GitHub issue."
   successtext="Setup was successful. Amanda backup tool is now taking backups at 01:00. For further readings, start at http://wiki.zmanda.com/index.php/User_documentation."
 
   if [ -n "$INTERACTIVE" ]; then
-    if ! (whiptail --title "Amanda backup setup, Continue?" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then return 0; fi
+    if ! (whiptail --title "Amanda backup installation" --yes-button "Yes" --no-button "No, I'll go read it" --defaultno --yesno "$querytext" 10 80) then return 0; fi
+    whiptail --msgbox "$introtext" 25 132
   fi
 
   echo -n "$(timestamp) [openHABian] Setting up the Amanda backup system ... "
@@ -1807,10 +1809,12 @@ show_main_menu() {
 
   elif [[ "$choice" == "50"* ]]; then
     choice2=$(whiptail --title "Welcome to the openHABian Configuration Tool $(get_git_revision)" --menu "Setup Options" 10 116 3 --cancel-button Back --ok-button Execute \
-    "51 | Amada Backup"           "Set up a backup solution on top of Amanda" \
+    "50 | Amanda Backup documentation"           "Read this before installing the Amanda backup software" \
+    "51 | Amanda Backup"           "Set up a backup solution on top of Amanda" \
     3>&1 1>&2 2>&3)
     if [ $? -eq 1 ] || [ $? -eq 255 ]; then return 0; fi
     case "$choice2" in
+      50\ *) whiptail --textbox /opt/openhabian/docs/openhabian-amanda.md --scrolltext 25 132 ;;
       51\ *) amanda_setup ;;
       "") return 0 ;;
       *) whiptail --msgbox "A not supported option was selected (probably a programming error):\n  \"$choice2\"" 8 80 ;;


### PR DESCRIPTION
There's still too many users that don't read the Amanda docs before installing, so they now get
another wink.
Also increased runtapes as first backup run may be larger than a virtual container.

Signed-off-by: Markus Storm markus.storm@gmx.net (github: mstormi)