### PR TITLE
Run openhabian in Debian-lxc container (YAHM Version)

### DIFF
--- a/build-yahm-lxc.sh
+++ b/build-yahm-lxc.sh
@@ -4,6 +4,7 @@ timestamp() { date +"%F_%T_%Z"; }
 
 fail_inprogress() {
   echo -e "$(timestamp) [HOST] [openHABian] Initial setup exiting with an error!\\n\\n"
+  cat /var/log/yahm/openhabian_install.log
   exit 1
 }
 
@@ -30,23 +31,26 @@ then
     exit
 fi
 
+mkdir -p /var/log/yahm
+rm -rf /var/log/yahm/openhabian_install.log
+
 echo "\n$(timestamp) [GLOBAL] [openHABian] Starting the openHABian Host LXC installation.\n"
 
 echo -n "$(timestamp) [HOST] [openHABian] Updating repositories and upgrading installed packages..."
-until apt update &>/dev/null; do sleep 1; done
-apt --yes upgrade &>/dev/null
+until apt update &>> /var/log/yahm/openhabian_install.log; do sleep 1; done
+apt --yes upgrade &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [HOST] [openHABian] Installing dependencies..."
-/usr/bin/apt -y install debootstrap &>/dev/null
+/usr/bin/apt -y install debootstrap &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [HOST] [openHABian] Creating new LXC debian container: openhab..."
-lxc-create -n openhab -t debian &>/dev/null
+lxc-create -n openhab -t debian &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration..."
-yahm-network -n openhab -f attach_bridge &>/dev/null
+yahm-network -n openhab -f attach_bridge &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 echo lxc.include=/var/lib/lxc/openhab/config.network >> /var/lib/lxc/openhab/config
 
@@ -57,43 +61,43 @@ if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 echo "\n$(timestamp) [GLOBAL] [openHABian] Host Installation done, beginning with LXC preparation.\n"
 
 echo -n "$(timestamp) [LXC] [openHABian] Installing dependencies..."
-lxc-attach -n openhab -- apt install -y wget gnupg git lsb-release &>/dev/null
+lxc-attach -n openhab -- apt install -y wget gnupg git lsb-release &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 if is_pithree || is_pizerow; then
     echo "$(timestamp) [INFO] [openHABian] Raspberry Pi Hardware found, setup addition repositories."
 
     echo -n "$(timestamp) [LXC] [openHABian] Installing repository key..."
-    wget -qO - http://archive.raspberrypi.org/debian/raspberrypi.gpg.key  | lxc-attach -n openhab -- apt-key add - &>/dev/null
+    wget -qO - http://archive.raspberrypi.org/debian/raspberrypi.gpg.key  | lxc-attach -n openhab -- apt-key add - &>> /var/log/yahm/openhabian_install.log
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
     echo -n "$(timestamp) [LXC] [openHABian] Installing repository files..."
-    echo 'deb http://archive.raspberrypi.org/debian/ stretch main ui' | lxc-attach -n openhab  -- tee /etc/apt/sources.list.d/rpi.list &>/dev/null
+    echo 'deb http://archive.raspberrypi.org/debian/ stretch main ui' | lxc-attach -n openhab  -- tee /etc/apt/sources.list.d/rpi.list &>> /var/log/yahm/openhabian_install.log
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating gpio user..."
-lxc-attach -n openhab -- useradd gpio &>/dev/null
+lxc-attach -n openhab -- useradd gpio &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian user..."
-lxc-attach -n openhab -- useradd -m openhabian &>/dev/null
+lxc-attach -n openhab -- useradd -m openhabian &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Setting default password for openhabian user..."
-echo openhabian:openhabian | lxc-attach -n openhab -- chpasswd &>/dev/null
+echo openhabian:openhabian | lxc-attach -n openhab -- chpasswd &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Cloning openhabian repository..."
-lxc-attach -n openhab -- git clone -b master https://github.com/openhab/openhabian.git /opt/openhabian &>/dev/null
+lxc-attach -n openhab -- git clone -b master https://github.com/openhab/openhabian.git /opt/openhabian &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Linking openhabian configuration utility to /usr/bin..."
-lxc-attach -n openhab -- ln -sfn /opt/openhabian/openhabian-setup.sh /usr/bin/openhabian-config &>/dev/null
+lxc-attach -n openhab -- ln -sfn /opt/openhabian/openhabian-setup.sh /usr/bin/openhabian-config &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian default configuration..."
-echo -e "hostname=openHABian\nusername=openhabian\nuserpw=openhabian\ntimeserver=0.pool.ntp.org\nlocales='en_US.UTF-8 de_DE.UTF-8'\nsystem_default_locale=en_US.UTF-8\ntimezone=Europe/Berlin" > /var/lib/lxc/openhab/rootfs/etc/openhabian.conf &>/dev/null
+echo -e "hostname=openHABian\nusername=openhabian\nuserpw=openhabian\ntimeserver=0.pool.ntp.org\nlocales='en_US.UTF-8 de_DE.UTF-8'\nsystem_default_locale=en_US.UTF-8\ntimezone=Europe/Berlin" > /var/lib/lxc/openhab/rootfs/etc/openhabian.conf &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo  "$(timestamp) [LXC] [openHABian] Starting openhabian installation, this can take a lot of time....."

