### PR TITLE
Add ability to setup static ip on first boot

### DIFF
--- a/build-image/config_static_ip_template.txt
+++ b/build-image/config_static_ip_template.txt
@@ -1,0 +1,19 @@
+#########Static IP file added by openhabian
+### This file will be concatinated to /etc/dhcpcd.conf file 
+### Configure the interface you would like to have static
+### eth0 for wired or wlan0 for wireless
+interface wlan0
+
+### Put the ipaddress you would like to have below
+static ip_address=192.168.1.95/24
+
+### Replace with default gateway ip.  
+### Usually the first part of ip xxx.xxx.xxx.1 
+### but ending in a 1
+static routers=192.168.1.1
+
+### Place the name servers here.  8.8.8.8 is public dns server and can be left.
+### This is usually the same as the gateway on home routers.
+static domain_name_servers=8.8.8.8 192.168.1.1
+
+#########End data added by openhabian

--- a/build-image/first-boot.sh
+++ b/build-image/first-boot.sh
@@ -5,6 +5,33 @@ exec &> >(tee -a "/boot/first-boot.log")
 
 timestamp() { date +"%F_%T_%Z"; }
 
+
+if [ -s /boot/config_static_ip.txt ]
+then
+
+   echo -e "$(timestamp) [openHABian]Found config_static_ip.txt file"
+   echo -e "$(timestamp) [openHABian]building static ip config"
+   IPLines=`wc -l /boot/config_static_ip.txt | cut -d\  -f1` 
+   echo -e "$(timestamp) [openHABian] Adding $IPLines to /etc/dhcpcd.conf"
+   tail -n $IPLines /boot/config_static_ip.txt >> /etc/dhcpcd.conf
+   mv /boot/config_static_ip.txt /boot/config_static_ip_merged.txt
+   reboot 
+   
+elif [ -e /boot/config_static_ip.txt ]
+then
+
+   echo -e "$(timestamp) [openHABian] File config_static_ip.txt present but empty"
+   echo -e "$(timestamp) [openHABian] If you want a static ip you must make a copy of"
+   echo -e "$(timestamp) [openHABian] static_ip.txt and make the appropriate changes"
+   echo -e "$(timestamp) [openHABian] exiting setup"
+   exit 1
+
+else
+
+   echo -e "$(timestamp) [openHABian] No static ip file, continuing dhcp setup"
+
+fi
+
 fail_inprogress() {
   rm -f /opt/openHABian-install-inprogress
   touch /opt/openHABian-install-failed

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -68,7 +68,7 @@ if [[ -n "$UNATTENDED" ]]; then
   vimrc_copy
   firemotd_setup
   java_zulu_embedded
-  openhab2_setup
+  openhab2_setup testing
   vim_openhab_syntax
   nano_openhab_syntax
   multitail_openhab_scheme


### PR DESCRIPTION
Add the ability to setup static ip using the dhcpcd.conf file on first boot.

This is done by modifying the file config_static_ip_template.txt and renaming to config_static_ip.txt.

The changes will be concatenated to /etc/dhcpcd.conf.