### PR TITLE
Add WiFi for RPI4

### DIFF
--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -29,4 +29,4 @@ wifi_country=""
 
 # Java architecture mode
 # Use "32-bit" or "64-bit"
-java_arch="32-bit"
+java_arch="64-bit"

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -12,8 +12,10 @@ system_default_locale="en_US.UTF-8"
 #timezone=Europe/Berlin
 
 # Wi-Fi settings. An ethernet connection is recommended
-# Requirement: RPi3, RPi0W, PineA64 or a supported external Wi-Fi dongle
+# Requirement: RPi4, RPi3, RPi0W or a supported external Wi-Fi dongle
 # Fill in your SSID and password below, leave empty to use ethernet
+# ATTENTION: you need to escape these special characters: $, `, ", \, (newline)
+# 'Escaping' means to put an additional \ in front of that character
 wifi_ssid=""
 wifi_psk=""
 
@@ -27,4 +29,4 @@ wifi_country=""
 
 # Java architecture mode
 # Use "32-bit" or "64-bit"
-java_arch="64-bit"
+java_arch="32-bit"

--- a/build-image/openhabian.pi-raspbian.conf
+++ b/build-image/openhabian.pi-raspbian.conf
@@ -12,8 +12,10 @@ system_default_locale="en_US.UTF-8"
 #timezone=Europe/Berlin
 
 # Wi-Fi settings. An ethernet connection is recommended
-# Requirement: RPi3, RPi0W, PineA64 or a supported external Wi-Fi dongle
+# Requirement: RPi4, RPi3, RPi0W or a supported external Wi-Fi dongle
 # Fill in your SSID and password below, leave empty to use ethernet
