### PR TITLE
Zram fixes size to match Karaf cache and to change repo

### DIFF
--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -112,6 +112,7 @@ show_main_menu() {
     "36 | Wifi Setup"             "Configure the build-in Raspberry Pi 3 / Pine A64 wifi" \
     "37 | Move root to USB"       "Move the system root from the SD card to a USB device (SSD or stick)" \
     "38 | Use zram (BETA)"        "Use compressed RAM/disk sync for active directories to avoid SD card corruption" \
+    "   | Remove zram"            "Don't use compressed memory (back to standard Raspbian FS layout)" \
     3>&1 1>&2 2>&3)
     if [ $? -eq 1 ] || [ $? -eq 255 ]; then return 0; fi
     case "$choice2" in
@@ -123,6 +124,7 @@ show_main_menu() {
       36\ *) wifi_setup ;;
       37\ *) move_root2usb ;;
       38\ *) init_zram_mounts install;;
+      *Remove\ zram) init_zram_mounts remove;;
       "") return 0 ;;
       *) whiptail --msgbox "A not supported option was selected (probably a programming error):\\n  \"$choice2\"" 8 80 ;;
     esac

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -6,8 +6,8 @@ init_zram_mounts() {
       # point to ZRAM status thread on forum
       if ! (whiptail --title "Install ZRAM, Continue?" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then echo "CANCELED"; return 0; fi
     fi
-    local ZRAMGIT=https://github.com/mstormi/zram-config
-    local TAG=openhabian_v1.5
+    local ZRAMGIT=https://github.com/StuartIanNaylor/zram-config
+    local TAG=mster
     TMP="$(mktemp -d /tmp/openhabian.XXXXXXXXXX)"
 
     /usr/bin/git clone -q --branch "$TAG" "$ZRAMGIT" "$TMP"

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -7,7 +7,7 @@ init_zram_mounts() {
       if ! (whiptail --title "Install ZRAM, Continue?" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then echo "CANCELED"; return 0; fi
     fi
     local ZRAMGIT=https://github.com/mstormi/openhabian-zram
-    local TAG=master
+    local TAG=openhabian_v1.5
     TMP="$(mktemp -d /tmp/openhabian.XXXXXXXXXX)"
 
     /usr/bin/git clone -q --branch "$TAG" "$ZRAMGIT" "$TMP"

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -6,8 +6,8 @@ init_zram_mounts() {
       # point to ZRAM status thread on forum
       if ! (whiptail --title "Install ZRAM, Continue?" --yes-button "Continue" --no-button "Back" --yesno "$introtext" 15 80) then echo "CANCELED"; return 0; fi
     fi
-    local ZRAMGIT=https://github.com/StuartIanNaylor/zram-config
-    local TAG=mster
+    local ZRAMGIT=https://github.com/mstormi/openhabian-zram
+    local TAG=master
     TMP="$(mktemp -d /tmp/openhabian.XXXXXXXXXX)"
 
     /usr/bin/git clone -q --branch "$TAG" "$ZRAMGIT" "$TMP"

--- a/includes/ztab
+++ b/includes/ztab
@@ -18,7 +18,7 @@
 swap	lz4	200M		600M		75		0		90
 
 # dir	alg	mem_limit	disk_size	target_dir		bind_dir
-dir	lz4	350M		600M		/var/lib/openhab2	/openhab2.bind
+dir	lz4	200M		600M		/var/lib/openhab2	/openhab2.bind
 
 # log	alg	mem_limit	disk_size	target_dir		bind_dir		oldlog_dir
-log	lzo	100M		300M		/var/log		/log.bind
+log	lzo	150M		500M		/var/log		/log.bind

--- a/includes/ztab
+++ b/includes/ztab
@@ -18,7 +18,7 @@
 swap	lz4	200M		600M		75		0		90
 
 # dir	alg	mem_limit	disk_size	target_dir		bind_dir
-dir	lz4	200M		400M		/var/lib/openhab2	/openhab2.bind
+dir	lz4	350M		600M		/var/lib/openhab2	/openhab2.bind
 
 # log	alg	mem_limit	disk_size	target_dir		bind_dir		oldlog_dir
 log	lzo	100M		300M		/var/log		/log.bind


### PR DESCRIPTION
to avoid the OverlayFS to become read-only when disksize limit is reached

Also add missing menu entry below 38 to uninstall zram and changed the upstream repo (to make installs work while waiting for it to be transferred).