### PR TITLE
Hardcode JDK `downloadPath`

### DIFF
--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -32,10 +32,10 @@ java_zulu(){
     file="/var/tmp/.zulu.$$"
 
     if is_aarch64; then
-      downloadPath=$(curl -s https://www.azul.com/downloads/zulu-embedded | grep -Eo "http://[a-zA-Z0-9./?=_-]*zulu8[a-zA-Z0-9./?=_-]*aarch64.tar.gz")
+      downloadPath="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz"
       archName=aarch64
     else
-      downloadPath=$(curl -s https://www.azul.com/downloads/zulu-embedded | grep -Eo "http://[a-zA-Z0-9./?=_-]*zulu8[a-zA-Z0-9./?=_-]*aarch32hf.tar.gz")
+      downloadPath="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz"
       archName=aarch32
     fi
     cond_redirect mkdir -p $jdkTempLocation


### PR DESCRIPTION
Azul changed their website and now it populates the list of JDKs
dynamically via Ajax call.

This PR hardcodes the 2 URLs in order to improve realiability of the
script and to point statically to a defined version so to avoid potential
compatibility issues. This also means that we will need to keep track
of new version and update the URLs.
We might consider extracting these URLs in two extranal constant defined
elsewhere.

cc: @teolairlasg @EliasGabrielsson

Closes https://github.com/openhab/openhabian/issues/642