### PR TITLE
Rewrite of Java rutine ensuring updated packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM minimum2scp/systemd-stretch
 
-RUN apt-get update && apt-get install -y git locales
+RUN apt-get update && apt-get install -y git locales jq
 RUN git clone https://github.com/bats-core/bats-core.git && \
     cd bats-core && \
     ./install.sh /usr/local

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -24,3 +24,7 @@ wifi_psk=""
 wifi_country=""
 
 # vim: filetype=sh
+
+# Java architecture mode
+# Use "32-bit" or "64-bit"
+java_arch="64-bit"

--- a/build-image/openhabian.pi-raspbian.conf
+++ b/build-image/openhabian.pi-raspbian.conf
@@ -24,3 +24,7 @@ wifi_psk=""
 wifi_country=""
 
 # vim: filetype=sh
+
+# Java architecture mode
+# Use "32-bit" or "64-bit"
+java_arch="32-bit"

--- a/build-image/openhabian.pine64-xenial.conf
+++ b/build-image/openhabian.pine64-xenial.conf
@@ -24,3 +24,7 @@ wifi_psk=""
 wifi_country=""
 
 # vim: filetype=sh
+
+# Java architecture mode
+# Use "32-bit" or "64-bit"
+java_arch="32-bit"

--- a/functions/config.bash
+++ b/functions/config.bash
@@ -28,3 +28,10 @@ load_create_config() {
 clean_config_userpw() {
   cond_redirect sed -i "s/^userpw=.*/\#userpw=xxxxxxxx/g" $CONFIGFILE
 }
+
+## Update java architecture in config file
+## Valid options: "32-bit" & "64-bit"
+update_config_java() {
+  cond_redirect grep -q '^java_arch' "$CONFIGFILE" && sed -i "s/^java_arch.*/java_arch=$1/" "$CONFIGFILE" || echo "option=$1" >> "$CONFIGFILE"
+  source "$CONFIGFILE"
+}

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -97,6 +97,12 @@ is_aarch64() {
     *) return 1 ;;
   esac
 }
