### PR TITLE
Install apt-transport-https prior to adding repos

### DIFF
--- a/functions/openhab.sh
+++ b/functions/openhab.sh
@@ -20,6 +20,8 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
     TESTING=1
   fi
 
+  cond_redirect apt -y install apt-transport-https
+
   if [ ! -n "$UNSTABLE" ]; then
     if [ ! -n "$TESTING" ]; then
       echo -n "$(timestamp) [openHABian] Installing or upgrading to latest openHAB release (stable)... "


### PR DESCRIPTION
During installation, apt requires apt-transport-https to be installed in order to add the new repo and its key.  This patch ensures apt-transport-https is installed at that point so the installation doesn't fail.

Signed-off-by: Brian Warner <brian@bdwarner.com>