--- a/build-yahm-lxc.sh
+++ b/build-yahm-lxc.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+timestamp() { date +"%F_%T_%Z"; }
+
+fail_inprogress() {
+  echo -e "$(timestamp) [HOST] [openHABian] Initial setup exiting with an error!\\n\\n"
+  exit 1
+}
+
+# @todo need better checks: bridge installed? bridge name? this script works only with default values (yahmbr0)
+if [ -f /opt/YAHM/bin/yahm-ctl ]
+then
+    echo -n "$(timestamp) [openHABian] ERROR: Please install YAHM first: https://github.com/leonsio/YAHM"
+    exit
+fi
+
+echo -n "$(timestamp) [GLOBAL] [openHABian] Starting the openHABian Host LXC installation."
+
+echo -n "$(timestamp) [HOST] [openHABian] Updating repositories and upgrading installed packages... "
+until apt update &>/dev/null; do sleep 1; done
+apt --yes upgrade &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [HOST] [openHABian] Installing dependencies."
+/usr/bin/apt -y install debootstrap &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [HOST] [openHABian] Creating new LXC debian container: openhab."
+lxc-create -n openhab -t debian &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration."
+yahm-network -n openhab -f attach_bridge &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+echo lxc.include=config.network >> /var/lib/lxc/openhab/config
+
+echo -n "$(timestamp) [HOST] [openHABian] Starting openhab LXC container."
+lxc-start -n openhab -d 
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [GLOBAL] [openHABian] Host Installation done, beginning with LXC preparation."
+
+echo -n "$(timestamp) [LXC] [openHABian] Installing dependencies."
+lxc-attach -n openhab -- apt install -y git lsb-release &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian user."
+lxc-attach -n openhab -- useradd -m openhabian &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Setting default password for openhabian user."
+echo openhabian:openhabian | lxc-attach -n openhab -- chpasswd &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Cloning openhabian repository."
+lxc-attach -n openhab -- git clone -b master https://github.com/openhab/openhabian.git /opt/openhabian &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Linking openhabian configuration utility to /usr/bin."
+lxc-attach -n openhab -- ln -sfn /opt/openhabian/openhabian-setup.sh /usr/bin/openhabian-config &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian default configuration."
+echo -e "hostname=openHABian\nusername=openhabian\nuserpw=openhabian\ntimeserver=0.pool.ntp.org\nlocales='en_US.UTF-8 de_DE.UTF-8'\nsystem_default_locale=en_US.UTF-8\ntimezone=Europe/Berlin" > /var/lib/lxc/openhab/rootfs/etc/openhabian.conf &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Starting openhabian installation, this can take a lot of time....."
+lxc-attach -n openhab -- /opt/openhabian/openhabian-setup.sh unattended 
+
+echo -n "$(timestamp) [LXC] [openHABian] Starting openHAB2 Service."
+lxc-attach -n openhab -- systemctl start openhab2.service
+
+echo -n "$(timestamp) [GLOBAL] [openHABian] Done."
+lxc-info -n openhab
+