+is_x86_64() {
+  case "$(uname -m)" in
+    x86_64|amd64) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 is_ubuntu() {
   [[ $(cat /etc/*release*) =~ "Ubuntu" ]]
   return $?

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -1,76 +1,204 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2181
 
-java_webupd8_archive() {
-  echo -n "$(timestamp) [openHABian] Preparing and Installing Oracle Java 8 Web Upd8 repository... "
-  cond_redirect apt-get -y install dirmngr
-  cond_redirect apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-  if [ $? -ne 0 ]; then echo "FAILED (keyserver)"; exit 1; fi
-  rm -f /etc/apt/sources.list.d/webupd8team-java.list
-  echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list
-  echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-  if [ $? -ne 0 ]; then echo "FAILED (debconf)"; exit 1; fi
-  cond_redirect apt-get update
-  cond_redirect apt-get -y install oracle-java8-installer
-  if [ $? -ne 0 ]; then echo "FAILED"; exit 1; fi
-  cond_redirect apt-get -y install oracle-java8-set-default
+## Install best suitible java version depending on platform. 
+## Valid argument choose between: 64-bit, 32-bit
+##
+##    java_install_and_update(String arch)
+##
+java_install_or_update(){
+  # Make sure we don't overwrite existing none Java Zulu installations 
+  if ! [ -x "$(command -v java)" ] || [[ ! "$(java -version)" == *"Zulu"* ]]; then
+    cond_redirect systemctl stop openhab2.service
+
+    if [ "$1" == "64-bit" ]; then
+      if is_x86_64; then
+        java_zulu_enterprise_8_apt
+      else
+        if java_zulu_tar_update_available; then
+          java_zulu_8_tar 64-bit
+        fi
+      fi
+
+    else # Default to 32-bit installation
+      if java_zulu_tar_update_available; then
+          java_zulu_8_tar 32-bit
+      fi
+    fi
+    cond_redirect systemctl start openhab2.service
+  fi
+}
+
+## Install Java Zulu 8 from direct from fetched .TAR file
+## Valid argument choose between: 64-bit, 32-bit
+##
+##    java_zulu_8_tar(String arch)
+##
+java_zulu_8_tar(){
+  local link
+  local jdkTempLocation
+  local jdkInstallLocation
+  local jdkBin
+  local jdkLib 
+  local jdkArch
+  local jdkSecurity
+  if [ "$1" == "32-bit" ]; then
+    echo -n "$(timestamp) [openHABian] Installing Java Zulu 32-Bit OpenJDK... "
+    if is_arm; then 
+      link="$(fetch_zulu_tar_url "arm-32-bit-hf")";
+      jdkArch="aarch32"
+    else 
+      link="$(fetch_zulu_tar_url "x86-32-bit")";
+      jdkArch="i386"
+    fi
+
+    if is_aarch64; then 
+      dpkg --add-architecture armhf
+      cond_redirect apt-get update
+      cond_redirect apt -y install libc6:armhf libncurses5:armhf libstdc++6:armhf
+    fi
+
+    if is_x86_64; then 
+      dpkg --add-architecture i386
+      cond_redirect apt update
+      cond_redirect apt -y install libc6:i386 libncurses5:i386 libstdc++6:i386
+    fi
+
+  elif [ "$1" == "64-bit" ]; then
+    echo -n "$(timestamp) [openHABian] Installing Java Zulu 64-Bit OpenJDK... "
+    if is_arm; then 
+      link="$(fetch_zulu_tar_url "arm-64-bit")";
+      jdkArch="aarch64"
+    else 
+      link="$(fetch_zulu_tar_url "x86-64-bit")";
+      jdkArch="amd64"
+    fi
+
+  else 
+    echo -n "[DEBUG] Unvalid argument to function java_zulu_8_tar()"
+    exit 1
+  fi
+  jdkTempLocation="$(mktemp -d /tmp/openhabian.XXXXX)"
+  if [ -z "$jdkTempLocation" ]; then echo "FAILED"; exit 1; fi
+  jdkInstallLocation="/opt/jdk"
+  mkdir -p $jdkInstallLocation
+
+  # Fetch and copy new JAVA runtime
+  cond_redirect wget -nv -O "$jdkTempLocation"/zulu8.tar.gz "$link"
+  tar -xpzf "$jdkTempLocation"/zulu8.tar.gz -C "${jdkTempLocation}"
+  if [ $? -ne 0 ]; then echo "FAILED"; rm -rf "$jdkTempLocation"/zulu8.tar.gz; exit 1; fi
+  rm -rf "$jdkTempLocation"/zulu8.tar.gz "${jdkInstallLocation:?}"/*
+  mv "${jdkTempLocation}"/* "${jdkInstallLocation}"/
+
+  rmdir "${jdkTempLocation}"
+
+  # Update system with new installation
+  jdkBin=$(find "${jdkInstallLocation}"/*/bin ... -print -quit)
+  jdkLib=$(find "${jdkInstallLocation}"/*/lib ... -print -quit)
+  cond_redirect update-alternatives --remove-all java
+  cond_redirect update-alternatives --remove-all javac
+  cond_redirect update-alternatives --install /usr/bin/java java "$jdkBin"/java 1083000
+  cond_redirect update-alternatives --install /usr/bin/javac javac "$jdkBin"/javac 1083000
+  echo "$jdkLib"/"$jdkArch" > /etc/ld.so.conf.d/java.conf
+  echo "$jdkLib"/"$jdkArch"/jli >> /etc/ld.so.conf.d/java.conf
+  ldconfig
+
+  java_zulu_install_crypto_extension
+
   if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
 }
 
-java_zulu(){
-  cond_redirect systemctl stop openhab2.service
-  if is_arm; then
-    echo -n "$(timestamp) [openHABian] Installing Zulu Embedded OpenJDK... "
-    local archName
-    local downloadPath
-    local file
-    local jdkTempLocation
-    local jdkInstallLocation
-    local javapath
-    jdkTempLocation="/var/tmp/jdk-new"
-    jdkInstallLocation="/opt/jdk"
-    file="/var/tmp/.zulu.$$"
-
-    if is_aarch64; then
-      downloadPath="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz"
-      archName=aarch64
-    else
-      downloadPath="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz"
-      archName=aarch32
-    fi
-    cond_redirect mkdir -p $jdkTempLocation
-    cond_redirect mkdir -p $jdkInstallLocation
-    cond_redirect wget -nv -O $file $downloadPath
-    cond_redirect tar -xpzf $file -C ${jdkTempLocation}
-    if [ $? -ne 0 ]; then echo "FAILED"; rm -f ${file}; exit 1; fi
-    rm -rf $file ${jdkInstallLocation:?}/*
-    mv ${jdkTempLocation}/* ${jdkInstallLocation}/; rmdir ${jdkTempLocation}
-
-    javaPath=$(echo $downloadPath|sed 's|https://cdn.azul.com/zulu-embedded/bin/||')
-    javaPath=$(echo $javaPath|sed 's|.tar.gz||')
-    cond_redirect update-alternatives --remove-all java
-    cond_redirect update-alternatives --remove-all javac
-    cond_redirect update-alternatives --install /usr/bin/java java $jdkInstallLocation/$javaPath/bin/java 1083000
-    cond_redirect update-alternatives --install /usr/bin/javac javac $jdkInstallLocation/$javaPath/bin/javac 1083000
-    echo $jdkInstallLocation/$javaPath/lib/$archName > /etc/ld.so.conf.d/java.conf
-    echo $jdkInstallLocation/$javaPath/lib/$archName/jli >> /etc/ld.so.conf.d/java.conf
-    cond_redirect ldconfig
-    if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
-
-  else
-    echo -n "$(timestamp) [openHABian] Installing Zulu Enterprise OpenJDK... "
+## Install Azuls Java Zulu Enterprise using APT repository.
+## (Updated version only availible on x86-64bit when checked August 2019)
+java_zulu_enterprise_8_apt(){ 
+  if ! dpkg -s 'zulu-8' >/dev/null 2>&1; then # Check if already is installed
+    echo -n "$(timestamp) [openHABian] Installing Zulu Enterprise 64-Bit OpenJDK... "
     cond_redirect apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 219BD9C9
-    if [ $? -ne 0 ]; then echo "FAILED (keyserver)"; exit 1; fi
-    if is_ubuntu; then
-      echo "deb $arch http://repos.azulsystems.com/ubuntu stable main" > /etc/apt/sources.list.d/zulu-enterprise.list
-    else
-      echo "deb $arch http://repos.azulsystems.com/debian stable main" > /etc/apt/sources.list.d/zulu-enterprise.list
-    fi
+    if [ $? -ne 0 ]; then echo "FAILED (keyserver)"; exit 1; fi 
+    echo "deb http://repos.azulsystems.com/debian stable main" > /etc/apt/sources.list.d/zulu-enterprise.list
     cond_redirect apt-get update
     cond_redirect apt-get -y install zulu-8
+    java_zulu_install_crypto_extension
     if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
   fi
-  if [ -f /usr/lib/systemd/system/openhab2.service ]; then
-    cond_redirect systemctl start openhab2.service
+}
+
+## Fetches download link for Java Zulu 8.
+## Valid architectures: arm-64-bit, arm-32-bit-sf, arm-32-bit-hf, x86-32-bit, x86-64-bit
+##
+##    fetch_zulu_tar_url(String arch)
+##
+## TODO: Rewrite using download API when it leaves alpha state. https://www.azul.com/downloads/zulu-community/api/
+fetch_zulu_tar_url(){
+  local downloadlink
+  local filter
+  if [ ! -x "$(command -v jq)" ]; then
+    apt-get install -y jq
   fi
+  filter='.[] | select(.os == "Linux") | select(.category_slug == "java-8-lts") | select(.latest == 1) | select(.packaging_slug == "jdk") | select(.arch_slug == "'$1'") | select((.os_flavor | index("Debian")) or (.os_flavor == "[]")) | .["bundles"] | .[] | select(.extension == "tar.gz") | .["link"]' # $1 = e.g. "arm-64-bit"  
+  # Fetch an JSON array of download candidates from azul and filter them
+  # shellcheck disable=SC2006
+  downloadlink=`curl 'https://www.azul.com/wp-admin/admin-ajax.php' -s \
+        -H 'Accept: */*' \
+        -H 'X-Requested-With: XMLHttpRequest' \
+        -H 'Content-Type: multipart/form-data; boundary=---------------------------17447165291708986765346780730' \
+        -H 'Connection: keep-alive' \
+        -H 'Cache-Control: max-age=0' -H 'TE: Trailers' \
+        --data-binary $'-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nbundles_filter_query\r\n-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nsearch_bundles\r\n-----------------------------17447165291708986765346780730--\r\n' \
+        | jq -r "$filter"`
+  if [ -z "$downloadlink" ]; then return 1; fi
+    # shellcheck disable=SC2046,SC2005,SC2006
+    echo `echo "$downloadlink" | head -n1`
+  return 0   
+}
+
+## Check whatever a newer version Zulu version is available.
+## Returns 0 / true if new version exist
+## TODO: Rewrite using download API when it leaves alpha state. https://www.azul.com/downloads/zulu-community/api/
+java_zulu_tar_update_available(){
+  if [ ! -x "$(command -v java)" ]; then return 0; fi
+  
+  local availableVersion # format: "8u222-b10"
+  local javaVersion
+  local filter
+  if [ ! -x "$(command -v jq)" ]; then
+    apt-get install -y jq
+  fi
+  filter='[.[] | select(.os == "Linux") | select(.category_slug == "java-8-lts") | select(.latest == 1)  | .["openjdk_version"]] | first'
+  # Fetch an JSON array of download candidates from azul and filter them
+  # shellcheck disable=SC2006
+  availableVersion=`curl 'https://www.azul.com/wp-admin/admin-ajax.php' -s \
+        -H 'Accept: */*' \
+        -H 'X-Requested-With: XMLHttpRequest' \
+        -H 'Content-Type: multipart/form-data; boundary=---------------------------17447165291708986765346780730' \
+        -H 'Connection: keep-alive' \
+        -H 'Cache-Control: max-age=0' -H 'TE: Trailers' \
+        --data-binary $'-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nbundles_filter_query\r\n-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nsearch_bundles\r\n-----------------------------17447165291708986765346780730--\r\n' \
+        | jq -r "$filter"`
+  availableVersion="${availableVersion:2}" # Strip first two char -> "222-b10"
+  javaVersion=$(java -version)
+  if [[ $javaVersion == *"$availableVersion"* ]]; then
+    # Java updated
+    return 1
+  fi
+  return 0
+}
+
+## Install Cryptography Extension Kit to enable cryptos using more then 128 bits
+java_zulu_install_crypto_extension(){
+  local jdkPath
+  local jdkSecurity
+  local policyTempLocation
+  jdkPath="$(readlink -f "$(command -v java)")"
+  jdkSecurity="$(dirname "${jdkPath}")/../lib/security"
+  mkdir -p $jdkSecurity
+  policyTempLocation="$(mktemp -d /tmp/openhabian.XXXXX)"
+  if [ -z "$policyTempLocation" ]; then echo "FAILED"; exit 1; fi
+
+  cond_redirect wget -nv -O "$policyTempLocation"/crypto.zip http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  cond_redirect unzip "$policyTempLocation"/crypto.zip -d "$policyTempLocation"
+  cp "$policyTempLocation"/ZuluJCEPolicies/*.jar "$jdkSecurity"
+
+  rm -rf "${policyTempLocation}"
+  return 0
 }

--- a/functions/java-jre.bats
+++ b/functions/java-jre.bats
@@ -3,8 +3,43 @@
 load java-jre
 load helpers
 
+@test "unit-zulu_fetch_tar_url" {
+  run fetch_zulu_tar_url "arm-32-bit-hf"
+  echo "# Fetched .TAR download link for \"arm-32-bit-hf\": $output"
+  curl -s --head "$output" | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null # Check if link is valid, result it $?
+  [ $? -eq 0 ]
+}
+
 @test "installation-java_exist" {
   run java -version
   [ "$status" -eq 0 ]
   [[ $output == *"Zulu"* ]]
+}
+
+@test "destructive-update_java-64bit_tar" {
+  case "$(uname -m)" in
+    aarch64|arm64|x86_64|amd64) ;;
+    *) skip ;;
+  esac
+  run systemctl start openhab2
+  run java_zulu_8_tar 64-bit
+  [ "$status" -eq 0 ]
+  run systemctl is-active --quiet openhab2
+  [ "$status" -eq 0 ]
+  run java -version
+  [ "$status" -eq 0 ]
+  [[ $output == *"Zulu"* ]]
+  [[ $output == *"64"* ]]
+}
+
+@test "destructive-update_java-32bit_tar" {
+  run systemctl start openhab2
+  run java_zulu_8_tar 32-bit
+  [ "$status" -eq 0 ]
+  run systemctl is-active --quiet openhab2
+  [ "$status" -eq 0 ]
+  run java -version
+  [ "$status" -eq 0 ]
+  [[ $output == *"Zulu"* ]]
+  [[ $output == *"32"* ]]
 }

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -165,9 +165,9 @@ show_main_menu() {
 
   elif [[ "$choice" == "60"* ]]; then
     choosenComponents=$(whiptail --title "Manual/Fresh Setup" --checklist "Choose which system components to install or configure:" 20 116 13 --cancel-button Back --ok-button Execute \
-    "61 | Upgrade System     "    "Upgrade all installed software packages to their newest version " OFF \
     "62 | Packages"               "Install needed and recommended system packages " OFF \
-    "63 | Zulu OpenJDK"           "Install Zulu Embedded OpenJDK Java 8 " OFF \
+    "63 | Zulu OpenJDK 32-bit"    "Install Zulu OpenJDK Java 8 32-bit" OFF \
+    "   | Zulu OpenJDK 64-bit"    "Install Zulu OpenJDK Java 8 64-bit" OFF \
     "64 | openHAB stable"         "Install the latest openHAB release" OFF \
     "   | openHAB testing"        "Install the latest openHAB testing build" OFF \
     "   | openHAB unstable"       "(Alternative) Install the latest openHAB SNAPSHOT build" OFF \
@@ -180,10 +180,9 @@ show_main_menu() {
     "   | Remove zram"            "Don't use compressed memory (back to standard Raspbian FS layout)" OFF \
     3>&1 1>&2 2>&3)
     if [ $? -eq 1 ] || [ $? -eq 255 ]; then return 0; fi
-
-    if [[ $choosenComponents == *"61"* ]]; then system_upgrade; fi
-    if [[ $choosenComponents == *"62"* ]]; then basic_packages && needed_packages; fi
-    if [[ $choosenComponents == *"63"* ]]; then java_zulu; fi
+    if [[ $choosenComponents == *"62"* ]]; then apt-get upgrade -y && basic_packages && needed_packages; fi
+    if [[ $choosenComponents == *"63"* ]]; then update_config_java "32-bit"; java_install_or_update "$java_arch"; fi
+    if [[ $choosenComponents == *"Zulu OpenJDK 64-bit"* ]]; then update_config_java "64-bit"; java_install_or_update "$java_arch"; fi
     if [[ $choosenComponents == *"64"* ]]; then openhab2_setup; fi
     if [[ $choosenComponents == *"openHAB testing"* ]]; then openhab2_setup testing; fi
     if [[ $choosenComponents == *"openHAB unstable"* ]]; then openhab2_setup unstable; fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -40,7 +40,7 @@ firemotd_setup() {
   echo "0 0 * * * root perl -e 'sleep int(rand(21600))' && /bin/bash /usr/local/bin/FireMotD -S &>/dev/null" >> /etc/cron.d/firemotd
   # invoke apt updates check after every apt action ('apt-get upgrade', ...)
   echo "DPkg::Post-Invoke { \"if [ -x /usr/local/bin/FireMotD ]; then echo -n 'Updating FireMotD available updates count ... '; /bin/bash /usr/local/bin/FireMotD --skiprepoupdate -S; echo ''; fi\"; };" > /etc/apt/apt.conf.d/15firemotd
-  if [ $FAILED -eq 1 ]; then echo -n "FAILED "; else echo -n "OK "; fi
+  if [ $FAILED -eq 1 ]; then echo "FAILED "; else echo "OK "; fi
 }
 
 create_mta_config() {

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -20,6 +20,7 @@ system_upgrade() {
     rm -f openhab-key.asc
   fi
   cond_redirect apt-get --yes upgrade
+  cond_redirect java_install_or_update "$java_arch"
   if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
 }
 

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -70,7 +70,7 @@ if [[ -n "$UNATTENDED" ]]; then
   bashrc_copy
   vimrc_copy
   firemotd_setup
-  java_zulu
+  java_install_or_update "$java_arch"
   openhab2_setup
   vim_openhab_syntax
   nano_openhab_syntax


### PR DESCRIPTION
* Dynamic fetching of Azul .tar using their updated backend.
* Defaults to 32-bit version of Java according to openHAB documentation.
* Updating JAVA when upgrade is choosen in openhabian menu. Closes: #592
* Installs Zulu Cryptography Extension Kit #111
* Add option to switch between 32 and 64 bit Java from menu and config file.
* Removed old `java_webupd8_archive` function.
* Updated menus to not wreak havok on already installed systems

Signed-off-by: Elias Gabrielsson <elias@gabson.se>