### PR TITLE
[homegear] added missing Ubuntu Bionic Beaver

### DIFF
--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -109,24 +109,34 @@ is_raspbian() {
   [[ "$(cat /etc/*release*)" =~ "Raspbian" ]]
   return $?
 }
+# Debian/Raspbian, to be deprecated, LTS ends 2020-06-30
 is_jessie() {
   [[ $(cat /etc/*release*) =~ "jessie" ]]
   return $?
 }
+# Debian/Raspbian oldstable
 is_stretch() {
   [[ $(cat /etc/*release*) =~ "stretch" ]]
   return $?
 }
+# Debian/Raspbian stable
 is_buster() {
   [[ $(cat /etc/*release*) =~ "buster" ]]
   return $?
 }
+# Ubuntu 14, to be deprecated
 is_trusty() {
   [[ $(cat /etc/*release*) =~ "trusty" ]]
   return $?
 }
+# Ubuntu 16
 is_xenial() {
   [[ $(cat /etc/*release*) =~ "xenial" ]]
+  return $?
+}
+# Ubuntu 18
+is_bionic() {
+  [[ $(cat /etc/*release*) =~ "bionic" ]]
   return $?
 }
 running_in_docker() {

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -151,6 +151,9 @@ To continue your integration in openHAB 2, please follow the instructions under:
     Ubuntu-xenial)
       echo 'deb https://apt.homegear.eu/Ubuntu/ xenial/' > /etc/apt/sources.list.d/homegear.list
       ;;
+    Ubuntu-bionic)
+      echo 'deb https://apt.homegear.eu/Ubuntu/ bionic/' > /etc/apt/sources.list.d/homegear.list
+      ;;
     *)
       cond_echo "Your OS is not supported"
       exit 1


### PR DESCRIPTION
Just noticed that we missed current Ubuntu release when installing homegear.
May no longer be needed if we implement #621.

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>