### PR TITLE
fix Java install/upgrade

### DIFF
--- a/functions/system.bash
+++ b/functions/system.bash
@@ -9,17 +9,7 @@ whiptail_check() {
 
 system_upgrade() {
   echo -n "$(timestamp) [openHABian] Updating repositories and upgrading installed packages... "
-  # TODO: Remove updating the key on each update after some time (in 2020)
-  cond_redirect wget -O openhab-key.asc 'https://bintray.com/user/downloadSubjectPublicKey?username=openhab'
-  if ! cond_redirect apt-key add openhab-key.asc; then
-    echo "FAILED (updating OH key)"
-    echo -n "attempting to continue..."
-  else
-    rm -f openhab-key.asc
-  fi
   cond_redirect apt-get --yes upgrade
-  # shellcheck disable=SC2154
-  if cond_redirect java_install_or_update "$java_arch"; then echo "OK"; else echo "FAILED"; exit 1; fi
 }
 
 basic_packages() {


### PR DESCRIPTION
remove calling java (re)install on Option 03 (Upgrade) to avoid Java reinstall of same version
fix installing 64bit where applicable (x86) or explicitly requested

Fixes #723
Fixes #729
Fixes #805  
Fixes #839

I have been waiting so long before publishing this PR because I would have preferred Elias to check for installed java version in his install routine as I don't want to touch that code, but now that he's offline I think it's reasonable to implement it.

Signed-off-by: Markus Storm <markus.storm@gmx.net>