### PR TITLE
hotfix to download aarch32hf instead of sf 

### DIFF
--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -147,9 +147,9 @@ fetch_zulu_tar_url(){
 
   if [ "$1" == "32-bit" ]; then
     if is_arm; then
-      downloadlink=$(curl "${link}&arch=arm&hw_bitness=32" -s -L -I -o /dev/null -w '%{url_effective}')
+      downloadlink=$(curl "${link}&arch=arm&hw_bitness=32" -s -L -I -o /dev/null -w '%{url_effective}' | sed -e 's#32sf#32hf#g')
     else
-      downloadlink=$(curl "${link}&arch=x86&hw_bitness=32" -s -L -I -o /dev/null -w '%{url_effective}')
+      downloadlink=$(curl "${link}&arch=x86&hw_bitness=32" -s -L -I -o /dev/null -w '%{url_effective}' | sed -e 's#32sf#32hf#g')
     fi
 
   elif [ "$1" == "64-bit" ]; then


### PR DESCRIPTION
after a recent change there's multiple results returned in Azul REST API

Signed-off-by: Markus Storm <markus.storm@gmx.net>