### PR TITLE
DRAFT replace nrjavaserial by reversioned 5.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On x86 hardware, 64 bit is the standard.
 Please check the [official documentation article](https://www.openhab.org/docs/installation/openhabian.html) to learn about openHABian and please visit and subscribe to our very active [community forum thread](https://community.openhab.org/t/13379).
 
 If you want to install openHABian on non-supported hardware, you can actually fake it to make openHABian treat your box as if it was one of the supported ones. Needless to say that that may work out or not, but it's worth a try.
-See [openhabian](openhabian.md) how to edit openhabian.conf before booting. Set the hw, hwarch and release parameters to match your system best.
+See [openhabian](docs/openhabian.md) how to edit openhabian.conf before booting. Set the hw, hwarch and release parameters to match your system best.
 
 ## Development
 openHABian is foremost a collection of `bash` scripts versioned and deployed using git. In the current state the scripts can only be invoked through the terminal menu system [whiptail](https://en.wikibooks.org/wiki/Bash_Shell_Scripting/Whiptail). There is a longterm need to better separate the UI part from the script code. A work has started to define conventions and further explain the code base in the document [CONTRIBUTING](CONTRIBUTING.md) along with development guidelines in general.
@@ -74,7 +74,7 @@ $ sudo bash build.bash platform dev-url branch url
 ```
 
 ### Testing
-Testing is done continuously with Travis using the test framework [Bats](https://github.com/bats-core/bats-core) and the linter [Shellcheck](https://www.shellcheck.net/).  As the tests focus on installing software, a docker solution is used for easy build-up and teardown. To run the test suite execute the commands below or `"$ ./test.bash docker-full"`. Docker and Shellcheck need to be installed. For more details regarding the tests see [Test Architecture](https://github.com/openhab/openhabian/blob/master/CONTRIBUTING.md#test-architecture) in CONTRIBUTING.
+Testing is done continuously with Travis using the test framework [Bats](https://github.com/bats-core/bats-core) and the linter [Shellcheck](https://www.shellcheck.net/).  As the tests focus on installing software, a docker solution is used for easy build-up and teardown. To run the test suite execute the commands below or `"$ ./test.bash docker-full"`. Docker and Shellcheck need to be installed. For more details regarding the tests see [Test Architecture](https://github.com/openhab/openhabian/blob/master/CONTRIBUTING.md#test-architecture) in [CONTRIBUTING](CONTRIBUTING.md).
 
 ```
 docker build -t openhabian/openhabian-bats .

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Setting up a fully working Linux system with all needed packages and openHAB rec
 openHABian aims to provide a **self-configuring** Linux system setup specific to the needs of every openHAB user.
 The project provides two things:
 
-*   a set of scripts to set up openHAB on any Debian based system (Raspbian, Ubuntu)
+*   a set of scripts to set up openHAB on any Debian based system (Raspberry Pi OS, Ubuntu)
 *   a complete **SD-card image pre-configured with openHAB** and many other openHAB- and Hardware-specific preparations for all *Raspberry Pi* models.
 
 ## Hardware and OS support
@@ -29,18 +29,16 @@ But remember if you hit any problem related to memory or hardware, you'll be on 
 
 Going beyond what the RPi image provides, as a manually installed set of scripts, there's a fair chance that openHABian will work on all Debian like Linux distributions such as Ubuntu, on either ARM or x86 hardware, but remember this is not _supported_.
 
-Our recommendation is to install Raspbian lite (ARM) or generic Debian (x86). This is what we support and test openHABian against.
-
-If you choose not to use the image, we expect you to use the stable distribution that openHABian testing is based on, 'buster' for Raspbian (ARM) and Debian (x86) that is.
+If you choose not to use the image, we expect you to use the stable distribution that openHABian testing is based on, 'buster' for Raspberry Pi OS (ARM) and Debian (x86) that is.
 To install openHABian on anything older or newer may work or not. If you encounter issues, you may need to upgrade first or to live with the consequences of running an OS on the edge of software development.
 
 Either way, please note that you're on your own when it comes to configuring and installing the HW with the proper OS yourself.
 
-### 64 bit ?
-Although RPi3 and 4 have a 64 bit processor, you cannot run openHAB in 64 bit.
+### 64bit - bigger, better, faster, more ?
+Although RPi 3 and 4 have a 64 bit processor, you cannot run openHAB in 64 bit.
 The Azul Java Virtual Machine we currently use is incompatible with the aarch64 ARM architecture.
 In general you should be aware that to run in 64 bit has a major drawback, increased memory usage, that is not a good idea on a heavily memory constrained platform like a RPi.
-Also remember openHABian makes use of Raspbian which today still is a 32 bit OS.
+Also remember openHABian makes use of Raspberry Pi OS which today still is a 32 bit OS.
 
 We are closely observing development and will adapt openHABian once it will reliably work on 64 bit.
 So things may change in the future, but for the time being, you should not manually enforce to install a 64 bit JVM.
@@ -60,7 +58,7 @@ A good place to look at to start to understand the code is the file `openhabian-
 
 ### Building Hardware Images
 Take a look at the `build.bash` script to get an idea of the process.
-Simply explained run the code below with `platform` being either `rpi` or `pine64`. The RPi image is based on the [Raspbian Lite](https://www.raspberrypi.org/downloads/raspbian) standard image while the Pine64 image is based on [build-pine64-image](https://github.com/longsleep/build-pine64-image).
+Simply explained run the code below with `platform` being `rpi`. The RPi image is based on the [Raspberry Pi OS Lite](https://www.raspberrypi.org/downloads/raspbian) standard image.
 ```
 $ sudo bash ./build.bash platform
 ```

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ To install openHABian on anything older or newer may work or not. If you encount
 
 Either way, please note that you're on your own when it comes to configuring and installing the HW with the proper OS yourself.
 
-### 64bit - bigger, better, faster, more ?
-Although RPi 3 and 4 have a 64 bit processor, you cannot run openHAB in 64 bit.
-The Azul Java Virtual Machine we currently use is incompatible with the aarch64 ARM architecture.
-In general you should be aware that to run in 64 bit has a major drawback, increased memory usage, that is not a good idea on a heavily memory constrained platform like a RPi.
+### 64 bits - bigger, better, faster, more ?
+Although RPi 3 and 4 have a 64 bit processor, you _could_ but _should not_ run openHAB in 64 bit.
+The Azul Java version 8 Virtual Machine we currently deploy per default is incompatible with the aarch64 ARM architecture.
+We have added options in the 40 menu to use JVMs other than the default, including 64 bit versions, but note these are marked to be BETA for the time being.
+Generally speaking, there is no real advantage in moving to 64 bits while you should be aware that to run in 64 bit has a major drawback, increased memory usage, that is not a good idea on a heavily memory constrained platform like a RPi.
 Also remember openHABian makes use of Raspberry Pi OS which today still is a 32 bit OS.
 
-We are closely observing development and will adapt openHABian once it will reliably work on 64 bit.
-So things may change in the future, but for the time being, you should not manually enforce to install a 64 bit JVM.
+We are closely observing development and will adapt openHABian once it will reliably work on 64 bits so things may change in the future.
 
 On x86 hardware, 64 bit is the standard.
 

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -444,7 +444,7 @@ select_nrjavaserial() {
   local url=https://github.com/wborn/nrjavaserial/releases/download/reversioned521/nrjavaserial-3.15.0.OH2.jar
   local location=/usr/share/openhab2/runtime/system/org/openhab/nrjavaserial/3.15.0.OH2
   local origbundle=nrjavaserial-3.15.0.OH2.jar
-  local newbundle=nrjavaserial-3.15.0.OH2-wborn.jar
+  local newbundle=nrjavaserial-3.15.0.OH2-reversioned.jar
 
   if [[ "$1" == "backport" ]]; then
     wget -O "${location}/${newbundle}" "${url}"

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -435,7 +435,10 @@ java_alternatives_reset(){
   update-alternatives --remove-all javac # TODO: remove sometime late 2020
 }
 
-nrjavaserial_update() {
+## switch nrjavaserial lib used in openHAB
+## arguments "backport", "orig"
+##
+select_nrjavaserial() {
   local pass=habopen
   local client=${OPENHAB_RUNTIME}/bin/client
   local url=https://github.com/wborn/nrjavaserial/releases/download/reversioned521/nrjavaserial-3.15.0.OH2.jar
@@ -446,7 +449,7 @@ nrjavaserial_update() {
   if [[ "$1" == "backport" ]]; then
     wget -O "${location}/${newbundle}" "${url}"
     cmd="bundle:update $id file:${location}/${newbundle}"
-  else
+  elif [[ "$1" == "orig" ]]; then
     cmd="bundle:update $id file:${location}/${origbundle}"
   fi
   id=$($client -p "$pass" "bundle:list | grep nrjavaserial" | tail -1|cut -d' ' -f1)

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -434,3 +434,21 @@ java_alternatives_reset(){
   update-alternatives --remove-all jexec
   update-alternatives --remove-all javac # TODO: remove sometime late 2020
 }
+
+nrjavaserial_update() {
+  local pass=habopen
+  local client=${OPENHAB_RUNTIME}/bin/client
+  local url=https://github.com/wborn/nrjavaserial/releases/download/reversioned521/nrjavaserial-3.15.0.OH2.jar
+  local location=/usr/share/openhab2/runtime/system/org/openhab/nrjavaserial/3.15.0.OH2
+  local origbundle=nrjavaserial-3.15.0.OH2.jar
+  local newbundle=nrjavaserial-3.15.0.OH2-wborn.jar
+
+  if [[ "$1" == "backport" ]]; then
+    wget -O "${location}/${newbundle}" "${url}"
+    cmd="bundle:update $id file:${location}/${newbundle}"
+  else
+    cmd="bundle:update $id file:${location}/${origbundle}"
+  fi
+  id=$($client -p "$pass" "bundle:list | grep nrjavaserial" | tail -1|cut -d' ' -f1)
+  $client -p "$pass" "$cmd"
+}


### PR DESCRIPTION
Replace nrjavaserial 3.15.0 as used in OH2.5 frozen core with a reversioned 5.2.1 bundle
from https://github.com/wborn/nrjavaserial to fix issues with serial interfaces on Java 11

Signed-off-by: Markus Storm <markus.storm@gmx.net>