### PR TITLE
add ip capabilities to arping

### DIFF
--- a/functions/system.sh
+++ b/functions/system.sh
@@ -192,6 +192,7 @@ permissions_corrections() {
 misc_system_settings() {
   echo -n "$(timestamp) [openHABian] Applying miscellaneous system settings... "
   cond_redirect setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' $(realpath /usr/bin/java)
+  cond_redirect /sbin/setcap cap_net_raw,cap_net_admin=eip  /usr/sbin/arping
   if is_pine64; then cond_redirect dpkg --add-architecture armhf; fi
   # user home note
   echo -e "This is your linux user's \"home\" folder.\nPlace personal files, programs or scripts here." > /home/$username/README.txt

--- a/functions/system.sh
+++ b/functions/system.sh
@@ -192,7 +192,7 @@ permissions_corrections() {
 misc_system_settings() {
   echo -n "$(timestamp) [openHABian] Applying miscellaneous system settings... "
   cond_redirect setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' $(realpath /usr/bin/java)
-  setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' /usr/sbin/arping
+  cond_redirect setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' /usr/sbin/arping
   if is_pine64; then cond_redirect dpkg --add-architecture armhf; fi
   # user home note
   echo -e "This is your linux user's \"home\" folder.\nPlace personal files, programs or scripts here." > /home/$username/README.txt

--- a/functions/system.sh
+++ b/functions/system.sh
@@ -192,7 +192,7 @@ permissions_corrections() {
 misc_system_settings() {
   echo -n "$(timestamp) [openHABian] Applying miscellaneous system settings... "
   cond_redirect setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' $(realpath /usr/bin/java)
-  cond_redirect /sbin/setcap cap_net_raw,cap_net_admin=eip  /usr/sbin/arping
+  setcap 'cap_net_raw,cap_net_admin=+eip cap_net_bind_service=+ep' /usr/sbin/arping
   if is_pine64; then cond_redirect dpkg --add-architecture armhf; fi
   # user home note
   echo -e "This is your linux user's \"home\" folder.\nPlace personal files, programs or scripts here." > /home/$username/README.txt


### PR DESCRIPTION
arping needs to be executed as either root or with these capabilities to have proper access to the network to work. openHAB network binding to use it won't work without.

Signed-off-by: Markus Storm markus.storm@gmx.net (github: mstormi)