### PR TITLE
add extra output when waiting after selecting a menu option while apt-get update hasnt finished

### DIFF
--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -16,6 +16,7 @@ apt_update() {
 }
 
 wait_for_apt_to_finish_update() {
+  echo -n "$(timestamp) [openHABian] Updating Linux package information ... "
   if [ ! -v PID_APT ]; then
     apt_update
   fi


### PR DESCRIPTION
(via small patch exception)

Signed-off-by: Markus Storm <markus.storm@gmx.net>