### PR TITLE
Grafana not installing when not running on jessie

### DIFF
--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1199,6 +1199,9 @@ influxdb_grafana_setup() {
     if is_pione || is_pizero || is_pizerow; then GRAFANA_REPO_PI1="-rpi-1b"; fi
     echo "deb https://dl.bintray.com/fg2it/deb${GRAFANA_REPO_PI1} jessie main" > /etc/apt/sources.list.d/grafana-fg2it.list || FAILED=2
     cond_redirect apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61 || FAILED=2
+  else
+    cond_redirect curl https://packagecloud.io/gpg.key | sudo apt-key add - || FAILED=2
+    cond_redirect sudo apt-add-repository "deb https://packagecloud.io/grafana/stable/debian/ jessie main" || FAILED=2
   fi
   cond_redirect apt update || FAILED=2
   cond_redirect apt -y install grafana || FAILED=2

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1194,14 +1194,13 @@ influxdb_grafana_setup() {
   if [ $FAILED -eq 1 ]; then echo -n "FAILED "; else echo -n "OK "; fi
   cond_echo ""
 
-  echo -n "Grafana (fg2it)... "
-  if is_jessie; then
-    if is_pione || is_pizero || is_pizerow; then GRAFANA_REPO_PI1="-rpi-1b"; fi
+  echo -n "Grafana... "
+  if is_pi; then
     echo "deb https://dl.bintray.com/fg2it/deb${GRAFANA_REPO_PI1} jessie main" > /etc/apt/sources.list.d/grafana-fg2it.list || FAILED=2
     cond_redirect apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61 || FAILED=2
   else
-    cond_redirect curl https://packagecloud.io/gpg.key | sudo apt-key add - || FAILED=2
-    cond_redirect sudo apt-add-repository "deb https://packagecloud.io/grafana/stable/debian/ jessie main" || FAILED=2
+    cond_redirect wget -O - https://packagecloud.io/gpg.key | sudo apt-key add - || FAILED=2
+    echo "deb https://packagecloud.io/grafana/stable/debian/ jessie main" > /etc/apt/sources.list.d/grafana.list || FAILED=2
   fi
   cond_redirect apt update || FAILED=2
   cond_redirect apt -y install grafana || FAILED=2

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -1196,10 +1196,11 @@ influxdb_grafana_setup() {
 
   echo -n "Grafana... "
   if is_pi; then
+    if is_pione || is_pizero || is_pizerow; then GRAFANA_REPO_PI1="-rpi-1b"; fi
     echo "deb https://dl.bintray.com/fg2it/deb${GRAFANA_REPO_PI1} jessie main" > /etc/apt/sources.list.d/grafana-fg2it.list || FAILED=2
     cond_redirect apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61 || FAILED=2
   else
-    cond_redirect wget -O - https://packagecloud.io/gpg.key | sudo apt-key add - || FAILED=2
+    cond_redirect wget -O - https://packagecloud.io/gpg.key | apt-key add - || FAILED=2
     echo "deb https://packagecloud.io/grafana/stable/debian/ jessie main" > /etc/apt/sources.list.d/grafana.list || FAILED=2
   fi
   cond_redirect apt update || FAILED=2


### PR DESCRIPTION
When base operating system is not Jessie, Grafana repository was not being added to apt

Fixes #239

Signed-off-by: Garry Mitchell <garrymitchell@my105e.com> (github: ConfusedTA)