### PR TITLE
Another CORS fix

### DIFF
--- a/includes/nginx.conf
+++ b/includes/nginx.conf
@@ -18,9 +18,9 @@ server {
 
     # Cross-Origin Resource Sharing.
     add_header 'Access-Control-Allow-Origin' '*' always; # "Always" makes sure that also a 400-type response works
-    add_header 'Access-Control-Allow_Credentials' 'true';
-    add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-    add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
+    add_header 'Access-Control-Allow_Credentials' 'true' always;
+    add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range' always;
+    add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH' always;
     
 ## Secure Certificate Locations
 #   ssl_certificate                 CERTPATH;

--- a/includes/nginx.conf
+++ b/includes/nginx.conf
@@ -17,7 +17,7 @@ server {
 #   add_header                      Strict-Transport-Security "max-age=31536000; includeSubDomains";
 
     # Cross-Origin Resource Sharing.
-    # add_header 'Access-Control-Allow-Origin' 'http://localhost:8080/rest';
+    add_header 'Access-Control-Allow-Origin' '*' always; # "Always" makes sure that also a 400-type response works
     add_header 'Access-Control-Allow_Credentials' 'true';
     add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
     add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';


### PR DESCRIPTION
openHAB sometimes respond with a 400-type http error code (if you send a command to an item and the item type doesn't allow that command for instance). So CORS must also work for 400-type codes. Added "always" therefore.

Signed-off-by: davidgraeff <david.graeff@web.de>