### PR TITLE
remove wlan0 config lines from /etc/network/interfaces on wifi disable

### DIFF
--- a/functions/system.bash
+++ b/functions/system.bash
@@ -276,8 +276,8 @@ enable_rpi_audio() {
 }
 
 prepare_serial_port() {
-  introtext="Proceeding with this routine, the serial console normally provided by a Raspberry Pi can be disabled for the sake of a usable serial port. The provided port can henceforth be used by devices like Razberry, UZB or Busware SCC.
-On a Raspberry Pi 3 the Bluetooth module can be disabled, ensuring the operation of a RaZberry or other HAT (usage of BT and HATs to use serial is mutually exclusive).
+  introtext="Proceeding with this routine, the serial console normally provided by a Raspberry Pi can be disabled for the sake of a usable serial port. The provided port can henceforth be used by devices like RaZberry, UZB or Busware SCC.
+On a Raspberry Pi 3 and 4 the Bluetooth module should be disabled to ensure the operation of a RaZberry or other HAT. Usage of BT and HATs to use serial is mutually exclusive.
 \\nPlease make your choice:"
 #  failtext="Sadly there was a problem setting up the selected option. Please report this problem in the openHAB community forum or as a openHABian GitHub issue."
   successtext="All done. After a reboot the serial console will be available via /dev/ttyAMA0 or /dev/ttyS0 (depends on your device)."
@@ -293,8 +293,8 @@ On a Raspberry Pi 3 the Bluetooth module can be disabled, ensuring the operation
 
   if [ -n "$INTERACTIVE" ]; then
     if ! selection=$(whiptail --title "Prepare Serial Port" --checklist --separate-output "$introtext" 20 78 3 \
-    "1"  "(RPi) Disable serial console           (Razberry, SCC, Enocean)" $sel_1 \
-    "2"  "(RPi3) Disable Bluetooth module        (Razberry)" $sel_2 \
+    "1"  "(RPi) Disable serial console           (RaZberry, SCC, Enocean)" $sel_1 \
+    "2"  "(RPi3/4) Disable Bluetooth module      (RaZberry)" $sel_2 \
     3>&1 1>&2 2>&3); then echo "CANCELED"; return 0; fi
   else
     echo "SKIPPED"

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -15,7 +15,6 @@ wifi_setup() {
       if (whiptail --title "WiFi is currently disabled" --yesno "WiFi is currently disabled on your box. Enable and switch over, i.e. disable Ethernet ?" 7 55); then
         cond_echo "Removing 'dtoverlay=disable-wifi' from /boot/config.txt"
         sed -i '/^[[:space:]]*dtoverlay=disable-wifi/d' /boot/config.txt
-	whiptail --title "Operation Successful!" --msgbox "Please reboot now to switch networking to your WiFi hardware.\\nRun openhabian-config and select this menu option again to continue." 8 75
       fi
     else
       if (whiptail --title "WiFi is currently ON" --defaultno --yesno "WiFi is currently enabled on your box.\\n\\nATTENTION:\\nDo you want to disable it and return to Ethernet ?" 10 50); then

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -22,6 +22,8 @@ wifi_setup() {
       if (whiptail --title "WiFi is currently ON" --defaultno --yesno "WiFi is currently enabled on your box.\\n\\nATTENTION:\\nDo you want to disable it ?" 10 50); then
         cond_echo "Adding 'dtoverlay=disable-wifi' to /boot/config.txt (RPi0W/3/4)"
         echo "dtoverlay=disable-wifi" >> /boot/config.txt
+	sed -i '/wlan0/d; /nwpa-roam/d; /iface default inet dhcp/d' /etc/network/interfaces
+
 	whiptail --title "Operation successful!" --msgbox "Please reboot now to have your WiFi hardware disabled." 7 70
         return 0
       fi

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -12,19 +12,18 @@ wifi_setup() {
 
   if [ -n "$INTERACTIVE" ]; then
     if grep -q "^[[:space:]]*dtoverlay=disable-wifi" /boot/config.txt; then
-      if (whiptail --title "WiFi is currently disabled" --yesno "WiFi is currently disabled on your box. Enable ?" 7 55); then
+      if (whiptail --title "WiFi is currently disabled" --yesno "WiFi is currently disabled on your box. Enable and switch over, i.e. disable Ethernet ?" 7 55); then
         cond_echo "Removing 'dtoverlay=disable-wifi' from /boot/config.txt"
         sed -i '/^[[:space:]]*dtoverlay=disable-wifi/d' /boot/config.txt
-	whiptail --title "Operation Successful!" --msgbox "Please reboot now to enable your WiFi hardware.\\nRun openhabian-config and select this menu option again to continue." 8 75
+	whiptail --title "Operation Successful!" --msgbox "Please reboot now to switch networking to your WiFi hardware.\\nRun openhabian-config and select this menu option again to continue." 8 75
       fi
-      return 0
     else
-      if (whiptail --title "WiFi is currently ON" --defaultno --yesno "WiFi is currently enabled on your box.\\n\\nATTENTION:\\nDo you want to disable it ?" 10 50); then
+      if (whiptail --title "WiFi is currently ON" --defaultno --yesno "WiFi is currently enabled on your box.\\n\\nATTENTION:\\nDo you want to disable it and return to Ethernet ?" 10 50); then
         cond_echo "Adding 'dtoverlay=disable-wifi' to /boot/config.txt (RPi0W/3/4)"
         echo "dtoverlay=disable-wifi" >> /boot/config.txt
-	sed -i '/wlan0/d; /nwpa-roam/d; /iface default inet dhcp/d' /etc/network/interfaces
+	sed -i '/wlan0/d; /wpa-roam/d; /iface default inet dhcp/d' /etc/network/interfaces
 
-	whiptail --title "Operation successful!" --msgbox "Please reboot now to have your WiFi hardware disabled." 7 70
+	whiptail --title "Operation successful!" --msgbox "Please reboot now to switch back from WiFi to Ethernet." 7 70
         return 0
       fi
     fi


### PR DESCRIPTION
Fixes #608 

I think the proper way to handle #608 is to enable Eth (X)OR WiFi exclusively.
This PR to remove wlan0 config from /etc/network/interfaces on disabling WiFi so that should remain empty hence Ethernet gets reenabled.


Signed-off-by: Markus Storm <markus.storm@gmx.net>