### PR TITLE
Use Zulu API v1 when upgrading Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,7 @@ jobs:
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-x86 .
         - echo -e "\n\e[36mopenHABian test installation 64bit Azul Enterprise Java on virtual $HW ...\n"
         - docker run --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
-          docker exec -i "openhabian-${HW}" bash -c \
-            'VIRT=$(sudo virt-what); echo -e "\n\e[37mTesting openhabian install on ${VIRT} ...\n"; ./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
+          docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
     - env: arm32hf
       arch: arm64
       script:
@@ -73,8 +72,7 @@ jobs:
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-ARMv6hf-native .
         - echo -e "\n\e[36mopenHABian test installation 32bit Azul Embedded Java on virtual $HW ...\n"
         - docker run --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
-          docker exec -i "openhabian-${HW}" bash -c \
-            'VIRT=$(sudo virt-what); echo -e "\n\e[37mTesting openhabian install on ${VIRT} ...\n"; ./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
+          docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
     - env: arm32hf
       arch: arm64
       script:
@@ -84,20 +82,7 @@ jobs:
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-arm32hf-native .
         - echo -e "\n\e[36mopenHABian test installation 32bit Azul Embedded Java on virtual $HW ...\n"
         - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian
-        - docker exec -i "openhabian-${HW}" bash -c \
-            'VIRT=$(sudo virt-what); echo -e "\n\e[37mTesting openhabian install on ${VIRT} ...\n"; ./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
-    - env: aarch64
-      arch: arm64
-      script:
-        # 64bit Azul Java on 64bit ARMv8 (RPi3, CM3) on 32bit OS on Travis Arm64 HW -- supposed to fail !
-        - export HW=rpi3
-        - sed -i 's/java_arch=32-bit$/java_arch=64-bit/' build-image/openhabian.conf
-        - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-aarch64-native .
-        - echo -e "\n\e[36mopenHABian test installation 64bit Azul Embedded Java on virtual $HW ..."
-        - echo -e "\e[31m ** This is known to not work. openHABian is supposed to force install down to 32bit **\n"
-        - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
-        - docker exec -i "openhabian-${HW}" bash -c \
-            'VIRT=$(sudo virt-what); echo -e "\n\e[37mTesting openhabian install on ${VIRT} ...\n"; ./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
+        - docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
     - env: arm32hf
       arch: arm64
       script:
@@ -107,8 +92,31 @@ jobs:
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-arm32hf-CM3 .
         - echo -e "\n\e[36mopenHABian test installation 32bit Azul Embedded Java on virtual $HW ...\n"
         - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
-        - docker exec -i "openhabian-${HW}" bash -c \
-            'VIRT=$(sudo virt-what); echo -e "\n\e[37mTesting openhabian install on ${VIRT} ...\n"; ./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
+        - docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
+    - env: arm32hf
+      arch: arm64
+      script:
+        # 64bit Azul Java on 32bit ARMv8 (RPi3, CM3) on 32bit OS on Travis Arm64 HW
+        # This is known to not work - openHABian is supposed to downgrade to 32bit on install.
+        - export HW=rpi3
+        - sed -i 's/java_arch=32-bit$/java_arch=64-bit/' build-image/openhabian.conf
+        - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-arm32hf-native .
+        - echo -e "\n\e[36mopenHABian test installation 64bit Azul Embedded Java on virtual $HW ..."
+        - echo -e "\e[31m ** This is known to not work. openHABian is supposed to force install down to 32bit **\n"
+        - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
+        - docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
+    - env: aarch64
+      arch: arm64
+      script:
+        # 64bit Azul Java on 64bit ARMv8 (RPi3,4) on 32bit OS on Travis Arm64 HW
+        # This is known to not work - openHABian is supposed to downgrade to 32bit on install.
+        - export HW=rpi3
+        - sed -i 's/java_arch=32-bit$/java_arch=64-bit/' build-image/openhabian.conf
+        - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-aarch64-native .
+        - echo -e "\n\e[36mopenHABian test installation 64bit Azul Embedded Java on virtual $HW ..."
+        - echo -e "\e[31m ** This is known to not work. openHABian is supposed to force install down to 32bit **\n"
+        - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
+        - docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
     - env: aarch64
       arch: arm64
       script:
