### PR TITLE
Fix #286 - Homegear won't install on Openhabian 1.4

### DIFF
--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -87,7 +87,23 @@ is_debian() {
   [[ $(lsb_release -d) =~ "Debian" ]]
   return $?
 }
+is_raspbian() {
+  [[ "$(lsb_release -si)" = "Raspbian" ]]
+  return $?
+}
 is_jessie() {
   [[ $(lsb_release -c) =~ "jessie" ]]
+  return $?
+}
+is_stretch() {
+  [[ $(lsb_release -sc) =~ "stretch" ]]
+  return $?
+}
+is_trusty() {
+  [[ $(lsb_release -sc) =~ "trusty" ]]
+  return $?
+}
+is_xenial() {
+  [[ $(lsb_release -sc) =~ "xenial" ]]
   return $?
 }

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -80,19 +80,19 @@ is_armv6l() {
   esac
 }
 is_ubuntu() {
-  [[ $(lsb_release -d) =~ "Ubuntu" ]]
+  [[ $(lsb_release -sd) =~ "Ubuntu" ]]
   return $?
 }
 is_debian() {
-  [[ $(lsb_release -d) =~ "Debian" ]]
+  [[ $(lsb_release -sd) =~ "Debian" ]]
   return $?
 }
 is_raspbian() {
-  [[ "$(lsb_release -si)" = "Raspbian" ]]
+  [[ "$(lsb_release -si)" =~ "Raspbian" ]]
   return $?
 }
 is_jessie() {
-  [[ $(lsb_release -c) =~ "jessie" ]]
+  [[ $(lsb_release -sc) =~ "jessie" ]]
   return $?
 }
 is_stretch() {

--- a/functions/packages.sh
+++ b/functions/packages.sh
@@ -80,22 +80,22 @@ To continue your integration in openHAB 2, please follow the instructions under:
   distro="$(lsb_release -si)-$(lsb_release -sc)"
   case "$distro" in
     Debian-jessie)
-      echo 'deb https://apt.homegear.eu/Debian/ jessie/' >> /etc/apt/sources.list.d/homegear.list
+      echo 'deb https://apt.homegear.eu/Debian/ jessie/' > /etc/apt/sources.list.d/homegear.list
       ;;
     Debian-stretch)
-      echo 'deb https://apt.homegear.eu/Debian/ stretch/' >> /etc/apt/sources.list.d/homegear.list
+      echo 'deb https://apt.homegear.eu/Debian/ stretch/' > /etc/apt/sources.list.d/homegear.list
       ;;
     Raspbian-jessie)
-      echo 'deb https://apt.homegear.eu/Raspbian/ jessie/' >> /etc/apt/sources.list.d/homegear.list
+      echo 'deb https://apt.homegear.eu/Raspbian/ jessie/' > /etc/apt/sources.list.d/homegear.list
       ;;
     Raspbian-stretch)
-      echo 'deb https://apt.homegear.eu/Raspbian/ stretch/' >> /etc/apt/sources.list.d/homegear.list
+      echo 'deb https://apt.homegear.eu/Raspbian/ stretch/' > /etc/apt/sources.list.d/homegear.list
       ;;
     Ubuntu-trusty)
-      echo 'deb https://apt.homegear.eu/Ubuntu/ trusty/' >> /etc/apt/sources.list.d/homegear.list
+      echo 'deb https://apt.homegear.eu/Ubuntu/ trusty/' > /etc/apt/sources.list.d/homegear.list
       ;;
     Ubuntu-xenial)
-      echo 'deb https://apt.homegear.eu/Ubuntu/ xenial/' >> /etc/apt/sources.list.d/homegear.list
+      echo 'deb https://apt.homegear.eu/Ubuntu/ xenial/' > /etc/apt/sources.list.d/homegear.list
       ;;
     *)
       echo "Your OS is not supported"

--- a/functions/packages.sh
+++ b/functions/packages.sh
@@ -76,7 +76,33 @@ To continue your integration in openHAB 2, please follow the instructions under:
   fi
 
   cond_redirect wget -O - http://homegear.eu/packages/Release.key | apt-key add -
-  echo "deb https://homegear.eu/packages/Raspbian/ jessie/" > /etc/apt/sources.list.d/homegear.list
+
+  distro="$(lsb_release -si)-$(lsb_release -sc)"
+  case "$distro" in
+    Debian-jessie)
+      echo 'deb https://apt.homegear.eu/Debian/ jessie/' >> /etc/apt/sources.list.d/homegear.list
+      ;;
+    Debian-stretch)
+      echo 'deb https://apt.homegear.eu/Debian/ stretch/' >> /etc/apt/sources.list.d/homegear.list
+      ;;
+    Raspbian-jessie)
+      echo 'deb https://apt.homegear.eu/Raspbian/ jessie/' >> /etc/apt/sources.list.d/homegear.list
+      ;;
+    Raspbian-stretch)
+      echo 'deb https://apt.homegear.eu/Raspbian/ stretch/' >> /etc/apt/sources.list.d/homegear.list
+      ;;
+    Ubuntu-trusty)
+      echo 'deb https://apt.homegear.eu/Ubuntu/ trusty/' >> /etc/apt/sources.list.d/homegear.list
+      ;;
+    Ubuntu-xenial)
+      echo 'deb https://apt.homegear.eu/Ubuntu/ xenial/' >> /etc/apt/sources.list.d/homegear.list
+      ;;
+    *)
+      echo "Your OS is not supported"
+      exit 1
+      ;;
+  esac
+
   cond_redirect apt update
   if [ $? -ne 0 ]; then echo "FAILED"; exit 1; fi
   cond_redirect apt -y install homegear homegear-homematicbidcos homegear-homematicwired


### PR DESCRIPTION
This adds support for all OSes supported by Homegear at the moment and should fix #286 

I've added the functions to helper.sh but ended up not using them. I'm an absolute bash newbie so I hope this solution is fine for you.
  
Signed-off-by: Lars Francke <mail@lars-francke.de> (github: lfrancke)