### PR TITLE
Fix typo in samba password change function

### DIFF
--- a/functions/passwords.sh
+++ b/functions/passwords.sh
@@ -77,7 +77,7 @@ change_password() {
     echo "$username:$passwordChange" | chpasswd
     if [ $FAILED -eq 0 ]; then echo "OK"; else echo "FAILED"; fi
   fi
-  if [[ $accountsi == *"Samba"* ]]; then
+  if [[ $accounts == *"Samba"* ]]; then
     echo -n "$(timestamp) [openHABian] Changing password for samba (fileshare) account \"$username\"... "
     (echo "$passwordChange"; echo "$passwordChange") | /usr/bin/smbpasswd -s -a "$username"
     if [ $FAILED -eq 0 ]; then echo "OK"; else echo "FAILED"; fi


### PR DESCRIPTION
Fixes #362 

Signed-off-by: Ben Clark <ben@benjyc.uk>