### PR TITLE
workaround for frontail installation, #647

### DIFF
--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -30,16 +30,21 @@ nodejs_setup() {
 frontail_setup() {
   nodejs_setup
   echo -n "$(timestamp) [openHABian] Installing the openHAB Log Viewer (frontail)... "
+  frontail_base="/usr/lib/node_modules/frontail"
+  # clear frontail install dir if it exists, otherwise npm install will fail, #647
+  if [ -d "$frontail_base" ]; then 
+    # rm -rf "$frontail_base"
+    cond_redirect npm uninstall -g frontail
+  fi
   cond_redirect npm install -g frontail
   if [ $? -ne 0 ]; then echo "FAILED (frontail)"; exit 1; fi
   cond_redirect npm update -g frontail
   #
-  frontail_base="/usr/lib/node_modules/frontail"
   mkdir -p ${frontail_base}/preset ${frontail_base}/web/assets/styles
   
-  cp $BASEDIR/includes/frontail-preset.json $frontail_base/preset/openhab.json
-  cp $BASEDIR/includes/frontail-theme.css $frontail_base/web/assets/styles/openhab.css
-  cp $BASEDIR/includes/frontail.service /etc/systemd/system/frontail.service
+  cp "$BASEDIR"/includes/frontail-preset.json $frontail_base/preset/openhab.json
+  cp "$BASEDIR"/includes/frontail-theme.css $frontail_base/web/assets/styles/openhab.css
+  cp "$BASEDIR"/includes/frontail.service /etc/systemd/system/frontail.service
   chmod 664 /etc/systemd/system/frontail.service
   cond_redirect systemctl daemon-reload
   cond_redirect systemctl enable frontail.service


### PR DESCRIPTION
npm installation of frontail fails if it is already installed.
Not sure if it is the right approach call `npm uninstall` or if it would be better to wipe install directory.
Also fixed the spellcheck warnings for this function.
Closes #647
Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>