### PR TITLE
Auto-create copies of Amanda config and status database in backup storage directory; docs improvements

### DIFF
--- a/docs/openhabian-amanda.md
+++ b/docs/openhabian-amanda.md
@@ -119,6 +119,7 @@ YOU HAVE BEEN WARNED.
 ---------------------
 
 ### NAS mount example
+
 ```
 ----- EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY ----- 
 pi@pi:~ $ sudo bash
@@ -134,11 +135,14 @@ Filesystem                       1K-blocks       Used Available  Use% Mounted on
 root@pi:/home/pi#
 ----- EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY ----- 
 ```
+
 ### USB storage mount example
+
 Note that this is showing two alternative versions, for FAT16/FAT32 filesystems (i.e. the original MS-DOS and the improved
 Windows filesystems that you usually use for USB sticks) and another version to use the ext4 native Linux filesystem. You can 
 use ext4 on a stick or USB-attached hard drive.
 Either way, you just need one or the other.
+
 ```
 ----- EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY ----- 
 root@pi:/home/pi# fdisk -l /dev/sda
@@ -190,6 +194,7 @@ root@pi:/home/pi#
 ```
 
 ## Software installation
+
 Next (but only AFTER you successfully mounted/prepared your storage !), install Amanda using the openHABian menu.
 When you start the Amanda installation from the openHABian menu, the install routine will create a directory/link structure in
 the directory you tell it. Your local user named "backup" will need to have write access there. Amanda install routine should do
@@ -230,6 +235,7 @@ please don't expect us to guide you through Amanda, which is a rather complex sy
 
 
 # Operating Amanda - a (yes, very brief) usage guide
+
 The overall config is to be found in `/etc/amanda/openhab-<config>/amanda.conf`.
 You are free to change this file, but doing so is at your own risk.
 You can specify files, directories and raw devices (such as HDD partitions or SD cards) that you want to be backed up in
@@ -242,6 +248,7 @@ openHABian setup routine will create cron entries in `/etc/cron.d/amanda` to sta
 run a check at 06:00PM. 
 
 ## Backup
+
 Find below a terminal session log of a manually started backup run.
 It's showing the three most important commands to use. They all can be started as user _backup_ only, interactively or via cron, 
 and you always need to specify the config to use. You can have multiple backup configs in parallel use.
@@ -346,7 +353,9 @@ backup@pi:~$ amcheck openhab-dir
 ```
 
 ## Restore
+
 ### Restoring a file
+
 To restore a file, you need to use the `amrecover` command as the `root` user.
 Note that since Amanda is designed to restore ANY file of the system, you are required to run `amrecover` as the root user to
 have the appropriate file access rights.
@@ -422,7 +431,6 @@ To restore a raw disk partition, you need to use amfetchdump command. Unlike amd
 Here’s another terminal session log to use amfetchdump to first retrieve the backup image from your backup storage to image called
 openhabianpi-image on /server/temp/
 
-
 **Reminder:** you have to be logged in as the `backup` user. 
 
 ```
@@ -470,11 +478,13 @@ and use Etcher or other tool in order to write the image to the card.
 
 
 ### A final word on when things have gone badly wrong...
+
 and your SD card to contain the Amanda database is broken: don't give up!
 Whenever you use a directory as the storage area, openHABian Amanda by default creates a copy of its config and index files (to know what's
 stored where) in your storage directory once a day (see `/etc/cron.d/amanda`). So you can reinstall openHABian including Amanda from scratch
 and copy back those files. Even if you fail to recover your index files, you can still access the files in your storage area. Backed-up
 directories are stored as tar files with a header, here's an example how to decode them:
+
 ```
 [18:13:29] root@openhabianpi:/volatile/backup/slots/slot7# ls -l
 insgesamt 2196552

--- a/docs/openhabian-amanda.md
+++ b/docs/openhabian-amanda.md
@@ -421,18 +421,52 @@ Here's another terminal session log to show how a couple of files are restored i
 To restore a raw disk partition, you need to use `amfetchdump` command. Unlike `amdump`, you have to run `amfetchdump` as user
 _backup_, though. Here's another terminal session log to use `amfetchdump` to first retrieve the backup image from storage.
 The last line also shows how to restore this image file to a SD card from Linux. In this example, we have an external SD card
-writer with a (blank) SD card attached to `/dev/sdd`. You could also move that temporary recovered image file to your Windows PC
-that has a card writer, and use Etcher or other tool in order to write the image to the card.
+writer with a (blank) SD card attached to `/dev/sdd`. 
+Restoring a partition
+To restore a raw disk partition, you need to use amfetchdump command. Unlike amdump, you have to run amfetchdump as user backup, though. Here’s another terminal session log to use amfetchdump to first retrieve the backup image from your backup storage to image called openhabianpi-image on /server/temp/
+
 
 **Reminder:** you have to be logged in as the `backup` user. 
 
 ```
