### PR TITLE
make python webserver start

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -27,7 +27,9 @@ source /etc/openhabian.conf
 echo "OK"
 
 echo -n "$(timestamp) [openHABian] Starting webserver with installation log... "
-if hash python 2>/dev/null; then
+cond_redirect apt-get update
+cond_redirect apt-get install python3 python3-pip
+if hash python3 2>/dev/null; then
   bash /boot/webif.bash start
   sleep 5
   webifisrunning=$(ps -ef | pgrep python3)
@@ -37,7 +39,7 @@ if hash python 2>/dev/null; then
     echo "OK"
   fi
 else
-  echo "Python not found, SKIPPED"    
+  echo "Python 3 not found, SKIPPED"    
 fi
 
 userdef="openhabian"

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -28,7 +28,7 @@ echo "OK"
 
 echo -n "$(timestamp) [openHABian] Starting webserver with installation log... "
 cond_redirect apt-get update
-cond_redirect apt-get install python3 python3-pip
+cond_redirect apt-get -y install python3 python3-pip
 if hash python3 2>/dev/null; then
   bash /boot/webif.bash start
   sleep 5


### PR DESCRIPTION
seems that never worked properly that early in the process because 1) python was not installed and 2) some install/grep stuff used  "python" and some "python3"

Signed-off-by: Markus Storm markus.storm@gmx.net