### PR TITLE
fixing failing drive0 and drive1 symlink creation

### DIFF
--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -20,7 +20,7 @@ create_backup_config() {
       if ! (whiptail --title "Storage container creation" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then echo "CANCELED"; return 0; fi
   fi
   # create virtual 'tapes'
-  mkdir ${storage}/slots # folder needed for following symlinks 
+  /bin/chown ${backupuser}:${backupuser} mkdir ${storage}/slots # folder needed for following symlinks 
   ln -s ${storage}/slots ${storage}/slots/drive0;ln -s ${storage}/slots ${storage}/slots/drive1    # taper-parallel-write 2 so we need 2 virtual drives
   counter=1
   while [ ${counter} -le ${tapes} ]; do

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -20,6 +20,7 @@ create_backup_config() {
       if ! (whiptail --title "Storage container creation" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then echo "CANCELED"; return 0; fi
   fi
   # create virtual 'tapes'
+  mkdir ${storage}/slots # folder needed for following symlinks 
   ln -s ${storage}/slots ${storage}/slots/drive0;ln -s ${storage}/slots ${storage}/slots/drive1    # taper-parallel-write 2 so we need 2 virtual drives
   counter=1
   while [ ${counter} -le ${tapes} ]; do

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -20,7 +20,8 @@ create_backup_config() {
       if ! (whiptail --title "Storage container creation" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then echo "CANCELED"; return 0; fi
   fi
   # create virtual 'tapes'
-  /bin/chown ${backupuser}:${backupuser} mkdir ${storage}/slots # folder needed for following symlinks 
+  mkdir ${storage}/slots # folder needed for following symlinks
+  /bin/chown ${backupuser}:${backupuser} ${storage}/slots
   ln -s ${storage}/slots ${storage}/slots/drive0;ln -s ${storage}/slots ${storage}/slots/drive1    # taper-parallel-write 2 so we need 2 virtual drives
   counter=1
   while [ ${counter} -le ${tapes} ]; do


### PR DESCRIPTION
Hi,
the target folder for
`ln -s ${storage}/slots ${storage}/slots/drive0;ln -s ${storage}/slots ${storage}/slots/drive1`
doesn't exist, to avoid the creation fail the need folder is created in before

Best
mues-lee

Signed-off-by: Marcus Krüger github@mues-lee.de (github: mues-lee)