@@ -118,6 +126,4 @@ jobs:
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.openhabian-aarch64-64bit .
         - echo -e "\n\e[36mopenHABian test installation 64bit Azul Embedded Java \e[31m on 64bit OS\e[36m on virtual $HW ...\n"
         - docker run --memory="2G" --memory-reservation="2G" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
-          docker exec -i "openhabian-${HW}" bash -c \
-            'VIRT=$(sudo virt-what); echo -e "\n\e[37mTesting openhabian install on ${VIRT} ...\n"; ./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'
-
+          docker exec -i "openhabian-${HW}" bash -c './build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local'

--- a/Dockerfile.openhabian-arm32hf-native
+++ b/Dockerfile.openhabian-arm32hf-native
@@ -1,6 +1,6 @@
 # assumes at least ARMv71 but not ARMv8 (aarch64) yet
 FROM balenalib/raspberry-pi2-debian-node:latest-buster
- 
+
 ENV container docker
 ENV INITSYSTEM on
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
@@ -37,7 +37,7 @@ RUN cp docker-systemctl-replacement/files/docker/systemctl.py /bin/systemctl
 ENTRYPOINT ["/usr/bin/entry.sh"]
 
 RUN adduser openhabian --gecos "Openhabian,,," --disabled-password
-RUN echo "openhabian:openhabian" | chpasswd   
+RUN echo "openhabian:openhabian" | chpasswd
 RUN /bin/echo -n "Running on " && /usr/bin/arch
 
 COPY . /opt/openhabian/
@@ -50,4 +50,3 @@ VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL 37
 
 CMD ["bash", "start.sh"]
-

