### PR TITLE
remove unneeded openhab2 service start from java install routine and nodejs_setup() from main

### DIFF
--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -70,4 +70,7 @@ java_zulu(){
     cond_redirect apt-get -y install zulu-8
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
   fi
+  if [ -f /usr/lib/systemd/system/openhab2.service ]; then
+    cond_redirect systemctl start openhab2.service
+  fi 
 }

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -70,5 +70,4 @@ java_zulu(){
     cond_redirect apt-get -y install zulu-8
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
   fi
-  cond_redirect systemctl start openhab2.service
 }

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -80,7 +80,6 @@ if [[ -n "$UNATTENDED" ]]; then
   misc_system_settings
   samba_setup
   clean_config_userpw
-  nodejs_setup
   frontail_setup
 else
   whiptail_check


### PR DESCRIPTION
... it's not installed (yet) at this stage - which is next in unattended install.

Signed-off-by: Markus Storm markus.storm@gmx.net