--- a/build-yahm-lxc.sh
+++ b/build-yahm-lxc.sh
@@ -7,16 +7,32 @@ fail_inprogress() {
   exit 1
 }
 
+is_pizerow() {
+  grep -q "^Revision\s*:\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0[cC][0-9a-fA-F]$" /proc/cpuinfo
+  return $?
+} 
+
+is_pithree() {
+  grep -q "^Revision\s*:\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]08[0-9a-fA-F]$" /proc/cpuinfo
+  return $?
+}
+
+
 # @todo need better checks: bridge installed? bridge name? this script works only with default values (yahmbr0)
-if [ -f /opt/YAHM/bin/yahm-ctl ]
+if [ ! -f /opt/YAHM/bin/yahm-ctl ]
 then
-    echo -n "$(timestamp) [openHABian] ERROR: Please install YAHM first: https://github.com/leonsio/YAHM"
+    echo "$(timestamp) [openHABian] ERROR: Please install YAHM first: https://github.com/leonsio/YAHM"
+    exit
+fi
+if [ -d /var/lib/lxc/openhab ]
+then
+    echo "$(timestamp) [openHABian] ERROR: Openhab LXC Instance found, please delete it first /var/lib/lxc/openhab"
     exit
 fi
 
-echo -n "$(timestamp) [GLOBAL] [openHABian] Starting the openHABian Host LXC installation."
+echo "\n$(timestamp) [GLOBAL] [openHABian] Starting the openHABian Host LXC installation.\n"
 
-echo -n "$(timestamp) [HOST] [openHABian] Updating repositories and upgrading installed packages... "
+echo -n "$(timestamp) [HOST] [openHABian] Updating repositories and upgrading installed packages."
 until apt update &>/dev/null; do sleep 1; done
 apt --yes upgrade &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
@@ -32,16 +48,32 @@ if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration."
 yahm-network -n openhab -f attach_bridge &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
-echo lxc.include=config.network >> /var/lib/lxc/openhab/config
+echo lxc.include=/var/lib/lxc/openhab/config.network >> /var/lib/lxc/openhab/config
 
 echo -n "$(timestamp) [HOST] [openHABian] Starting openhab LXC container."
 lxc-start -n openhab -d 
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [GLOBAL] [openHABian] Host Installation done, beginning with LXC preparation."
+echo "\n$(timestamp) [GLOBAL] [openHABian] Host Installation done, beginning with LXC preparation.\n"
 
 echo -n "$(timestamp) [LXC] [openHABian] Installing dependencies."
-lxc-attach -n openhab -- apt install -y git lsb-release &>/dev/null
+lxc-attach -n openhab -- apt install -y wget gnupg git lsb-release &>/dev/null
+if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+if is_pithree || is_pizerow; then
+    echo "$(timestamp) [INFO] [openHABian] Raspberry Pi Hardware found, setup addition repositories."
+
+    echo -n "$(timestamp) [LXC] [openHABian] Installing repository key."
+    wget -qO - http://archive.raspberrypi.org/debian/raspberrypi.gpg.key  | lxc-attach -n openhab -- apt-key add - &>/dev/null
+    if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+
+    echo -n "$(timestamp) [LXC] [openHABian] Installing repository files."
+    echo 'deb http://archive.raspberrypi.org/debian/ stretch main ui' | lxc-attach -n openhab  -- tee /etc/apt/sources.list.d/rpi.list &>/dev/null
+    if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+fi
+
+echo -n "$(timestamp) [LXC] [openHABian] Creating gpio user."
+lxc-attach -n openhab -- useradd gpio &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian user."
@@ -64,12 +96,12 @@ echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian default configurati
 echo -e "hostname=openHABian\nusername=openhabian\nuserpw=openhabian\ntimeserver=0.pool.ntp.org\nlocales='en_US.UTF-8 de_DE.UTF-8'\nsystem_default_locale=en_US.UTF-8\ntimezone=Europe/Berlin" > /var/lib/lxc/openhab/rootfs/etc/openhabian.conf &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Starting openhabian installation, this can take a lot of time....."
