### PR TITLE
removes wpa_supplicant.conf on failed start so the user has a chance to correct it

### DIFF
--- a/build-rpi-raspbian/first-boot.sh
+++ b/build-rpi-raspbian/first-boot.sh
@@ -62,10 +62,14 @@ until ping -c1 9.9.9.9 &>/dev/null || [ "$(wget -qO- http://www.msftncsi.com/ncs
     if grep -q "openHABian" /etc/wpa_supplicant/wpa_supplicant.conf && iwconfig 2>&1 | grep -q "ESSID:off"; then
       echo ""
       echo "I was not able to connect to the configured Wi-Fi."
-      echo "Please try again with your correct SSID and password."
-      echo "Also check your signal quality. Available Wi-Fi networks:"
+      echo "Please check your signal quality. Reachable Wi-Fi networks are:"
       iwlist wlan0 scanning | grep "ESSID" | sed 's/^\s*ESSID:/\t- /g'
       echo ""
+      echo "Please try again with your correct SSID and password."
+      echo "The following Wi-Fi configuration was used:"
+      echo ""
+      cat /etc/wpa_supplicant/wpa_supplicant.conf
+      rm -f /etc/wpa_supplicant/wpa_supplicant.conf
     else
       echo "$(timestamp) [openHABian] The public internet is not reachable. Please check your network."
     fi


### PR DESCRIPTION
Fixes #273 

Removes the dirty config file on wifi setup failure so that its easy to correct it without reflashing

Here is the output on failed setup:
```
2018-03-13_22:54:01_UTC [openHABian] Starting the openHABian initial setup.
2018-03-13_22:54:01_UTC [openHABian] Storing configuration... OK
2018-03-13_22:54:01_UTC [openHABian] Changing default username and password... OK
2018-03-13_22:54:02_UTC [openHABian] Setting up Wi-Fi connection... OK, rebooting... 
2018-03-13_22:54:35_UTC [openHABian] Starting the openHABian initial setup.
2018-03-13_22:54:35_UTC [openHABian] Storing configuration... OK
2018-03-13_22:54:35_UTC [openHABian] Changing default username and password... SKIPPED
2018-03-13_22:54:35_UTC [openHABian] Setting up Wi-Fi connection... OK
2018-03-13_22:54:35_UTC [openHABian] Ensuring network connectivity... FAILED

I was not able to connect to the configured Wi-Fi.
Please try again with your correct SSID and password.
Also check your signal quality. Available Wi-Fi networks:
	- "ESP_0B4275"
	- "SCOTTS"
	- ""
	- "SPARK-JLYVD9"
	- "Anchorage"
	- "vodafone2B6AB8"
	- "SPARK-LX3SLQ-5G"
	- "vodafone2B6AB8-5"

Here is the current config for you to check:
# config generated by openHABian first boot setup
country=US
ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
update_config=1
network={
	ssid="SCOTTSX"
	psk="xxxxxxxx"
	key_mgmt=WPA-PSK
}
2018-03-13_22:56:22_UTC [openHABian] Initial setup exiting with an error!
```