### PR TITLE
Fix/539 nginx letsencrypt failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ node_modules/
 *.img.bz2
 *.log
 .DS_Store
+
+# =========================
+### JetBrains IDE
+
+.idea/
+*.iws
+*.iml

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -428,10 +428,10 @@ nginx_setup() {
   fi
 
   function comment {
-    sed -i "$1"' s/^/#/' "$2"
+    sed -e "/#_$1_#/ s/^/#/" -i "$2"
   }
   function uncomment {
-    sed -i "$1"' s/^ *#//' "$2"
+    sed -e "/#_$1_#/ s/^#//" -i "$2"
   }
 
   echo "Installing DNS utilities..."
@@ -528,7 +528,7 @@ nginx_setup() {
       apt-get -y -q install apache2-utils || FAILED=true
       echo "Creating password file..."
       htpasswd -b -c /etc/nginx/.htpasswd "$username" "$password"
-      uncomment 32,33 /etc/nginx/sites-enabled/openhab
+      uncomment "AUTH" /etc/nginx/sites-enabled/openhab
     fi
 
     if [ "$SECURE" = true ]; then
@@ -556,7 +556,7 @@ nginx_setup() {
         echo "Installing certbot..."
         apt-get -y -q --force-yes install "${certbotpackage}" "${certbotoption}" "${certbotrepo}"
         mkdir -p /var/www/$domain
-        uncomment 37,39 /etc/nginx/sites-enabled/openhab
+        uncomment "WEBROOT" /etc/nginx/sites-enabled/openhab
         nginx -t && service nginx reload
         echo "Creating Let's Encrypt certificate..."
         certbot certonly --webroot -w /var/www/$domain -d $domain || FAILED=true #This will cause a prompt
@@ -572,12 +572,12 @@ nginx_setup() {
         openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $keypath -out $certpath || FAILED=true #This will cause a prompt
       fi
       if [ "$FAILED" = false ]; then
-        uncomment 20,21 /etc/nginx/sites-enabled/openhab
+        uncomment "CERT" /etc/nginx/sites-enabled/openhab
         sed -i "s|CERTPATH|${certpath}|g" /etc/nginx/sites-enabled/openhab
         sed -i "s|KEYPATH|${keypath}|g" /etc/nginx/sites-enabled/openhab
-        uncomment 6,10 /etc/nginx/sites-enabled/openhab
-        uncomment 15,17 /etc/nginx/sites-enabled/openhab
-        comment 14 /etc/nginx/sites-enabled/openhab
+        uncomment "REDIR" /etc/nginx/sites-enabled/openhab
+        uncomment "HTTPS" /etc/nginx/sites-enabled/openhab
+        comment "HTTP" /etc/nginx/sites-enabled/openhab
       fi
     fi
     nginx -t && systemctl reload nginx.service || FAILED=true

--- a/includes/nginx.conf
+++ b/includes/nginx.conf
@@ -3,18 +3,18 @@
 #################################
 
 ## Redirection
-#server {
-#   listen                          80;
-#   server_name                     DOMAINNAME;
-#   return 301                      https://$server_name$request_uri;
-#}
+#server {                                                               #_REDIR_#
+#   listen                          80;                                 #_REDIR_#
+#   server_name                     DOMAINNAME;                         #_REDIR_#
+#   return 301                      https://$server_name$request_uri;   #_REDIR_#
+#}                                                                      #_REDIR_#
 
 ## Reverse Proxy to openHAB
 server {
-    listen                          80;
-#   listen                          443 ssl;
+    listen                          80;                                                                 #_HTTP_#
+#   listen                          443 ssl;                                                            #_HTTPS_#
     server_name                     DOMAINNAME;
-#   add_header                      Strict-Transport-Security "max-age=31536000; includeSubDomains";
+#   add_header                      Strict-Transport-Security "max-age=31536000; includeSubDomains";    #_HTTPS_#
 
     # Cross-Origin Resource Sharing.
     # add_header 'Access-Control-Allow-Origin' 'http://localhost:8080/rest';
@@ -23,8 +23,8 @@ server {
     add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
     
 ## Secure Certificate Locations
-#   ssl_certificate                 CERTPATH;
-#   ssl_certificate_key             KEYPATH;
+#   ssl_certificate                 CERTPATH;   #_CERT_#
+#   ssl_certificate_key             KEYPATH;    #_CERT_#
 
     location / {
         proxy_pass                              http://localhost:8080/;
@@ -35,14 +35,14 @@ server {
         proxy_set_header X-Forwarded-Proto      $scheme;
 
 ## Password Protection
-#       auth_basic                              "Username and Password Required";
-#       auth_basic_user_file                    /etc/nginx/.htpasswd;
+#       auth_basic                              "Username and Password Required";   #_AUTH_#
+#       auth_basic_user_file                    /etc/nginx/.htpasswd;               #_AUTH_#
     }
 
 ## Let's Encrypt webroot location
-#   location /.well-known/acme-challenge/ {
-#       root                                    /var/www/DOMAINNAME;
-#   }
+#   location /.well-known/acme-challenge/ {                             #_WEBROOT_#
+#       root                                    /var/www/DOMAINNAME;    #_WEBROOT_#
+#   }                                                                   #_WEBROOT_#
 }
 
 # vim: filetype=conf


### PR DESCRIPTION
NGINX setup is currently broken due to it trying to uncomment the wrong line numbers.

The uncomment/comment function now use a keyword to find the lines, instead of pointing to a specific line number.

Signed-off-by: Lionel SAURON altair2010@users.noreply.github.com