### PR TITLE
add optional component "Tellstick core service"

### DIFF
--- a/functions/menu.sh
+++ b/functions/menu.sh
@@ -77,6 +77,7 @@ show_main_menu() {
     "27 | knxd"                  "KNX specific, the KNX router/gateway daemon knxd" \
     "28 | 1wire"                 "1wire specific, owserver and related packages" \
     "29 | FIND"                  "Framework for Internal Navigation and Discovery" \
+    "2A | Tellstick core"        "Driver and daemon for Tellstick usb devices" \
     3>&1 1>&2 2>&3)
     if [ $? -eq 1 ] || [ $? -eq 255 ]; then return 0; fi
     case "$choice2" in
@@ -89,6 +90,7 @@ show_main_menu() {
       27\ *) knxd_setup ;;
       28\ *) 1wire_setup ;;
       29\ *) find_setup ;;
+      2A\ *) tellstick_core_setup ;;
       "") return 0 ;;
       *) whiptail --msgbox "A not supported option was selected (probably a programming error):\\n  \"$choice2\"" 8 80 ;;
     esac

--- a/includes/telldusd.service
+++ b/includes/telldusd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Tellstick service daemon
+After=multi-user.target
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/telldusd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This patch adds a install script for usb based Tellstick devices.
It consist of three parts:

1) The tool, driver and service itself.
2) A custom systemd service for autostart.
3) An improved administration tool for device detection.

Signed-off-by: Elias Gabrielsson elias@gabson.se (github: EliasGabrielsson)