### PR TITLE
Restore ability to choose new conffile or not

### DIFF
--- a/functions/openhab.sh
+++ b/functions/openhab.sh
@@ -40,7 +40,7 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
     echo "deb http://openhab.jfrog.io/openhab/openhab-linuxpkg unstable main" > /etc/apt/sources.list.d/openhab2.list
   fi
   cond_redirect apt update
-  cond_redirect apt -y -o Dpkg::Options::="--force-confnew" install openhab2
+  cond_redirect apt -y install openhab2
   if [ $? -ne 0 ]; then echo "FAILED (apt)"; exit 1; fi
   cond_redirect adduser openhab dialout
   cond_redirect adduser openhab tty


### PR DESCRIPTION
I think this option was a good measure to prevent logging failure. But if there is a need to publish changes in linuxpkg that will overwrite other files like `/etc/default/openhab2`, then this becomes problematic.

Hopefully most people are on the latest stable/unstable by now.

Signed-off-by: Ben Clark <ben@benjyc.uk>