### PR TITLE
fix nginx install

### DIFF
--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -518,7 +518,6 @@ nginx_setup() {
 
   if (whiptail --title "Confirmation" --yesno "$confirmtext" 22 80) then
     echo "Installing NGINX..."
-    mkdir -p /etc/nginx && chmod 755 /etc/nginx
     apt-get -y -q install nginx || FAILED=true
 
     rm -rf /etc/nginx/sites-enabled/default
@@ -584,7 +583,6 @@ nginx_setup() {
       fi
     fi
 
-    mkdir -p /var/log/nginx && chgrp adm /var/log/nginx && chmod 775 /var/log/nginx
     nginx -t && systemctl restart nginx.service || FAILED=true
     if [ "$FAILED" = true ]; then
       whiptail --title "Operation Failed!" --msgbox "$failtext" 15 80

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -582,7 +582,9 @@ nginx_setup() {
         uncomment "#SSL" /etc/nginx/sites-enabled/openhab
       fi
     fi
-    nginx -t && systemctl reload nginx.service || FAILED=true
+
+    mkdir -p /var/log/nginx && chgrp adm /var/log/nginx && chmod 775 /var/log/nginx
+    nginx -t && systemctl restart nginx.service || FAILED=true
     if [ "$FAILED" = true ]; then
       whiptail --title "Operation Failed!" --msgbox "$failtext" 15 80
     else

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -518,6 +518,7 @@ nginx_setup() {
 
   if (whiptail --title "Confirmation" --yesno "$confirmtext" 22 80) then
     echo "Installing NGINX..."
+    mkdir -p /etc/nginx && chmod 755 /etc/nginx
     apt-get -y -q install nginx || FAILED=true
 
     rm -rf /etc/nginx/sites-enabled/default

--- a/includes/nginx.conf
+++ b/includes/nginx.conf
@@ -3,11 +3,11 @@
 #################################
 
 ## Redirection
-#server {
+#REDIR server {
 #REDIR   listen                          80;
 #REDIR   server_name                     DOMAINNAME;
 #REDIR   return 301                      https://$server_name$request_uri;
-#}
+#REDIR }
 
 ## Reverse Proxy to openHAB
 server {


### PR DESCRIPTION
We may not assume that nginx is installed/running as part of Raspbian already.

So we need to
* create nginx log dir (it may be missing)
* (re)start instead of reload

Fixes #866

Siggned-off-by: Markus Storm <markus.storm@gmx.net>