### PR TITLE
Removed duplicate inclusion of permission groups

### DIFF
--- a/functions/openhab.sh
+++ b/functions/openhab.sh
@@ -56,11 +56,7 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
   openhabVersion="$(apt-cache madison openhab2 | head -n 1 | cut -d'|' -f2 | xargs)"
   cond_redirect apt-get -y install "openhab2=${openhabVersion}"
   if [ $? -ne 0 ]; then echo "FAILED (apt)"; exit 1; fi
-  cond_redirect adduser openhab dialout
-  cond_redirect adduser openhab tty
   cond_redirect adduser openhab gpio
-  cond_redirect adduser openhab audio
-  cond_redirect adduser openhab bluetooth
   cond_redirect systemctl daemon-reload
   cond_redirect systemctl enable openhab2.service
   if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi

--- a/functions/system.sh
+++ b/functions/system.sh
@@ -165,15 +165,15 @@ permissions_corrections() {
     cond_redirect sed -i -e '$i \chmod -R ug+rw /sys/class/gpio \n' /etc/rc.local
   fi
 
-  cond_redirect adduser openhab dialout
-  cond_redirect adduser openhab tty
-  cond_redirect adduser openhab gpio
-  cond_redirect adduser openhab audio
-  cond_redirect adduser $username openhab
-  cond_redirect adduser $username dialout
-  cond_redirect adduser $username tty
-  cond_redirect adduser $username gpio
-  cond_redirect adduser $username audio
+  for pGroup in audio bluetooth dialout gpio tty
+  do
+    if getent group "$pGroup" > /dev/null 2>&1 ; then
+      cond_redirect adduser openhab "$pGroup"
+      cond_redirect adduser "$username" "$pGroup"
+    fi
+  done
+  cond_redirect adduser "$username" openhab
+
   #
   openhab_folders=(/etc/openhab2 /var/lib/openhab2 /var/log/openhab2 /usr/share/openhab2/addons)
   cond_redirect chown openhab:$username /srv /srv/README.txt


### PR DESCRIPTION
Closes #526 

 - Standard permission groups are now handled by the openhab2 package.
   - This does not include GPIO
 - Also added bluetooth to list of groups in fix permission script.
   - Script now checks first to see if the group exists before modifying it.

Signed-off-by: Ben Clark <ben@benjyc.uk>