### PR TITLE
remove extra installs of apt-transport-http

### DIFF
--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -218,7 +218,6 @@ influxdb_install() {
   influxdb_address="http://localhost:8086"
   influxdb_admin_username="admin"
   if [ ! -f /etc/influxdb/influxdb.conf ]; then
-    cond_redirect apt-get -y install apt-transport-https
     cond_redirect wget -O - https://repos.influxdata.com/influxdb.key | apt-key add - || FAILED=1
     echo "deb https://repos.influxdata.com/$dist $codename stable" > /etc/apt/sources.list.d/influxdb.list || FAILED=1
     cond_redirect apt-get update || FAILED=1

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -21,8 +21,6 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
     TESTING=1
   fi
 
-  cond_redirect apt-get -y install apt-transport-https
-
   if [ -z "$UNSTABLE" ]; then
     if [ -z "$TESTING" ]; then
       echo -n "$(timestamp) [openHABian] Installing or upgrading to latest openHAB release (stable)... "


### PR DESCRIPTION
already gets installed in needed_packages()

Signed-off-by: Markus Storm <markus.storm@gmx.net>