### PR TITLE
add hw,hwarch,release parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Closely related to openHABian is the repository [openhab-linuxpkg](https://githu
 
 Please check the [official documentation article](https://www.openhab.org/docs/installation/openhabian.html) to learn about openHABian and please visit and subscribe to our very active [community forum thread](https://community.openhab.org/t/13379).
 
+If you want to install openHABian on non supported hardware, you can actually fake to make openHABian treat your box as if it was one of the supported ones. Needless to say that that may work out or not.
+See [openhabian](openhabian.md) how to edit openhabian.conf before booting and set either of the hw, hwarch and release parameters.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Closely related to openHABian is the repository [openhab-linuxpkg](https://githu
 
 Please check the [official documentation article](https://www.openhab.org/docs/installation/openhabian.html) to learn about openHABian and please visit and subscribe to our very active [community forum thread](https://community.openhab.org/t/13379).
 
-If you want to install openHABian on non supported hardware, you can actually fake to make openHABian treat your box as if it was one of the supported ones. Needless to say that that may work out or not.
-See [openhabian](openhabian.md) how to edit openhabian.conf before booting and set either of the hw, hwarch and release parameters.
+If you want to install openHABian on non-supported hardware, you can actually fake it to make openHABian treat your box as if it was one of the supported ones. Needless to say that that may work out or not, but it's worth a try.
+See [openhabian](openhabian.md) how to edit openhabian.conf before booting. Set the hw, hwarch and release parameters to match your system best.
 
 ## Development
 

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -37,6 +37,20 @@ clonebranch=master
 # values: "unattended", "unattended_debug" (verbose output in log) or "debug_maximum" (show every command in either mode)
 mode=unattended
 
+# Hardware
+# Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
+hw=Pi2
+
+# Hardware architecture
+# x86_64, amd64, armv6l, armv7l, aarch64, arm64
+hwarch=armv7l
+
+# OS Release
+# ubuntu, raspbian, debian
+# jessie, stretch, buster, bullseye, sid,
+# trusty, xenial, bionic, disco
+release=disco
+
 # Java architecture mode
 # values: "Zulu32", "Zulu64" or "AdoptOpenJDK"
 java_arch=32-bit

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -39,17 +39,17 @@ mode=unattended
 
 # Hardware
 # Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
-hw=Pi2
+#hw=Pi3
 
 # Hardware architecture
 # x86_64, amd64, armv6l, armv7l, aarch64, arm64
-hwarch=armv7l
+#hwarch=armv7l
 
 # OS Release
 # ubuntu, raspbian, debian
 # jessie, stretch, buster, bullseye, sid,
 # trusty, xenial, bionic, disco
-release=disco
+#release=buster
 
 # Java architecture mode
 # values: "Zulu32", "Zulu64" or "AdoptOpenJDK"

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -38,8 +38,8 @@ clonebranch=master
 mode=unattended
 
 # Hardware
-# Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
-#hw=Pi3
+# pi0, pi0w, pi1, cm1, pi2, pi3, cm3, pi3+, cm3+, pi4
+#hw=pi3
 
 # Hardware architecture
 # x86_64, amd64, armv6l, armv7l, aarch64, arm64

--- a/build-image/openhabian.pi-raspbian.conf
+++ b/build-image/openhabian.pi-raspbian.conf
@@ -37,6 +37,20 @@ clonebranch=master
 # values: "unattended", "unattended_debug" (verbose output in log) or "debug_maximum" (show every command in either mode)
 mode=unattended
 
+# Hardware
+# Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
+hw=Pi2
+
+# Hardware architecture
+# x86_64, amd64, armv6l, armv7l, aarch64, arm64
+hwarch=armv7l
+
+# OS Release
+# ubuntu, raspbian, debian
+# jessie, stretch, buster, bullseye, sid,
+# trusty, xenial, bionic, disco
+release=disco
+
 # Java architecture mode
 # values: "Zulu32", "Zulu64" or "AdoptOpenJDK"
 java_arch=32-bit

--- a/build-image/openhabian.pi-raspbian.conf
+++ b/build-image/openhabian.pi-raspbian.conf
@@ -39,17 +39,17 @@ mode=unattended
 
 # Hardware
 # Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
-hw=Pi2
+#hw=Pi3
 
 # Hardware architecture
 # x86_64, amd64, armv6l, armv7l, aarch64, arm64
-hwarch=armv7l
+#hwarch=armv7l
 
 # OS Release
 # ubuntu, raspbian, debian
 # jessie, stretch, buster, bullseye, sid,
 # trusty, xenial, bionic, disco
-release=disco
+#release=buster
 
 # Java architecture mode
 # values: "Zulu32", "Zulu64" or "AdoptOpenJDK"

--- a/build-image/openhabian.pi-raspbian.conf
+++ b/build-image/openhabian.pi-raspbian.conf
@@ -38,8 +38,8 @@ clonebranch=master
 mode=unattended
 
 # Hardware
-# Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
-#hw=Pi3
+# pi0, pi0w, pi1, cm1, pi2, pi3, cm3, pi3+, cm3+, pi4
+#hw=pi3
 
 # Hardware architecture
 # x86_64, amd64, armv6l, armv7l, aarch64, arm64

--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -132,7 +132,7 @@ The "Manual/Fresh Setup" submenu entry is the right place for you. Execute all e
 > Report problems you encounter to the [openHABian Issue Tracker](https://github.com/openhab/openhabian/issues).
 
 {: #openhabian.conf}
-You can actually set a number of parameters before you try installing from SD card for the first time. You can also try with a different set of parameters if you initial attempt fails.
+You can actually set a number of parameters before you try installing from SD card for the first time. You can also try with a different set of parameters if your initial attempt fails.
 
 - Flash the system image to your micro SD card as described, do not remove the SD card yet
 - Access the first SD card partition using the file explorer. It's a vfat (Windows) filesystem.

--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -131,6 +131,17 @@ The "Manual/Fresh Setup" submenu entry is the right place for you. Execute all e
 > Please be cautious and have a close look at the console output for errors.
 > Report problems you encounter to the [openHABian Issue Tracker](https://github.com/openhab/openhabian/issues).
 
+{: #openhabian.conf}
+You can actually set a number of parameters before you try installing from SD card for the first time. You can also try with a different set of parameters if you initial attempt fails.
+
+- Flash the system image to your micro SD card as described, do not remove the SD card yet
+- Access the first SD card partition using the file explorer. It's a vfat (Windows) filesystem.
+  (we assume you're using a Windows, Mac or other desktop system to flash the SD)
+- Open the file `openhabian.conf` in a text editor
+- Uncomment and complete the lines to contain the parameters you want to set
+- Save, Unmount, Insert, Boot
+- Continue with the instructions for your hardware
+
 {: #wifi-setup}
 ### Wi-Fi based Setup Notes
 
@@ -138,17 +149,18 @@ If you own a RPi3, RPi3+, RPi4, a RPi0W, a Pine A64, or a compatible Wi-Fi dongl
 For the setup on Wi-Fi, you'll need to make your SSID and password known to the system before the first boot.
 Additionally to the setup instructions given above, the following steps are needed:
 
-- Flash the system image to your micro SD card as described, do not remove the SD card yet
-- Access the first SD card partition using the file explorer. It's a vfat (Windows) filesystem.
-  (we assume you're using a Windows, Mac or other desktop system to flash the SD)
-- Open the file `openhabian.conf` in a text editor
-- Uncomment and complete the lines reading `wifi_ssid="My Wi-Fi SSID"` and `wifi_psk="password123"`
-- Save, Unmount, Insert, Boot
-- Continue with the instructions for your hardware
+In `openhabian.conf`, uncomment and complete the lines reading `wifi_ssid="My Wi-Fi SSID"` and `wifi_psk="password123"`
+
+{: #fake-hw}
+### Fake hardware mode
+If to install openHABian fails because you have a non-supported hardware or run an unsupported OS release, you can "fake" your hardware and OS to make openHABian behave as if you did own that HW/OS.
+
+In `openhabian.conf`, uncomment and complete the lines reading `hw=`, `hwarch=` and/or `release=` with the hw and os versions you want to attempt installation with.
 
 {: #debug-mode}
 ### Debug mode
-See [Troubleshooting] section if you run into trouble installing. If you want to turn on debug mode, follow the instructions in the previous section and insert a line into `openhabian.conf` reading either `mode=unattended_debug` or better right away `mode=debug_maximum`.
+See [Troubleshooting] section if you run into trouble installing. If you want to turn on debug mode, 
+edit `openhabian.conf` and set the `debug=` parameter to either `none`, `on` or `maximum`.
 
 {: #ipv6-notes}
 ### IPv6 notes

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -33,6 +33,7 @@ cond_echo() {
 }
 
 is_pizero() {
+  # shellcheck disable=SC2154
   if [[ "$hw" == "Pi0" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]09[0-9a-fA-F]$" /proc/cpuinfo
   return $?
@@ -58,7 +59,7 @@ is_pitwo() {
   return $?
 }
 is_pithree() {
-  if [[ "$hw" == "Pi3" ]]; return 0; fi
+  if [[ "$hw" == "Pi3" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]08[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
@@ -85,6 +86,7 @@ is_arm() {
   return 1;
 }
 is_arm64() {
+  # shellcheck disable=SC2154
   if [[ "$hwarch" == "arm64" ]]; then return 0; fi
   case "$(uname -m)" in
     arm64) return 0 ;;
@@ -120,6 +122,7 @@ is_x86_64() {
   esac
 }
 is_ubuntu() {
+  # shellcheck disable=SC2154
   if [[ "$release" == "ubuntu" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "Ubuntu" ]]
   return $?

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -70,7 +70,7 @@ is_pithreeplus() {
 }
 is_pifour() {
   if [[ "$hw" == "pi4" ]]; then return 0; fi
-  ! grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]11[0-9a-fA-F]$" /proc/cpuinfo
+  grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]11[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pi() {

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -33,36 +33,43 @@ cond_echo() {
 }
 
 is_pizero() {
+  if [[ "$hw" == "Pi0" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]09[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pizerow() {
+  if [[ "$hw" == "Pi0W" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0[cC][0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pione() {
+  if [[ "$hw" == "Pi1" ]]; then return 0; fi
   if grep -q "^Revision\\s*:\\s*00[0-9a-fA-F][0-9a-fA-F]$" /proc/cpuinfo; then
     return 0
-  elif  grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0[0-36][0-9a-fA-F]$" /proc/cpuinfo; then
+  elif grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0[0-36][0-9a-fA-F]$" /proc/cpuinfo; then
     return 0
   else
     return 1
   fi
 }
 is_pitwo() {
+  if [[ "$hw" == "Pi2" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]04[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pithree() {
+  if [[ "$hw" == "Pi3" ]]; return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]08[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pithreeplus() {
+  if [[ "$hw" == "Pi3+" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0d[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pifour() {
-  grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]11[0-9a-fA-F]$" /proc/cpuinfo
+  if [[ "$hw" == "Pi4" ]]; then return 0; fi
+  ! grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]11[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pi() {
@@ -74,75 +81,111 @@ is_pine64() {
   return $?
 }
 is_arm() {
+  if is_armv6l || is_armv7l || is_aarch64; then return 0; fi
+  return 1;
+}
+is_arm64() {
+  if [[ "$hwarch" == "arm64" ]]; then return 0; fi
   case "$(uname -m)" in
-    armv6l|armv7l|armhf|arm64|aarch64) return 0 ;;
+    arm64) return 0 ;;
     *) return 1 ;;
   esac
 }
 is_armv6l() {
+  if [[ "$hwarch" == "armv6l" ]]; then return 0; fi
   case "$(uname -m)" in
     armv6l) return 0 ;;
     *) return 1 ;;
   esac
 }
 is_armv7l() {
+  if [[ "$hwarch" == "armv7l" ]]; then return 0; fi
   case "$(uname -m)" in
     armv7l) return 0 ;;
     *) return 1 ;;
   esac
 }
 is_aarch64() {
+  if [[ "$hwarch" == "aarch64" ]] || [[ "$hwarch" == "arm64" ]]; then return 0; fi
   case "$(uname -m)" in
     aarch64|arm64) return 0 ;;
     *) return 1 ;;
   esac
 }
 is_x86_64() {
+  if [[ "$hwarch" == "x86_64" ]] || [[ "$hwarch" == "amd64" ]]; then return 0; fi
   case "$(uname -m)" in
     x86_64|amd64) return 0 ;;
     *) return 1 ;;
   esac
 }
 is_ubuntu() {
+  if [[ "$release" == "ubuntu" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "Ubuntu" ]]
   return $?
 }
 is_debian() {
+  if [[ "$release" == "debian" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "Debian" ]]
   return $?
 }
 is_raspbian() {
+  if [[ "$release" == "raspbian" ]]; then return 0; fi
   [[ "$(cat /etc/*release*)" =~ "Raspbian" ]]
   return $?
 }
 # Debian/Raspbian, to be deprecated, LTS ends 2020-06-30
 is_jessie() {
+  if [[ "$release" == "jessie" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "jessie" ]]
   return $?
 }
 # Debian/Raspbian oldstable
 is_stretch() {
+  if [[ "$release" == "stretch" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "stretch" ]]
   return $?
 }
 # Debian/Raspbian stable
 is_buster() {
+  if [[ "$release" == "buster" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "buster" ]]
+  return $?
+}
+# Debian/Raspbian testing
+is_bullseye() {
+  if [[ "$release" == "bullseye" ]]; then return 0; fi
+  [[ $(cat /etc/*release*) =~ "bullseye" ]]
+  return $?
+}
+# Debian/Raspbian unstable
+is_sid() {
+  if [[ "$release" == "sid" ]]; then return 0; fi
+  [[ $(cat /etc/*release*) =~ "sid" ]]
   return $?
 }
 # Ubuntu 14, to be deprecated
 is_trusty() {
+  if [[ "$release" == "trusty" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "trusty" ]]
   return $?
 }
 # Ubuntu 16
 is_xenial() {
+  if [[ "$release" == "xenial" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "xenial" ]]
   return $?
 }
 # Ubuntu 18
 is_bionic() {
+  if [[ "$release" == "bionic" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "bionic" ]]
+  return $?
+}
+# Ubuntu 20
+is_disco() {
+  if [[ "$release" == "disco" ]]; then return 0; fi
+  [[ $(cat /etc/*release*) =~ "disco" ]]
   return $?
 }
 running_in_docker() {

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -34,17 +34,17 @@ cond_echo() {
 
 is_pizero() {
   # shellcheck disable=SC2154
-  if [[ "$hw" == "Pi0" ]]; then return 0; fi
+  if [[ "$hw" == "pi0" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]09[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pizerow() {
-  if [[ "$hw" == "Pi0W" ]]; then return 0; fi
+  if [[ "$hw" == "pi0w" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0[cC][0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pione() {
-  if [[ "$hw" == "Pi1" ]]; then return 0; fi
+  if [[ "$hw" == "pi1" ]]; then return 0; fi
   if grep -q "^Revision\\s*:\\s*00[0-9a-fA-F][0-9a-fA-F]$" /proc/cpuinfo; then
     return 0
   elif grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0[0-36][0-9a-fA-F]$" /proc/cpuinfo; then
@@ -54,22 +54,22 @@ is_pione() {
   fi
 }
 is_pitwo() {
-  if [[ "$hw" == "Pi2" ]]; then return 0; fi
+  if [[ "$hw" == "pi2" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]04[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pithree() {
-  if [[ "$hw" == "Pi3" ]]; then return 0; fi
+  if [[ "$hw" == "pi3" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]08[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pithreeplus() {
-  if [[ "$hw" == "Pi3+" ]]; then return 0; fi
+  if [[ "$hw" == "pi3+" ]]; then return 0; fi
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]0d[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
 is_pifour() {
-  if [[ "$hw" == "Pi4" ]]; then return 0; fi
+  if [[ "$hw" == "pi4" ]]; then return 0; fi
   ! grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]11[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -37,8 +37,8 @@ clonebranch=master
 mode=unattended
 
 # Hardware
-# Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
-#hw=Pi3
+# pi0, pi0w, pi1, cm1, pi2, pi3, cm3, pi3+, cm3+, pi4
+#hw=pi3
 
 # Hardware architecture
 # x86_64, amd64, armv6l, armv7l, aarch64, arm64

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -38,17 +38,17 @@ mode=unattended
 
 # Hardware
 # Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
-hw=Pi2
+#hw=Pi3
 
 # Hardware architecture
 # x86_64, amd64, armv6l, armv7l, aarch64, arm64
-hwarch=armv7l
+#hwarch=armv7l
 
 # OS Release
 # ubuntu, raspbian, debian
 # jessie, stretch, buster, bullseye, sid,
 # trusty, xenial, bionic, disco
-release=disco
+#release=buster
 
 # Java architecture mode
 # values: "Zulu32", "Zulu64" or "AdoptOpenJDK"

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -36,6 +36,20 @@ clonebranch=master
 # values: "unattended", "unattended_debug" (verbose output in log) or "debug_maximum" (show every command in either mode)
 mode=unattended
 
+# Hardware
+# Pi0, Pi0W, Pi1, CM1, Pi2, Pi3, CM3, Pi3+, CM3+, Pi4
+hw=Pi2
+
+# Hardware architecture
+# x86_64, amd64, armv6l, armv7l, aarch64, arm64
+hwarch=armv7l
+
+# OS Release
+# ubuntu, raspbian, debian
+# jessie, stretch, buster, bullseye, sid,
+# trusty, xenial, bionic, disco
+release=disco
+
 # Java architecture mode
 # values: "Zulu32", "Zulu64" or "AdoptOpenJDK"
 java_arch=32-bit


### PR DESCRIPTION
Allow to fake Hardware and OS Release IDs via openhabian.conf parameters
This can be used to validate openHABian in CI automated testing to work on specific hardware/OS.

The feature can also be used for users with unsupported HW or OS

Fixes: #900 

Signed-off-by: Markus Storm <markus.storm@gmx.net>