### PR TITLE
replace fstab by explicit systemd mount units to ensure proper order

### DIFF
--- a/includes/mount_template
+++ b/includes/mount_template
@@ -1,0 +1,13 @@
+[Unit]
+Description=openhab2-%DEST mount
+After=zram-config.service
+
+[Mount]
+What=%SRC
+Where=/srv/openhab2-%DEST
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target
+

--- a/includes/smb.conf
+++ b/includes/smb.conf
@@ -183,33 +183,33 @@
 
 #======================= Share Definitions =======================
 
-[homes]
-  comment = Home Directories
-  browseable = no
-  valid users = %S
-  writeable = yes
-  create mask = 0700
-  directory mask = 0700
+;[homes]
+;  comment = Home Directories
+;  browseable = no
+;  valid users = %S
+;  writeable = yes
+;  create mask = 0700
+;  directory mask = 0700
 
-[printers]
-   comment = All Printers
-   browseable = no
-   public = no
-   path = /var/spool/samba
-   printable = yes
-   guest ok = no
-   read only = yes
-   create mask = 0700
+;[printers]
+;   comment = All Printers
+;   browseable = no
+;   public = no
+;   path = /var/spool/samba
+;   printable = yes
+;   guest ok = no
+;   read only = yes
+;   create mask = 0700
 
 # Windows clients look for this share name as a source of downloadable
 # printer drivers
-[print$]
-   comment = Printer Drivers
-   path = /var/lib/samba/printers
-   browseable = no
-   public = no
-   read only = yes
-   guest ok = no
+;[print$]
+;   comment = Printer Drivers
+;   path = /var/lib/samba/printers
+;   browseable = no
+;   public = no
+;   read only = yes
+;   guest ok = no
 # Uncomment to allow remote administration of Windows print drivers.
 # You may need to replace 'lpadmin' with the name of the group your
 # admin users are members of.
@@ -219,15 +219,15 @@
 
 #=================== Custom Share Definitions ====================
 
-[openHAB-share]
-  comment=openHAB2 combined folders
-  path=/srv
-  writeable=yes
-  public=no
-  create mask=0664
-  directory mask=0775
-  veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/._*/
-  delete veto files = yes
+;[openHAB-share]
+;  comment=openHAB2 combined folders
+;  path=/srv
+;  writeable=yes
+;  public=no
+;  create mask=0664
+;  directory mask=0775
+;  veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/._*/
+;  delete veto files = yes
 
 [openHAB-conf]
   comment=openHAB2 site configuration
@@ -259,15 +259,15 @@
 ;  veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/._*/
 ;  delete veto files = yes
 
-;[openHAB-log]
-;  comment=openHAB2 log files
-;  path=/var/log/openhab2
-;  writeable=yes
-;  public=no
-;  create mask=0664
-;  directory mask=0775
-;  veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/._*/
-;  delete veto files = yes
+[openHAB-logs]
+  comment=openHAB2 log files
+  path=/var/log/openhab2
+  writeable=yes
+  public=no
+  create mask=0664
+  directory mask=0775
+  veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/._*/
+  delete veto files = yes
 
 ;[var-www]
 ;  comment=webserver files


### PR DESCRIPTION
... to make ZRAM work with Samba shares of /srv/openhab2-*

Note this effectively removes most entries from /etc/fstab but that's intentional else we would not get the intended order of mounts to work.

Use option 13 to validate.

Fixes #795 

Signed-off-by: Markus Storm <markus.storm@gmx.net>