### PR TITLE
Download and install Zulu Embedded Java from .tar

### DIFF
--- a/docs/azul_zulu_license.md
+++ b/docs/azul_zulu_license.md
@@ -1,0 +1,14 @@
+Zulu is copyrighted software based on OpenJDK (http://openjdk.java.net/) and is 100% open source.
+By downloading, installing, or otherwise using Zulu, you hereby agree as follows:
+
+Zulu is provided “AS IS” and without warranty of any kind, express or implied, including without limitation any warranty of merchantability,
+fitness for a particular purpose, or noninfringement, each of which are hereby expressly disclaimed.
+You acknowledge and agree that any use of Zulu is at your sole risk.
+Azul will not be liable to you (whether under contract, tort, strict liability, negligence, or any other legal or equitable theory) for
+(i) any indirect, incidental, consequential, special, punitive, or reliance damages relating to your download, use or installation of Zulu
+(including without limitation any loss of or damage to data or systems), or (ii) for any direct damages in excess of (in the aggregate) one hundred U.S. dollars ($100).
+wSome states do not allow the exclusion or limitation of incidental or consequential damages, so the above limitations may not apply to you.
+Azul is not obligated to provide you with any support for Zulu (unless you have entered into a separate written agreement for such support,
+in which case such separate agreement shall apply).
+You also represent and warrant that you do not intend to distribute the software in a manner that is not compliant with relevant export control
+laws or regulations administered by the U.S. Commerce Department, OFAC, or any other government agency.

--- a/functions/menu.sh
+++ b/functions/menu.sh
@@ -171,7 +171,7 @@ show_main_menu() {
     
     if [[ $choosenComponents == *"61"* ]]; then system_upgrade; fi
     if [[ $choosenComponents == *"62"* ]]; then basic_packages && needed_packages; fi
-    if [[ $choosenComponents == *"63"* ]]; then java_zulu_embedded; fi
+    if [[ $choosenComponents == *"63"* ]]; then java_zulu; fi
     if [[ $choosenComponents == *"Oracle Java 8"* ]]; then java_webupd8; fi
     if [[ $choosenComponents == *"64"* ]]; then openhab2_setup; fi
     if [[ $choosenComponents == *"openHAB testing"* ]]; then openhab2_setup testing; fi


### PR DESCRIPTION
We need to change the installation method of Zulu Java as Azul systems does not maintain Java repos any more.

Signed-off-by: Markus Storm markus.storm@gmx.net (github: mstormi)