+# ATTENTION: you need to escape these special characters: $, `, ", \, (newline)
+# 'Escaping' means to put an additional \ in front of that character
 wifi_ssid=""
 wifi_psk=""
 

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 wifi_setup() {
-  local question="We could not any WiFi hardware on your system.\\nYou are not running any of supported systems RPi4, RPi3, RPi0W or Pine to have WiFi builtin, but we cannot detect all possible WiFi hardware.\\nDo you really want to continue and have openHABian try to setup WiFi ?"
+  local question="We could not detect any WiFi hardware on your system.\\nYou are not running any of supported systems RPi4, RPi3, RPi0W or Pine to have WiFi builtin, but we cannot detect all possible WiFi hardware.\\nDo you really want to continue and have openHABian try to setup WiFi ?"
   echo -n "$(timestamp) [openHABian] Setting up WiFi (PRi3 or Pine A64)... "
 
   if ! is_pifour && ! is_pithree && ! is_pithreeplus && ! is_pizerow && ! is_pine64; then

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 wifi_setup() {
-  echo -n "$(timestamp) [openHABian] Setting up Wifi (PRi3 or Pine A64)... "
-  if ! is_pithree && ! is_pithreeplus && ! is_pizerow && ! is_pine64; then
+  local question="We could not any WiFi hardware on your system.\\nYou are not running any of supported systems RPi4, RPi3, RPi0W or Pine to have WiFi builtin, but we cannot detect all possible WiFi hardware.\\nDo you really want to continue and have openHABian try to setup WiFi ?"
+  echo -n "$(timestamp) [openHABian] Setting up WiFi (PRi3 or Pine A64)... "
+
+  if ! is_pifour && ! is_pithree && ! is_pithreeplus && ! is_pizerow && ! is_pine64; then
     if [ -n "$INTERACTIVE" ]; then
-      whiptail --title "Incompatible Hardware Detected" --msgbox "Wifi setup: This option is for the Pi3, Pi0W or the Pine A64 system only." 10 60
+      if ! (whiptail --title "No WiFi Hardware Detected" --yesno "$question" 10 80); then echo "FAILED"; return 1; fi
     fi
-    echo "FAILED"; return 1
   fi
   if [ -n "$INTERACTIVE" ]; then
     if ! SSID=$(whiptail --title "Wifi Setup" --inputbox "Which Wifi (SSID) do you want to connect to?" 10 60 3>&1 1>&2 2>&3); then return 1; fi
@@ -22,15 +23,15 @@ wifi_setup() {
     if grep -q "^${WIFICOUNTRY^^}\\s" /usr/share/zoneinfo/zone.tab; then
       WIFICOUNTRY=${WIFICOUNTRY^^}
     else
-      whiptail --title "Wifi Setup" --msgbox "${WIFICOUNTRY} is not a valid country code found in /usr/share/zoneinfo/zone.tab" 10 60
+      whiptail --title "WiFi Setup" --msgbox "${WIFICOUNTRY} is not a valid country code found in /usr/share/zoneinfo/zone.tab" 10 60
       echo "${WIFICOUNTRY} is not a valid country code found in /usr/share/zoneinfo/zone.tab"; return 1
     fi
   else
     echo -n "Setting default SSID and password in 'wpa_supplicant.conf' "
-    SSID="myWifiSSID"
-    PASS="myWifiPassword"
+    SSID="myWiFiSSID"
+    PASS="myWiFiPassword"
   fi
-  if is_pithree || is_pithreeplus; then cond_redirect apt-get -y install firmware-brcm80211; fi
+  if is_pifour || is_pithree || is_pithreeplus; then cond_redirect apt-get -y install firmware-brcm80211; fi
   if is_pithreeplus; then
     if iwlist wlan0 scanning 2>&1 | grep -q "Interface doesn't support scanning"; then
       # wifi might be blocked
@@ -67,7 +68,7 @@ wifi_setup() {
   cond_redirect ifdown wlan0
   cond_redirect ifup wlan0
   if [ -n "$INTERACTIVE" ]; then
-    whiptail --title "Operation Successful!" --msgbox "Setup was successful. Your Wifi credentials were NOT tested. Please reboot now." 15 80
+    whiptail --title "Operation Successful!" --msgbox "Setup was successful. Your WiFi credentials were NOT tested. Please reboot now." 15 80
   fi
   echo "OK (Reboot needed)"
 }

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -2,7 +2,7 @@
 
 wifi_setup() {
   local question="We could not detect any WiFi hardware on your system.\\nYou are not running any of supported systems RPi4, RPi3, RPi0W or Pine to have WiFi builtin, but we cannot detect all possible WiFi hardware.\\nDo you really want to continue and have openHABian try to setup WiFi ?"
-  echo -n "$(timestamp) [openHABian] Setting up WiFi (PRi3 or Pine A64)... "
+  echo -n "$(timestamp) [openHABian] Setting up WiFi ... "
 
   if ! is_pifour && ! is_pithree && ! is_pithreeplus && ! is_pizerow && ! is_pine64; then
     if [ -n "$INTERACTIVE" ]; then

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -15,6 +15,14 @@ timezone=Europe/Berlin
 locales="en_US.UTF-8 de_DE.UTF-8"
 system_default_locale="en_US.UTF-8"
 
+# Wi-Fi settings. An ethernet connection is recommended
+# Requirement: RPi4, RPi3, RPi0W or a supported external Wi-Fi dongle
+# Fill in your SSID and password below, leave empty to use ethernet
+# ATTENTION: you need to escape these special characters: $, `, ", \, (newline)
+# 'Escaping' means to put an additional \ in front of that character
+wifi_ssid=""
+wifi_psk=""
+
 # repo to clone from (if not master for build and test)
 repositoryurl=https://github.com/openhab/openhabian.git
 clonebranch=master


### PR DESCRIPTION
Adds RPi4 to supported systems checked for in wifi_setup()

Changed that to also allow for continuing if none of the boxes to have WiFi builtin are detected (as someone might be using a WiFi hat or USB stick).
Added comment to openhabian.conf to escape special characters on manual WiFi setup

NOTE:
My fixes should not do harm (Pi4 WiFi setup is broken anyway), but I have no RPi4 to test against so cannot validate.

Fixes #767 

Might fix #725

Signed-off-by: Markus Storm markus.storm@gmx.net
