### PR TITLE
fix for multiple nginx users .htpasswd

### DIFF
--- a/functions/passwords.bash
+++ b/functions/passwords.bash
@@ -51,7 +51,7 @@ change_password() {
         passwordChange="$(whiptail --title "Authentication Setup" --passwordbox "Enter a new password: " 15 80 3>&1 1>&2 2>&3)"
         if [[ "$?" == 1 ]]; then return 0; fi
         if [ ! ${#passwordChange} -ge 10 ]; then
-          whiptail --title "Authentication Setup" --msgbox "Password must at least be 8 characters long... Please try again!" 15 80 3>&1 1>&2 2>&3
+          whiptail --title "Authentication Setup" --msgbox "Password must at least be 10 characters long... Please try again!" 15 80 3>&1 1>&2 2>&3
         else
           secondpasswordChange="$(whiptail --title "Authentication Setup" --passwordbox "Please confirm the new password:" 15 80 3>&1 1>&2 2>&3)"
           if [[ "$?" == 1 ]]; then return 0; fi

--- a/functions/passwords.bash
+++ b/functions/passwords.bash
@@ -19,15 +19,15 @@ change_password() {
   FAILED=0
 
   # BUILD LIST WITH INSTALLED SERVICES
-  whipParams=( --title "Change password function" --ok-button "Execute" --cancel-button "Back" --checklist "$introtext" 20 90 10)
+  whipParams=( --title "Change password function" --ok-button "Execute" --cancel-button "Back" --checklist "$introtext" 14 90 6)
   whipParams+=("Linux system" "Account; \"$username\" used for login to this computer" off )
   whipParams+=("openHAB Console" "Remote console account; \"openhab\" for manage openHAB" off )
   whipParams+=("Samba" "Fileshare account; \"$username\" for configuration files" off )
-  whipParams+=("Amanda backup" "User account; \"backup\" which could handle openHAB backups " off )
+  whipParams+=("Amanda backup" "User account; \"backup\" to handle openHAB backups" off )
 
   if [ -f /etc/nginx/.htpasswd ]; then
-    nginxuser="$(cut -d: -f1 /etc/nginx/.htpasswd)"
-    whipParams+=("Ngnix HTTP/HTTPS" "User; \"$nginxuser\" used for logon to openHAB web services " off )
+    nginxuser="$(cut -d: -f1 /etc/nginx/.htpasswd | head -1)"
+    whipParams+=("Ngnix HTTP/HTTPS" "User; \"$nginxuser\" used for logon to openHAB web services" off )
     allAccounts+=( "Ngnix HTTP/HTTPS" )
   fi
 
@@ -51,7 +51,7 @@ change_password() {
         passwordChange="$(whiptail --title "Authentication Setup" --passwordbox "Enter a new password: " 15 80 3>&1 1>&2 2>&3)"
         if [[ "$?" == 1 ]]; then return 0; fi
         if [ ! ${#passwordChange} -ge 10 ]; then
-          whiptail --title "Authentication Setup" --msgbox "Password must at least be 10 characters long... Please try again!" 15 80 3>&1 1>&2 2>&3
+          whiptail --title "Authentication Setup" --msgbox "Password must at least be 8 characters long... Please try again!" 15 80 3>&1 1>&2 2>&3
         else
           secondpasswordChange="$(whiptail --title "Authentication Setup" --passwordbox "Please confirm the new password:" 15 80 3>&1 1>&2 2>&3)"
           if [[ "$?" == 1 ]]; then return 0; fi


### PR DESCRIPTION
nginx .htpasswd screws up functionality if it contains more than 1 entry
Fixes #769 

8 chars are way more common, so don't require users to enter 10 char passwords
(due to this many people need to think of a new one)

Signed-off-by: Markus Storm <markus.storm@gmx.net>