### PR TITLE
create daily safety copy of /var/log/amanda too

### DIFF
--- a/functions/backup.sh
+++ b/functions/backup.sh
@@ -23,7 +23,7 @@ create_backup_config() {
   echo "0 18 * * * ${backupuser} /usr/sbin/amcheck -m ${config} >/dev/null 2>&1" >> /etc/cron.d/amanda
   if [ "${tapetype}" = "DIRECTORY" ]; then
     mkdir -p ${storage}/amanda-backups; chown ${backupuser}:backup ${storage}/amanda-backups
-    echo "0 2 * * * root (cd /; tar czf ${storage}/amanda-backups/amanda_data_$(date +\%Y\%m\%d\%H\%M\%S).tar.gz etc/amanda var/lib/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
+    echo "0 2 * * * root (cd /; tar czf ${storage}/amanda-backups/amanda_data_$(date +\%Y\%m\%d\%H\%M\%S).tar.gz etc/amanda var/lib/amanda var/log/amanda; find ${storage} -name amanda_data_\* -mtime +30 -delete) >/dev/null 2>&1" >> /etc/cron.d/amanda
   fi
 
   mkdir -p ${confdir}


### PR DESCRIPTION
reports to say database restore might not work without.
Probably just because the directory needs to be recreated, but let's play it safe, this is about backups :)

Signed-off-by: Markus Storm markus.storm@gmx.net (github: mstormi)