### PR TITLE
Fix sed expression to remove blank lines from /etc/fstab

### DIFF
--- a/functions/system.sh
+++ b/functions/system.sh
@@ -134,7 +134,7 @@ vimrc_copy() {
 srv_bind_mounts() {
   echo -n "$(timestamp) [openHABian] Preparing openHAB folder mounts under /srv/... "
   sed -i "\#[ \t]/srv/openhab2-#d" /etc/fstab
-  sed -i "\#^$#d" /etc/fstab
+  sed -i "/^$/d" /etc/fstab
   (
     echo ""
     echo "/usr/share/openhab2          /srv/openhab2-sys           none bind 0 0"


### PR DESCRIPTION
When first-boot.sh is run, I see an error in the log:

```
2018-10-23_11:50:18_NZDT [openHABian] Preparing openHAB folder mounts under /srv/... sed: -e expression #1, char 5: unterminated address regex
OK
```

I don't quite understand what is going on, but it seems "$#" is being parsed as something special, so the closing '#' is not recognised.

We can just revert to using the standard '/' delimiter