-  backup@pi:/server/temp$ amfetchdump -p openhab-dir pi /dev/mmcblk0 > /server/temp/openhabianpi-image
-  1 volume(s) needed for restoration
+backup@pi:/server/temp$ amfetchdump -p openhab-dir pi /dev/mmcblk0 > /server/temp/openhabianpi-image
+ 1 volume(s) needed for restoration
   The following volumes are needed: openhab-openhab-dir-001
   Press enter when ready
-
-  amfetchdump: 4: restoring split dumpfile: date 20170322084708 host pi disk /dev/mmcblk0 part 1/UNKNOWN lev 0 comp N program APPLICATION
-  927712 kb
-  backup@pi:/server/temp$ dd bs=4M if=/server/temp/openhabianpi-image of=/dev/sdd
 ```
+
+Before you actually press enter, you should get ready, by opening another terminal window and letting Amanda know in which slot the required
+tape is (you can do this also before starting the amfetchdump command). You have to find the slot yourself by checking their content. Once
+you find out the requested file (probably starting with 00000.) you redirect amanda to use the slot which contains the file (e.g. slot 1)
+using this:
+
+```
+backup@pi:/server/temp$ amtape openhab-dir slot 1
+slot   1: time 20170322084708 label openhab-openhab-dir-001
+changed to slot 1
+```
+
+And finally you can go back to the first terminal window and press enter. Amanda will automatically pick up another files if the backup
+consists of more than one file.
+
+```
+amfetchdump: 4: restoring split dumpfile: date 20170322084708 host pi disk /dev/mmcblk0 part 1/UNKNOWN lev 0 comp N program APPLICATION
+  927712 kb
+```
+
+You can also provide amfetchdump with the date of the backup that you want to restore by adding the date parameter (format e.g. 20180327)
+like this:
+
+```
+backup@pi:/server/temp$ amfetchdump -p openhab-dir pi /dev/mmcblk0 > /server/temp/openhabianpi-image 20180327
+```
+
+This line also shows how to restore this image file to a SD card from Linux. In this example, we have an external SD card writer with a
+(blank) SD card attached to /dev/sdd.
+
+```
+backup@pi:/server/temp$ dd bs=4M if=/server/temp/openhabianpi-image of=/dev/sdd
+```
+
+You could also move that temporary recovered image file to your Windows PC that has a card writer, rename the file with the .raw extension,
+and use Etcher or other tool in order to write the image to the card.

--- a/docs/openhabian-amanda.md
+++ b/docs/openhabian-amanda.md
@@ -15,7 +15,7 @@ Now think of a recovery concept for each of these components: what do you have t
 
 If the SD card in your Pi fails because of SD corruption (a very common problem), you need to have a PREinstalled, at least
 somewhat current clone SD card to contain all your current OS packages, including all helper programs you might be using (such
-as say mosquitto or any scripts you might have installed yourself), and your mathing CURRENT openHAB config, and more.
+as say mosquitto or any scripts you might have installed yourself), and your matching CURRENT openHAB config, and more.
 If you believe "in case of SD card crash, I'll simply reinstall my server from scratch", then think first!
 How long will that take you? Are you even capable of doing that ? Will the latest version of openHABian/Linux packages be 
 guaranteed to work with each other and with your hardware ?
@@ -26,7 +26,7 @@ restoration of all features and setups you used to have in operation before the 
 
 **One specific word of WARNING:**
 If you run a ZWave network like many openHAB users do, think what you need to do if the controller breaks and you need to
-replace it. A new controller has a different Home ID, so your device will not talk to it unless you re-include all of them (and
+replace it. A new controller has a different Home ID, so all of your devices will not talk to it unless you re-include all of them (and
 to physically access devices in quite a number of cases means you need to open your walls !!) And even if you have easy access,
 it can take many hours, even more so if it's dark and your ... no I'm NOT joking, and I'm not overdoing things.
 This is what happened to several people, and it can happen to you, too. We have seen people be so frustrated that they gave up
@@ -53,8 +53,8 @@ you with one solution that is designed to run on local hardware only. We provide
 destination. This can be a directory mounted from your NAS (if you have one), a USB-attached storage stick, hard drive, or other
 device. We also provide a config to store your most important data on Amazon Web Services if you are not afraid of that.
 We believe this will cover most openHAB backup use cases.
-NOTE: don't use CIFS (Windows sharing). If you have a NAS, se NFS instead. There's issues with CIFS and symlinks, and it doesn't
-make sense to use a Windows protocol to share a disk from a UNIX server (all NAS) to a UNIX client (openHABian).
+NOTE: don't use CIFS (Windows sharing). If you have a NAS, use NFS instead. There's issues with CIFS and symlinks, and it doesn't
+make sense to use a Windows protocol to share a disk from a UNIX server (all NAS) to a UNIX client (openHABian) at all.
 If you don't have a NAS, DON'T use your Windows box as the storage server. Attach a USB stick to your Pi instead for storage.
 There's many more possible configurations, the software is very flexible and you can tailor it to your own needs if those offers
 do not match your needs. You could even use it to backup all of your servers (if any) and desktop PCs, including Windows

--- a/docs/openhabian-amanda.md
+++ b/docs/openhabian-amanda.md
@@ -418,12 +418,9 @@ Here's another terminal session log to show how a couple of files are restored i
 
 ### Restoring a partition
 
-To restore a raw disk partition, you need to use `amfetchdump` command. Unlike `amdump`, you have to run `amfetchdump` as user
-_backup_, though. Here's another terminal session log to use `amfetchdump` to first retrieve the backup image from storage.
-The last line also shows how to restore this image file to a SD card from Linux. In this example, we have an external SD card
-writer with a (blank) SD card attached to `/dev/sdd`. 
-Restoring a partition
-To restore a raw disk partition, you need to use amfetchdump command. Unlike amdump, you have to run amfetchdump as user backup, though. Here’s another terminal session log to use amfetchdump to first retrieve the backup image from your backup storage to image called openhabianpi-image on /server/temp/
+To restore a raw disk partition, you need to use amfetchdump command. Unlike amdump, you have to run amfetchdump as user backup, though.
+Here’s another terminal session log to use amfetchdump to first retrieve the backup image from your backup storage to image called
+openhabianpi-image on /server/temp/
 
 
 **Reminder:** you have to be logged in as the `backup` user. 
@@ -437,7 +434,7 @@ backup@pi:/server/temp$ amfetchdump -p openhab-dir pi /dev/mmcblk0 > /server/tem
 
 Before you actually press enter, you should get ready, by opening another terminal window and letting Amanda know in which slot the required
 tape is (you can do this also before starting the amfetchdump command). You have to find the slot yourself by checking their content. Once
-you find out the requested file (probably starting with 00000.) you redirect amanda to use the slot which contains the file (e.g. slot 1)
+you find out the requested file (probably starting with 00000.), you redirect amanda to use the slot which contains the file (e.g. slot 1)
 using this:
 
 ```