--- a/functions/config.bash
+++ b/functions/config.bash
@@ -33,7 +33,18 @@ clean_config_userpw() {
 ## Update java architecture in config file
 ## Valid options: "32-bit" & "64-bit"
 update_config_java() {
-  cond_redirect grep -q '^java_arch' "$CONFIGFILE" && sed -i "s/^java_arch.*/java_arch=$1/" "$CONFIGFILE" || echo "java_arch=$1" >> "$CONFIGFILE"
+  if [ "$1" == "64-bit" ]; then
+    if (! is_x86_64 && ! [ "$(getconf LONG_BIT)" == "64" ]) || (! is_aarch64 && ! [ "$(getconf LONG_BIT)" == "64" ]); then
+      if [ -n "$INTERACTIVE" ]; then
+        whiptail --title "Incompatible hardware detected" --msgbox "Zulu OpenJDK 64-bit: this option does not currently work on your platform.\\n\\nDefaulting to 32-bit installation." 10 60
+      else
+        echo "Zulu OpenJDK 64-bit: this option does not currently work on your platform. Defaulting to 32-bit installation."
+      fi
+      cond_redirect grep -q '^java_arch' "$CONFIGFILE" && sed -i "s/^java_arch.*/java_arch=32-bit/" "$CONFIGFILE" || echo "java_arch=32-bit" >> "$CONFIGFILE"
+    fi
+  else
+    cond_redirect grep -q '^java_arch' "$CONFIGFILE" && sed -i "s/^java_arch.*/java_arch=$1/" "$CONFIGFILE" || echo "java_arch=$1" >> "$CONFIGFILE"
+  fi
   # shellcheck disable=SC1090
   source "$CONFIGFILE"
 }

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -1,36 +1,33 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2181
 
-## Install best suitible java version depending on platform.
-## Valid argument choose between: 64-bit, 32-bit
+## Install appropriate Java version based on current platform.
+## Valid arguments: 64-bit, 32-bit
 ##
 ##    java_install_and_update(String arch)
 ##
 java_install_or_update(){
-  # Make sure we don't overwrite existing none Java Zulu installations
+  # Make sure we don't overwrite existing non Java Zulu installations
   if ! [ -x "$(command -v java)" ] || [[ ! "$(java -version)" == *"Zulu"* ]]; then
-    cond_redirect systemctl stop openhab2.service
-
     if [ "$1" == "64-bit" ]; then
       if is_x86_64; then
         java_zulu_enterprise_8_apt
       else
-        if java_zulu_tar_update_available; then
+        if java_zulu_tar_update_available 64-bit; then
           java_zulu_8_tar 64-bit
         fi
       fi
 
     else # Default to 32-bit installation
-      if java_zulu_tar_update_available; then
-          java_zulu_8_tar 32-bit
+      if java_zulu_tar_update_available 32-bit; then
+        java_zulu_8_tar 32-bit
       fi
     fi
-    cond_redirect systemctl start openhab2.service
   fi
 }
 
-## Install Java Zulu 8 from direct from fetched .TAR file
-## Valid argument choose between: 64-bit, 32-bit
+## Install Java Zulu 8 directly from fetched .tar.gz file
+## Valid arguments: 64-bit, 32-bit
 ##
 ##    java_zulu_8_tar(String arch)
 ##
@@ -41,45 +38,41 @@ java_zulu_8_tar(){
   local jdkBin
   local jdkLib
   local jdkArch
-  local jdkSecurity
+
+  cond_redirect systemctl stop openhab2.service
+
   if [ "$1" == "32-bit" ]; then
     echo -n "$(timestamp) [openHABian] Installing Java Zulu 32-Bit OpenJDK... "
+    link=$(fetch_zulu_tar_url 32-bit)
     if is_arm; then
-      #link="$(fetch_zulu_tar_url "arm-32-bit-hf")";
-      link="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz"
       jdkArch="aarch32"
     else
-      #link="$(fetch_zulu_tar_url "x86-32-bit")";
-      link="https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-linux_i686.tar.gz"
       jdkArch="i386"
     fi
 
     if is_aarch64; then
       dpkg --add-architecture armhf
       cond_redirect apt-get update
-      cond_redirect apt -y install libc6:armhf libncurses5:armhf libstdc++6:armhf
+      cond_redirect apt-get --yes install libc6:armhf libncurses5:armhf libstdc++6:armhf
     fi
 
     if is_x86_64; then
       dpkg --add-architecture i386
-      cond_redirect apt update
-      cond_redirect apt -y install libc6:i386 libncurses5:i386 libstdc++6:i386
+      cond_redirect apt-get update
+      cond_redirect apt-get --yes install libc6:i386 libncurses5:i386 libstdc++6:i386
     fi
 
   elif [ "$1" == "64-bit" ]; then
     echo -n "$(timestamp) [openHABian] Installing Java Zulu 64-Bit OpenJDK... "
+    link=$(fetch_zulu_tar_url 64-bit)
     if is_arm; then
-      #link="$(fetch_zulu_tar_url "arm-64-bit")";
-      link="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz"
       jdkArch="aarch64"
     else
-      #link="$(fetch_zulu_tar_url "x86-64-bit")";
-      link="https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz"
       jdkArch="amd64"
     fi
 
   else
-    echo -n "[DEBUG] Unvalid argument to function java_zulu_8_tar()"
+    echo -n "[DEBUG] Invalid argument to function java_zulu_8_tar()"
     exit 1
   fi
   jdkTempLocation="$(mktemp -d /tmp/openhabian.XXXXX)"
@@ -87,7 +80,7 @@ java_zulu_8_tar(){
   jdkInstallLocation="/opt/jdk"
   mkdir -p $jdkInstallLocation
 
-  # Fetch and copy new JAVA runtime
+  # Fetch and copy new Java Zulu 8 runtime
   cond_redirect wget -nv -O "$jdkTempLocation"/zulu8.tar.gz "$link"
   tar -xpzf "$jdkTempLocation"/zulu8.tar.gz -C "${jdkTempLocation}"
   if [ $? -ne 0 ]; then echo "FAILED"; rm -rf "$jdkTempLocation"/zulu8.tar.gz; exit 1; fi
@@ -100,95 +93,117 @@ java_zulu_8_tar(){
   jdkBin=$(find "${jdkInstallLocation}"/*/bin ... -print -quit)
   jdkLib=$(find "${jdkInstallLocation}"/*/lib ... -print -quit)
   cond_redirect update-alternatives --remove-all java
+  ## TODO: remove sometime in late 2020
   cond_redirect update-alternatives --remove-all javac
   cond_redirect update-alternatives --install /usr/bin/java java "$jdkBin"/java 1083000
-  cond_redirect update-alternatives --install /usr/bin/javac javac "$jdkBin"/javac 1083000
   echo "$jdkLib"/"$jdkArch" > /etc/ld.so.conf.d/java.conf
   echo "$jdkLib"/"$jdkArch"/jli >> /etc/ld.so.conf.d/java.conf
   ldconfig
 
-  java_zulu_install_crypto_extension
+  cond_redirect java_zulu_install_crypto_extension
 
   if [ $? -eq 0 ]; then echo "OK"; else echo "FAILED"; exit 1; fi
+  cond_redirect systemctl start openhab2.service
 }
 
-## Install Azuls Java Zulu Enterprise using APT repository.
-## (Updated version only availible on x86-64bit when checked August 2019)
+## Install Azul's Java Zulu Enterprise using APT repository.
+## (package manager distributions only available on x86-64bit platforms when checked in April 2020)
+##
 java_zulu_enterprise_8_apt(){
   if ! dpkg -s 'zulu-8' >/dev/null 2>&1; then # Check if already is installed
+    cond_redirect systemctl stop openhab2.service
     echo -n "$(timestamp) [openHABian] Installing Zulu Enterprise 64-Bit OpenJDK... "
     cond_redirect apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 219BD9C9
     if [ $? -ne 0 ]; then echo "FAILED (keyserver)"; exit 1; fi
     echo "deb http://repos.azulsystems.com/debian stable main" > /etc/apt/sources.list.d/zulu-enterprise.list
     cond_redirect apt-get update
-    if cond_redirect apt-get -y install zulu-8 && java_zulu_install_crypto_extension; then echo "OK"; else echo "FAILED"; exit 1; fi
+    if cond_redirect apt-get --yes install zulu-8 && java_zulu_install_crypto_extension; then echo "OK"; else echo "FAILED"; exit 1; fi
+    cond_redirect systemctl start openhab2.service
   fi
 }
 
-## Fetches download link for Java Zulu 8.
-## Valid architectures: arm-64-bit, arm-32-bit-sf, arm-32-bit-hf, x86-32-bit, x86-64-bit
+## Fetch Java Zulu 8 directly from Azul API v1
+## Valid arguments: 64-bit, 32-bit
 ##
 ##    fetch_zulu_tar_url(String arch)
 ##
-## TODO: Rewrite using download API when it leaves alpha state. https://www.azul.com/downloads/zulu-community/api/
 fetch_zulu_tar_url(){
+  local link
   local downloadlink
-  local filter
-  if [ ! -x "$(command -v jq)" ]; then
-    apt-get install -y jq
+
+  link="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/binary/?jdk_version=8&ext=tar.gz&os=linux"
+
+  if [ "$1" == "32-bit" ]; then
+    if is_arm; then
+      downloadlink=$(curl "${link}&arch=arm&hw_bitness=32" -s -L -I -o /dev/null -w '%{url_effective}')
+    else
+      downloadlink=$(curl "${link}&arch=x86&hw_bitness=32" -s -L -I -o /dev/null -w '%{url_effective}')
+    fi
+
+  elif [ "$1" == "64-bit" ]; then
+    if is_arm; then
+      downloadlink=$(curl "${link}&arch=arm&hw_bitness=64" -s -L -I -o /dev/null -w '%{url_effective}')
+    else
+      downloadlink=$(curl "${link}&arch=x86&hw_bitness=64" -s -L -I -o /dev/null -w '%{url_effective}')
+    fi
+
+  else
+    echo -n "[DEBUG] Invalid argument to function fetch_zulu_tar_url()"
+    exit 1
   fi
-  filter='.[] | select(.category_slug == "java-8-lts") | select(.latest == 1) | select(.packaging_slug == "jdk") | select(.arch_slug == "'$1'") | .["bundles"] | .[] | select(.extension == "tar.gz") | .["link"]' # Temporary
-  # filter='.[] | select(.os == "Linux") | select(.category_slug == "java-8-lts") | select(.latest == 1) | select(.packaging_slug == "jdk") | select(.arch_slug == "'$1'") | select((.os_flavor | index("Debian")) or (.os_flavor == "[]")) | .["bundles"] | .[] | select(.extension == "tar.gz") | .["link"]' # $1 = e.g. "arm-64-bit"
-  # Fetch an JSON array of download candidates from azul and filter them
-  # shellcheck disable=SC2006
-  downloadlink=`curl 'https://www.azul.com/wp-admin/admin-ajax.php' -s \
-        -H 'Accept: */*' \
-        -H 'X-Requested-With: XMLHttpRequest' \
-        -H 'Content-Type: multipart/form-data; boundary=---------------------------17447165291708986765346780730' \
-        -H 'Connection: keep-alive' \
-        -H 'Cache-Control: max-age=0' -H 'TE: Trailers' \
-        --data-binary $'-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nbundles_filter_query\r\n-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nsearch_bundles\r\n-----------------------------17447165291708986765346780730--\r\n' \
-        | jq -r "$filter"`
+
   if [ -z "$downloadlink" ]; then return 1; fi
-    # shellcheck disable=SC2046,SC2005,SC2006
-    echo `echo "$downloadlink" | head -n1`
+  echo "$downloadlink"
   return 0
 }
 
-## Check whatever a newer version Zulu version is available.
-## Returns 0 / true if new version exist
-## TODO: Rewrite using download API when it leaves alpha state. https://www.azul.com/downloads/zulu-community/api/
+## Check if a newer version of Java Zulu 8 is available.
+## Returns 0 / true if new version exists
+## Valid arguments: 64-bit, 32-bit
+##
+##    java_zulu_tar_update_available(String arch)
+##
 java_zulu_tar_update_available(){
   if [ ! -x "$(command -v java)" ]; then return 0; fi
-
-  local availableVersion # format: "8u222-b10"
+  local availableVersion
   local javaVersion
   local filter
+  local link
   if [ ! -x "$(command -v jq)" ]; then
-    apt-get install -y jq
+    cond_redirect apt-get install --yes jq
   fi
-  filter='[.[] | select(.category_slug == "java-8-lts") | select(.latest == 1)  | .["openjdk_version"]] | first' # Temporary
-  #filter='[.[] | select(.os == "Linux") | select(.category_slug == "java-8-lts") | select(.latest == 1)  | .["openjdk_version"]] | first'
-  # Fetch an JSON array of download candidates from azul and filter them
-  # shellcheck disable=SC2006
-  availableVersion=`curl 'https://www.azul.com/wp-admin/admin-ajax.php' -s \
-        -H 'Accept: */*' \
-        -H 'X-Requested-With: XMLHttpRequest' \
-        -H 'Content-Type: multipart/form-data; boundary=---------------------------17447165291708986765346780730' \
-        -H 'Connection: keep-alive' \
-        -H 'Cache-Control: max-age=0' -H 'TE: Trailers' \
-        --data-binary $'-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nbundles_filter_query\r\n-----------------------------17447165291708986765346780730\r\nContent-Disposition: form-data; name="action"\r\n\r\nsearch_bundles\r\n-----------------------------17447165291708986765346780730--\r\n' \
-        | jq -r "$filter"`
-  availableVersion="${availableVersion:2}" # Strip first two char -> "222-b10"
-  javaVersion=$(java -version)
-  if [[ $javaVersion == *"$availableVersion"* ]]; then
-    # Java updated
-    return 1
+
+  filter='[.zulu_version[] | tostring] | join(".")'
+  link="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=8&ext=tar.gz&os=linux"
+  javaVersion=$(java -version 2>&1 | grep -m 1 -o "[0-9]\{0,3\}\.[0-9]\{0,3\}\.[0-9]\{0,3\}\.[0-9]\{0,3\}")
+
+  if [ "$1" == "32-bit" ]; then
+    if is_arm; then
+      availableVersion=$(curl -s -H "Accept: application/json" "${link}&arch=arm&hw_bitness=32" | jq -r "$filter")
+    else
+      availableVersion=$(curl -s -H "Accept: application/json" "${link}&arch=x86&hw_bitness=32" | jq -r "$filter")
+    fi
+
+  elif [ "$1" == "64-bit" ]; then
+    if is_arm; then
+      availableVersion=$(curl -s -H "Accept: application/json" "${link}&arch=arm&hw_bitness=64" | jq -r "$filter")
+    else
+      availableVersion=$(curl -s -H "Accept: application/json" "${link}&arch=x86&hw_bitness=64" | jq -r "$filter")
+    fi
+
+  else
+    echo -n "[DEBUG] Invalid argument to function java_zulu_tar_update_available()"
+    exit 1
+  fi
+
+  if [[ $javaVersion == "$availableVersion" ]]; then
+    return 1 # Java is up-to-date
   fi
   return 0
 }
 
-## Install Cryptography Extension Kit to enable cryptos using more then 128 bits
+## Install Zulu Cryptography Extension Kit to enable cryptos using more then 128 bits
+##
 java_zulu_install_crypto_extension(){
   local jdkPath
   local jdkSecurity
@@ -199,7 +214,7 @@ java_zulu_install_crypto_extension(){
   policyTempLocation="$(mktemp -d /tmp/openhabian.XXXXX)"
   if [ -z "$policyTempLocation" ]; then echo "FAILED"; exit 1; fi
 
-  cond_redirect wget -nv -O "$policyTempLocation"/crypto.zip http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  cond_redirect wget -nv -O "$policyTempLocation"/crypto.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
   cond_redirect unzip "$policyTempLocation"/crypto.zip -d "$policyTempLocation"
   cp "$policyTempLocation"/ZuluJCEPolicies/*.jar "$jdkSecurity"
 

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -65,10 +65,22 @@ java_zulu_8_tar(){
   elif [ "$1" == "64-bit" ]; then
     echo -n "$(timestamp) [openHABian] Installing Java Zulu 64-Bit OpenJDK... "
     link=$(fetch_zulu_tar_url 64-bit)
-    if is_arm; then
+    if is_aarch64 && [ "$(getconf LONG_BIT)" == "64" ]; then
       jdkArch="aarch64"
-    else
+    elif is_x86_64 && [ "$(getconf LONG_BIT)" == "64" ]; then
       jdkArch="amd64"
+    else
+      if [ -n "$INTERACTIVE" ]; then
+        whiptail --title "Incompatible hardware detected" --msgbox "Zulu OpenJDK 64-bit: this option does not currently work on your platform.\\n\\nDefaulting to 32-bit installation." 10 60
+      else
+        echo "Zulu OpenJDK 64-bit: this option does not currently work on your platform. Defaulting to 32-bit installation."
+      fi
+      link=$(fetch_zulu_tar_url 32-bit)
+      if is_arm; then
+        jdkArch="aarch32"
+      else
+        jdkArch="i386"
+      fi
     fi
 
   else
@@ -192,8 +204,7 @@ java_zulu_tar_update_available(){
     fi
 
   else
-    echo -n "[DEBUG] Invalid argument to function java_zulu_tar_update_available()"
-    exit 1
+    if [ $? -ne 0 ]; then echo "FAILED (java update available)"; exit 1; fi
   fi
 
   if [[ $javaVersion == "$availableVersion" ]]; then

--- a/functions/java-jre.bats
+++ b/functions/java-jre.bats
@@ -3,17 +3,17 @@
 load java-jre
 load helpers
 
-@test "unit-zulu_fetch_tar_url" {
-  run echo "https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz"
-  echo "# Fetched .TAR download link for \"arm-32-bit-hf\": $output"
-  curl -s --head "$output" | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null # Check if link is valid, result it $?
-  [ $? -eq 0 ]
-}
-
 @test "installation-java_exist" {
   run java -version
   [ "$status" -eq 0 ]
   [[ $output == *"Zulu"* ]]
+}
+
+@test "unit-zulu_fetch_tar_url" {
+  run fetch_zulu_tar_url 32-bit
+  echo "# Fetched .tar.gz download link for Java Zulu 32-bit: $output"
+  curl -s --head "$output" | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null # Check if link is valid, result it $?
+  [ $? -eq 0 ]
 }
 
 @test "destructive-update_java-64bit_tar" {

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -10,6 +10,8 @@ whiptail_check() {
 system_upgrade() {
   echo -n "$(timestamp) [openHABian] Updating repositories and upgrading installed packages... "
   cond_redirect apt-get --yes upgrade
+  # shellcheck disable=SC2154
+  if cond_redirect java_install_or_update "$java_arch"; then echo "OK"; else echo "FAILED"; exit 1; fi
 }
 
 basic_packages() {


### PR DESCRIPTION
Additionally, to clarify what Java version this will install, when
available, the API will prefer downloading a JRE. However, when a JRE is
not available it will use a JDK instead. However, when JDK's are
installed only the essential binaries are linked to `update-alternatives`
so extra JDK related software is unlinked (i.e. `javac`).

At the moment, Azul appears to only provide JDK builds for ARM platforms 
and so, as such, ARM platforms are most often the ones to not get a JRE
installed and the resulting installation tends to be a bit larger (~100
MB).

One minor inconvenience is that with the current Azul API it does not
allow explicitly choosing builds without the JavaFX additional binaries.
So at times, the Java version installed will have extra JavaFX binaries.
This is usually seen when the architecture being installed is x86 based.

Fixes #714
Fixes #723
See Also #629 

Signed-off-by: Ethan Dye <mrtops03@gmail.com>