### PR TITLE
Fix download url typo in JDK setup

### DIFF
--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -46,7 +46,7 @@ java_zulu(){
     rm -rf $file ${jdkInstallLocation:?}/*
     mv ${jdkTempLocation}/* ${jdkInstallLocation}/; rmdir ${jdkTempLocation}
 
-    javaPath=$(echo $downloadPath|sed 's|http://cdn.azul.com/zulu-embedded/bin/||')
+    javaPath=$(echo $downloadPath|sed 's|https://cdn.azul.com/zulu-embedded/bin/||')
     javaPath=$(echo $javaPath|sed 's|.tar.gz||')
     cond_redirect update-alternatives --remove-all java
     cond_redirect update-alternatives --remove-all javac


### PR DESCRIPTION
The script currently fails because the sed command fails to remove the different url path. Causing a silent error in `update-alternatives` and presumably in `ld`.

Signed-off-by: Ben Clark <ben@benjyc.uk>