### PR TITLE
Temporarly revert #459

### DIFF
--- a/functions/java-jre.sh
+++ b/functions/java-jre.sh
@@ -18,6 +18,27 @@ java_webupd8_archive() {
 }
 
 java_zulu() {
+  echo -n "$(timestamp) [openHABian] Installing Zulu Embedded OpenJDK... "
+  cond_redirect apt -y install dirmngr
+  if is_arm; then arch="[arch=armhf]"; fi
+  cond_redirect apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 219BD9C9
+  if [ $? -ne 0 ]; then echo "FAILED (keyserver)"; exit 1; fi
+  if is_ubuntu; then
+    echo "deb $arch http://repos.azulsystems.com/ubuntu stable main" > /etc/apt/sources.list.d/zulu-embedded.list
+  else  
+    echo "deb $arch http://repos.azulsystems.com/debian stable main" > /etc/apt/sources.list.d/zulu-embedded.list
+  fi
+  if is_pine64; then cond_redirect dpkg --add-architecture armhf; fi
+  cond_redirect apt update
+  if is_arm; then
+    cond_redirect apt -y install zulu-embedded-8
+  else
+    cond_redirect apt -y install zulu-8
+  fi
+  if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
+}
+
+java_zulu_NEW() {
   local FILE
   local INSTALLROOT
   local TEMPROOT


### PR DESCRIPTION
The PR disables the new java installation method introduced in #459 and re-inserts the old repository based installation in its stead. This PR is a short-term solution for the issues reported in #508 and a properly tested fix for #459 shall follow this weekend. 

Signed-off-by: Thomas Dietrich <Thomas.Dietrich@tu-ilmenau.de>