+echo  "$(timestamp) [LXC] [openHABian] Starting openhabian installation, this can take a lot of time....."
 lxc-attach -n openhab -- /opt/openhabian/openhabian-setup.sh unattended 
 
-echo -n "$(timestamp) [LXC] [openHABian] Starting openHAB2 Service."
+echo  "$(timestamp) [LXC] [openHABian] Starting openHAB2 Service."
 lxc-attach -n openhab -- systemctl start openhab2.service
 
-echo -n "$(timestamp) [GLOBAL] [openHABian] Done."
+echo  "\n$(timestamp) [GLOBAL] [openHABian] Done.\n"
 lxc-info -n openhab
 

--- a/build-yahm-lxc.sh
+++ b/build-yahm-lxc.sh
@@ -32,67 +32,67 @@ fi
 
 echo "\n$(timestamp) [GLOBAL] [openHABian] Starting the openHABian Host LXC installation.\n"
 
-echo -n "$(timestamp) [HOST] [openHABian] Updating repositories and upgrading installed packages."
+echo -n "$(timestamp) [HOST] [openHABian] Updating repositories and upgrading installed packages..."
 until apt update &>/dev/null; do sleep 1; done
 apt --yes upgrade &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [HOST] [openHABian] Installing dependencies."
+echo -n "$(timestamp) [HOST] [openHABian] Installing dependencies..."
 /usr/bin/apt -y install debootstrap &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [HOST] [openHABian] Creating new LXC debian container: openhab."
+echo -n "$(timestamp) [HOST] [openHABian] Creating new LXC debian container: openhab..."
 lxc-create -n openhab -t debian &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration."
+echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration..."
 yahm-network -n openhab -f attach_bridge &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 echo lxc.include=/var/lib/lxc/openhab/config.network >> /var/lib/lxc/openhab/config
 
-echo -n "$(timestamp) [HOST] [openHABian] Starting openhab LXC container."
+echo -n "$(timestamp) [HOST] [openHABian] Starting openhab LXC container..."
 lxc-start -n openhab -d 
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo "\n$(timestamp) [GLOBAL] [openHABian] Host Installation done, beginning with LXC preparation.\n"
 
-echo -n "$(timestamp) [LXC] [openHABian] Installing dependencies."
+echo -n "$(timestamp) [LXC] [openHABian] Installing dependencies..."
 lxc-attach -n openhab -- apt install -y wget gnupg git lsb-release &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 if is_pithree || is_pizerow; then
     echo "$(timestamp) [INFO] [openHABian] Raspberry Pi Hardware found, setup addition repositories."
 
-    echo -n "$(timestamp) [LXC] [openHABian] Installing repository key."
+    echo -n "$(timestamp) [LXC] [openHABian] Installing repository key..."
     wget -qO - http://archive.raspberrypi.org/debian/raspberrypi.gpg.key  | lxc-attach -n openhab -- apt-key add - &>/dev/null
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-    echo -n "$(timestamp) [LXC] [openHABian] Installing repository files."
+    echo -n "$(timestamp) [LXC] [openHABian] Installing repository files..."
     echo 'deb http://archive.raspberrypi.org/debian/ stretch main ui' | lxc-attach -n openhab  -- tee /etc/apt/sources.list.d/rpi.list &>/dev/null
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Creating gpio user."
+echo -n "$(timestamp) [LXC] [openHABian] Creating gpio user..."
 lxc-attach -n openhab -- useradd gpio &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian user."
+echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian user..."
 lxc-attach -n openhab -- useradd -m openhabian &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Setting default password for openhabian user."
+echo -n "$(timestamp) [LXC] [openHABian] Setting default password for openhabian user..."
 echo openhabian:openhabian | lxc-attach -n openhab -- chpasswd &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Cloning openhabian repository."
+echo -n "$(timestamp) [LXC] [openHABian] Cloning openhabian repository..."
 lxc-attach -n openhab -- git clone -b master https://github.com/openhab/openhabian.git /opt/openhabian &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Linking openhabian configuration utility to /usr/bin."
+echo -n "$(timestamp) [LXC] [openHABian] Linking openhabian configuration utility to /usr/bin..."
 lxc-attach -n openhab -- ln -sfn /opt/openhabian/openhabian-setup.sh /usr/bin/openhabian-config &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
-echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian default configuration."
+echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian default configuration..."
 echo -e "hostname=openHABian\nusername=openhabian\nuserpw=openhabian\ntimeserver=0.pool.ntp.org\nlocales='en_US.UTF-8 de_DE.UTF-8'\nsystem_default_locale=en_US.UTF-8\ntimezone=Europe/Berlin" > /var/lib/lxc/openhab/rootfs/etc/openhabian.conf &>/dev/null
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 

--- a/build-yahm-lxc.sh
+++ b/build-yahm-lxc.sh
@@ -25,9 +25,9 @@ then
     echo "$(timestamp) [openHABian] ERROR: Please install YAHM first: https://github.com/leonsio/YAHM"
     exit
 fi
-if [ -d /var/lib/lxc/openhab ]
+if [ -d /var/lib/lxc/openhabian ]
 then
-    echo "$(timestamp) [openHABian] ERROR: Openhab LXC Instance found, please delete it first /var/lib/lxc/openhab"
+    echo "$(timestamp) [openHABian] ERROR: Openhab LXC Instance found, please delete it first /var/lib/lxc/openhabian"
     exit
 fi
 
@@ -46,54 +46,54 @@ echo -n "$(timestamp) [HOST] [openHABian] Installing dependencies..."
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [HOST] [openHABian] Creating new LXC debian container: openhab..."
-lxc-create -n openhab -t debian &>> /var/log/yahm/openhabian_install.log
+lxc-create -n openhabian -t debian &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration..."
-yahm-network -n openhab -f attach_bridge &>> /var/log/yahm/openhabian_install.log
+yahm-network -n openhabian -f attach_bridge &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 echo lxc.include=/var/lib/lxc/openhab/config.network >> /var/lib/lxc/openhab/config
 
 echo -n "$(timestamp) [HOST] [openHABian] Starting openhab LXC container..."
-lxc-start -n openhab -d 
+lxc-start -n openhabian -d 
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo "\n$(timestamp) [GLOBAL] [openHABian] Host Installation done, beginning with LXC preparation.\n"
 
 echo -n "$(timestamp) [LXC] [openHABian] Installing dependencies..."
-lxc-attach -n openhab -- apt install -y wget gnupg git lsb-release &>> /var/log/yahm/openhabian_install.log
+lxc-attach -n openhabian -- apt install -y wget gnupg git lsb-release &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 if is_pithree || is_pizerow; then
     echo "$(timestamp) [INFO] [openHABian] Raspberry Pi Hardware found, setup addition repositories."
 
     echo -n "$(timestamp) [LXC] [openHABian] Installing repository key..."
-    wget -qO - http://archive.raspberrypi.org/debian/raspberrypi.gpg.key  | lxc-attach -n openhab -- apt-key add - &>> /var/log/yahm/openhabian_install.log
+    wget -qO - http://archive.raspberrypi.org/debian/raspberrypi.gpg.key  | lxc-attach -n openhabian -- apt-key add - &>> /var/log/yahm/openhabian_install.log
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
     echo -n "$(timestamp) [LXC] [openHABian] Installing repository files..."
