### PR TITLE
fix zram creation

### DIFF
--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -223,7 +223,6 @@ There are four measuers and methods included to cover this matter today but they
 3. (BETA) Reduce wear on SD-card by move write intensive actions temporary to RAM during operation (logs,persistant-data). Warning: powerfailure will result in lost data. [Menu option: 6A]
 4. (Advanced) Use [Amanda Network Backup](http://www.amanda.org/) for full-system backup, longer introduction [here](https://github.com/openhab/openhabian/blob/master/docs/openhabian-amanda.md). [Menu option: 51]
 
-
 ## Optional Components
 
 openHABian comes with a number of additional routines to quickly install and set up home automation related software.

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -1,11 +1,10 @@
 init_zram_mounts() {
   if [ "$1" == "install" ]; then
     local ZRAMGIT=https://github.com/mstormi/zram-config
-    local BRANCH=""
-    local TAG=openhabian
+    local TAG=openhabian_v1.5
     TMP="$(mktemp -d /tmp/.XXXXXXXXXX)"
 
-    /usr/bin/git clone ${BRANCH} ${ZRAMGIT} ${TMP}
+    /usr/bin/git clone --branch "$TAG" "$ZRAMGIT" "$TMP"
     cd ${TMP}
     /usr/bin/git fetch --tags
     /usr/bin/git checkout ${TAG}

--- a/functions/zram.bats
+++ b/functions/zram.bats
@@ -7,6 +7,13 @@ check_zram_mounts() {
   local FILE=/etc/ztab
   local i=0
 
+<<<<<<< HEAD
+=======
+  if ! [ -f ${FILE} ]; then
+    echo "# zram not installed, can not test." >&3
+    return 0
+  fi
+>>>>>>> keep most active directories in compressed RAM with sync to disk #576
   while read -r line; do
     case "${line}" in
       "#"*) continue ;;

--- a/functions/zram.bats
+++ b/functions/zram.bats
@@ -7,13 +7,6 @@ check_zram_mounts() {
   local FILE=/etc/ztab
   local i=0
 
-<<<<<<< HEAD
-=======
-  if ! [ -f ${FILE} ]; then
-    echo "# zram not installed, can not test." >&3
-    return 0
-  fi
->>>>>>> keep most active directories in compressed RAM with sync to disk #576
   while read -r line; do
     case "${line}" in
       "#"*) continue ;;


### PR DESCRIPTION
The upstream's 4yr old (!) upstream failed to compile on buster (it worked on stretch).
Created mirror repos so openHABian now will only ever clone tagged branches known to work.