### PR TITLE
Update installer to use Node.js 8 (from v7)

### DIFF
--- a/functions/nodejs-apps.sh
+++ b/functions/nodejs-apps.sh
@@ -15,8 +15,8 @@ nodejs_setup() {
     cond_redirect rm /tmp/nodejs-armv6l.tar.gz 2>&1
   else
     echo -n "$(timestamp) [openHABian] Installing Node.js (prerequisite for other packages)... "
-    cond_redirect wget -O /tmp/nodejs-v8.x.sh https://deb.nodesource.com/setup_8.x || FAILED=1
-    cond_redirect bash /tmp/nodejs-v8.x.sh || FAILED=1
+    cond_redirect wget -O /tmp/nodejs-setup.sh https://deb.nodesource.com/setup_8.x || FAILED=1
+    cond_redirect bash /tmp/nodejs-setup.sh || FAILED=1
     if [ $FAILED -eq 1 ]; then echo "FAILED (nodejs preparations)"; exit 1; fi
     cond_redirect apt -y install nodejs
     if [ $? -ne 0 ]; then echo "FAILED (nodejs installation)"; exit 1; fi

--- a/functions/nodejs-apps.sh
+++ b/functions/nodejs-apps.sh
@@ -15,8 +15,8 @@ nodejs_setup() {
     cond_redirect rm /tmp/nodejs-armv6l.tar.gz 2>&1
   else
     echo -n "$(timestamp) [openHABian] Installing Node.js (prerequisite for other packages)... "
-    cond_redirect wget -O /tmp/nodejs-v7.x.sh https://deb.nodesource.com/setup_7.x || FAILED=1
-    cond_redirect bash /tmp/nodejs-v7.x.sh || FAILED=1
+    cond_redirect wget -O /tmp/nodejs-v8.x.sh https://deb.nodesource.com/setup_8.x || FAILED=1
+    cond_redirect bash /tmp/nodejs-v8.x.sh || FAILED=1
     if [ $FAILED -eq 1 ]; then echo "FAILED (nodejs preparations)"; exit 1; fi
     cond_redirect apt -y install nodejs
     if [ $? -ne 0 ]; then echo "FAILED (nodejs installation)"; exit 1; fi


### PR DESCRIPTION
Resolves #379

Installation of fronttail was failing on Ubuntu distributions newer than Zesty
because they were not supported by Node v7. This patch changes the installed
version of Node to 8 in the openhabian-setup.sh installer.

Signed-off-by: Brian Warner <brian@bdwarner.com>