@@ -446,7 +443,7 @@ slot   1: time 20170322084708 label openhab-openhab-dir-001
 changed to slot 1
 ```
 
-And finally you can go back to the first terminal window and press enter. Amanda will automatically pick up another files if the backup
+Finally you can go back to the first terminal window and press Enter. Amanda will automatically pick up another files if the backup
 consists of more than one file.
 
 ```
@@ -468,5 +465,5 @@ This line also shows how to restore this image file to a SD card from Linux. In 
 backup@pi:/server/temp$ dd bs=4M if=/server/temp/openhabianpi-image of=/dev/sdd
 ```
 
-You could also move that temporary recovered image file to your Windows PC that has a card writer, rename the file with the .raw extension,
+You could also move that temporary recovered image file to your Windows PC that has a card writer, rename the file to have a .raw extension,
 and use Etcher or other tool in order to write the image to the card.

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -21,7 +21,7 @@ create_backup_config() {
   fi
   # create virtual 'tapes'
   mkdir ${storage}/slots # folder needed for following symlinks
-  /bin/chown ${backupuser}:${backupuser} ${storage}/slots
+  /bin/chown ${backupuser}:backup ${storage}/slots
   ln -s ${storage}/slots ${storage}/slots/drive0;ln -s ${storage}/slots ${storage}/slots/drive1    # taper-parallel-write 2 so we need 2 virtual drives
   counter=1
   while [ ${counter} -le ${tapes} ]; do
@@ -59,7 +59,8 @@ create_backup_config() {
   echo "0 1 * * * ${backupuser} /usr/sbin/amdump ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   if [ ${tapetype}" = "DIRECTORY" ]; then
-      echo "0 2 * * * root (cd /; tar czf /volatile/backup/amanda_data_$(date +%Y%m%d%H%M%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
+      mkdir -p ${storage}/amanda-backups; chown ${backupuser}:backup ${storage}/amanda-backups
+      echo "0 2 * * * root (cd /; tar czf ${storage}/amanda-backups/amanda_data_$(date +%Y%m%d%H%M%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
   fi
   
   mkdir -p ${confdir}

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -59,7 +59,7 @@ create_backup_config() {
   echo "0 1 * * * ${backupuser} /usr/sbin/amdump ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   if [ ${tapetype}" = "DIRECTORY" ]; then
-      echo "0 2 * * * root cd /; tar czf /volatile/backup/amanda_data_$(date +%Y%m%d%H%M%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete >/dev/null 2>&1" >> /etc/cron.d/amanda
+      echo "0 2 * * * root (cd /; tar czf /volatile/backup/amanda_data_$(date +%Y%m%d%H%M%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
   fi
   
   mkdir -p ${confdir}

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -56,10 +56,10 @@ create_backup_config() {
 
   /bin/grep -v ${config} /etc/cron.d/amanda; /usr/bin/touch /etc/cron.d/amanda
 
-  echo "0 1 * * * ${backupuser} /usr/sbin/amdump ${config} &>/dev/null" >> /etc/cron.d/amanda
-  echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} &>/dev/null" >> /etc/cron.d/amanda
+  echo "0 1 * * * ${backupuser} /usr/sbin/amdump ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
+  echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   if [ ${tapetype}" = "DIRECTORY" ]; then
-      echo "0 2 * * * root cd /; tar czf /volatile/backup/amanda_data_`date +%Y%m%d%H%M%S`.tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete &>/dev/null" >> /etc/cron.d/amanda
+      echo "0 2 * * * root cd /; tar czf /volatile/backup/amanda_data_$(date +%Y%m%d%H%M%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete >/dev/null 2>&1" >> /etc/cron.d/amanda
   fi
   
   mkdir -p ${confdir}

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -58,7 +58,10 @@ create_backup_config() {
 
   echo "0 1 * * * ${backupuser} /usr/sbin/amdump ${config} &>/dev/null" >> /etc/cron.d/amanda
   echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} &>/dev/null" >> /etc/cron.d/amanda
-
+  if [ ${tapetype}" = "DIRECTORY" ]; then
+      echo "0 2 * * * root cd /; tar czf /volatile/backup/amanda_data_`date +%Y%m%d%H%M%S`.tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete &>/dev/null" >> /etc/cron.d/amanda
+  fi
+  
   mkdir -p ${confdir}
   touch ${confdir}/tapelist
   hostname=`/bin/hostname`

--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -60,7 +60,7 @@ create_backup_config() {
   echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   if [ ${tapetype}" = "DIRECTORY" ]; then
       mkdir -p ${storage}/amanda-backups; chown ${backupuser}:backup ${storage}/amanda-backups
-      echo "0 2 * * * root (cd /; tar czf ${storage}/amanda-backups/amanda_data_$(date +%Y%m%d%H%M%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
+      echo "0 2 * * * root (cd /; tar czf ${storage}/amanda-backups/amanda_data_$(date +\%Y\%m\%d\%H\%M\%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
   fi
   
   mkdir -p ${confdir}


### PR DESCRIPTION
Added backup of Amanda config and status database to storage directory.

Please double-check before commiting. If ${storage} was empty, it'll delete the whole openHABian ...

Signed-By: Markus Storm <markus.storm@gmx.net> (github: mstormi)