-    echo 'deb http://archive.raspberrypi.org/debian/ stretch main ui' | lxc-attach -n openhab  -- tee /etc/apt/sources.list.d/rpi.list &>> /var/log/yahm/openhabian_install.log
+    echo 'deb http://archive.raspberrypi.org/debian/ stretch main ui' | lxc-attach -n openhabian  -- tee /etc/apt/sources.list.d/rpi.list &>> /var/log/yahm/openhabian_install.log
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating gpio user..."
-lxc-attach -n openhab -- useradd gpio &>> /var/log/yahm/openhabian_install.log
+lxc-attach -n openhabian -- useradd gpio &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian user..."
-lxc-attach -n openhab -- useradd -m openhabian &>> /var/log/yahm/openhabian_install.log
+lxc-attach -n openhabian -- useradd -m openhabian &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Setting default password for openhabian user..."
-echo openhabian:openhabian | lxc-attach -n openhab -- chpasswd &>> /var/log/yahm/openhabian_install.log
+echo openhabian:openhabian | lxc-attach -n openhabian -- chpasswd &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Cloning openhabian repository..."
-lxc-attach -n openhab -- git clone -b master https://github.com/openhab/openhabian.git /opt/openhabian &>> /var/log/yahm/openhabian_install.log
+lxc-attach -n openhabian -- git clone -b master https://github.com/openhab/openhabian.git /opt/openhabian &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Linking openhabian configuration utility to /usr/bin..."
-lxc-attach -n openhab -- ln -sfn /opt/openhabian/openhabian-setup.sh /usr/bin/openhabian-config &>> /var/log/yahm/openhabian_install.log
+lxc-attach -n openhabian -- ln -sfn /opt/openhabian/openhabian-setup.sh /usr/bin/openhabian-config &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo -n "$(timestamp) [LXC] [openHABian] Creating openhabian default configuration..."
@@ -101,10 +101,10 @@ echo -e "hostname=openHABian\nusername=openhabian\nuserpw=openhabian\ntimeserver
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 
 echo  "$(timestamp) [LXC] [openHABian] Starting openhabian installation, this can take a lot of time....."
-lxc-attach -n openhab -- /opt/openhabian/openhabian-setup.sh unattended 
+lxc-attach -n openhabian -- /opt/openhabian/openhabian-setup.sh unattended 
 
 echo  "$(timestamp) [LXC] [openHABian] Starting openHAB2 Service."
-lxc-attach -n openhab -- systemctl start openhab2.service
+lxc-attach -n openhabian -- systemctl start openhab2.service
 
 echo  "\n$(timestamp) [GLOBAL] [openHABian] Done.\n"
 lxc-info -n openhab

--- a/build-yahm-lxc.sh
+++ b/build-yahm-lxc.sh
@@ -60,7 +60,10 @@ if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
 echo -n "$(timestamp) [HOST] [openHABian] Creating LXC network configuration..."
 yahm-network -n openhabian -f attach_bridge &>> /var/log/yahm/openhabian_install.log
 if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; fail_inprogress; fi
+# attach network configuration
 echo lxc.include=/var/lib/lxc/openhabian/config.network >> /var/lib/lxc/openhabian/config
+# setup autostart
+echo 'lxc.start.auto = 1' >> /var/lib/lxc/openhabian/config
 
 echo -n "$(timestamp) [HOST] [openHABian] Starting openhabian LXC container..."
 lxc-start -n openhabian -d 

--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -176,7 +176,21 @@ The "Manual/Fresh Setup" submenu entry is the right place for you. Execute all e
 > Please be cautious and have a close look at the console output for errors.
 > Report problems you encounter to the [openHABian Issue Tracker](https://github.com/openhab/openhabian/issues).
 
+
+### YAHM Addon
+
+openHABian can be installed inside a LXC container on Debian/Armbian/Raspbian system supported by [YAHM](https://github.com/leonsio/YAHM). It is irrelevant which SBC is used. During the installation a new minimal [LXC](https://en.wikipedia.org/wiki/LXC) Debian container will be created with openHABian installed there.
+
+Only one requirement: YAHM must be installed first, the installation of CCU2-FW is not necessary.
+
+```shell
+wget -nv -O- https://raw.githubusercontent.com/openhab/openhabian/master/build-yahm-lxc.sh  | sudo -E  bash
+```
+
+
+
 {: #wifi-setup}
+
 ### Wi-Fi based Setup Notes
 
 If you own a RPi3, a RPi0W, a Pine A64, or a compatible Wi-Fi dongle you can set up and use openHABian purely via Wi-Fi.


### PR DESCRIPTION
hi

i have created a simple script to install openhabian in a minimal debian lxc container.
you can use it as a basis for one generic lxc installation script. currently i have included yahm network configuration part. it must be replaced with some code which can create/use a simple bridge to allow lxc networking.

successfully tested under raspbian (rpi3) and armbian (tinker board)

one click installation with 

```
wget -nv -O- https://raw.githubusercontent.com/leonsio/openhabian/master/build-yahm-lxc.sh  | sudo -E  bash
```

have fun

Leo