### PR TITLE
Deprecate PINEA64, Jessie, Xenial

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,8 @@ All announcements will be stored in /opt/openhabian/docs/NEWSLOG for you to look
 openhabian-config will now issue a warning if you start on unsupported hardware or OS releases.
 See [README](README.md) for supported HW and OS.
 In short, PINE A64 is no longer supported and OS releases other than the current `stable` and the previous one are deprecated.
-That's Debian / Raspbian 10 (buster) and 9 (stretch) as well as Ubuntu 20.04 (focal) and 18.04 (bionic).
-Note: Running on any of these may still work or not.
+Running on any of those may still work or not.
+The current and previous Debian / Raspbian releases are 10 ("buster") and 9 ("stretch"). Most current Ubuntu LTS releases are 20.04 ("focal") and 18.04 ("bionic").
 
 ## June 10, 2020
 ### new parameters in `openhabian.conf`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,70 +1,33 @@
-This is the new announcement page that will pop up whenever you start
-`openhabian-config` and the developers have significant news they would like to
-share with you.
+This is the new announcement page to pop up whenever you start openhabian-config and there's significant news we would like to share with you.
+Hit tab to unselect buttons and scroll through the text using UP/DOWN/PG UP/PG DOWN.
+When you choose 'I have read this' the message will not appear on startup anymore.
+All announcements will be stored in /opt/openhabian/docs/NEWSLOG for you to lookup.
 
-Hit tab to unselect the buttons and scroll through the text using UP/DOWN or
-PGUP/PGDN.
-
-All announcements will be stored in /opt/openhabian/docs/NEWSLOG for you to
-lookup.
+## June 17, 2020
+### removed support for PINE A64(+) and older Linux distributions
+openhabian-config will now issue a warning if you start on unsupported hardware or OS releases.
+See [README](README.md) for supported HW and OS.
+In short, PINE A64 is no longer supported and OS releases other than the current `stable` and the previous one are deprecated.
+That's Debian / Raspbian 10 (buster) and 9 (stretch) as well as Ubuntu 20.04 (focal) and 18.04 (bionic).
+Note: Running on any of these may still work or not.
 
 ## June 10, 2020
-
-### New parameters in `openhabian.conf`
-See `/etc/openhabian.conf` for a number of new parameters such as the useful
-`debugmode`, a fake hardware mode, the option to disable ipv6 and the ability to
-update from a custom repository other than the `master` and `stable` branches.
-
+### new parameters in `openhabian.conf`
+See `/etc/openhabian.conf` for a number of new parameters such as the useful `debugmode`, a fake hardware mode, to disable ipv6 and the ability to update from some repository other than the default `master` and `stable`.
 In case you are not aware, there is a Debug Guide in the `docs/` directory.
 
 ### New Java options
-Preparing for openHAB 3, new options for the JDK that runs openHAB are now
-available:
+Preparing for openHAB 3, new options for the JDK that runs openHAB are now available:
 
--   Java Zulu 8 32-Bit OpenJDK (default on ARM based platforms)
--   Java Zulu 8 64-Bit OpenJDK (default on x86 based platforms)
--   Java Zulu 11 32-Bit OpenJDK
--   Java Zulu 11 64-Bit OpenJDK
--   AdoptOpenJDK 11 OpenJDK (potential replacement for Zulu)
+ - Java Zulu 8 32-Bit OpenJDK (default on ARM based platforms)
+ - Java Zulu 8 64-Bit OpenJDK (default on x86 based platforms)
+ - Java Zulu 11 32-Bit OpenJDK
+ - Java Zulu 11 64-Bit OpenJDK
+ - AdoptOpenJDK 11 OpenJDK (replacement for Zulu)
 
-openHAB 3 will be Java 11 only.  2.5.X is supposed to work on both, Java 8 and
-Java 11. Running the current openHAB 2.X on Java 11 however has not been tested
-on a wide scale. Please be aware that there is a small number of known issues in
-this: v1 bindings may or may not work.
+openHAB 3 will be Java 11 only.  2.5.X is supposed to work on both, Java 8 and Java 11.
+Running the current openHAB 2.X on Java 11 however has not been tested on a wide scale.
+Please be aware that there is a small number of known issues in this: v1 bindings may or may not work.
 
-Please participate in beta testing to help create a smooth transition user
-experience for all of us.
-
-See [announcement thread](https://community.openhab.org/t/Java-testdrive/99827)
-on the community forum.
-
-
-## May 31, 2020
-
-### Stable branch
-Introducing a new versioning scheme to openHABian. Please welcome the `stable`
-branch.
-
-Similar to openHAB where there's releases and snapshots, you will from now on be
-using the stable branch. It's the equivalent of an openHAB release. We will keep
-providing new changes to the master branch first as soon as we make them
-available, just like we have been doing in the past. If you want to keep living
-on the edge, want to make use of new features fast or volunteer to help a little
-in advancing openHABian, you can choose to switch back to the master branch.
-Anybody else will benefit from less frequent but well better tested updates to
-happen to the stable branch in batches, whenever the poor daring people to use
-`master` have reported their trust in these changes to work flawlessly.
-
-You can switch branches at any time using the menu option 01.
-
-### ZRAM per default
-Swap, logs and persistence files are now put into ZRAM per default.
-See [ZRAM status thread](https://community.openhab.org/t/zram-status/80996) for
-more information.
-
-### Supported hardware and Operating Systems
-openHABian now fully supports all Raspberry Pi SBCs with our fast-start image.
-As an add-on package, it is supposed to run on all Debian based OSs.
-
-Check the [README](README.md) to see what "supported" actually means and what
-you can do if you want to run on other HW or OS.
+Please participate in beta testing to help create a smooth transition user experience for all of us.
+See [announcement thread](https://community.openhab.org/t/Java-testdrive/99827) on the community forum.

--- a/docs/NEWSLOG.md
+++ b/docs/NEWSLOG.md
@@ -1,60 +1,42 @@
-## June 10, 2020
+### removed support for PINE A64(+) and older Linux distributions
+openhabian-config will now issue a warning if you start on unsupported hardware or OS releases.
+See [README](README.md) for supported HW and OS.
+In short, PINE A64 is no longer supported and OS releases other than the current `stable` and the previous one are deprecated.
+That's Debian / Raspbian 10 (buster) and 9 (stretch) as well as Ubuntu 20.04 (focal) and 18.04 (bionic).
+Note: Running on any of these may still work or not.
 
-### New parameters in `openhabian.conf`
-See `/etc/openhabian.conf` for a number of new parameters such as the useful
-`debugmode`, a fake hardware mode, the option to disable ipv6 and the ability to
-update from a custom repository other than the `master` and `stable` branches.
-
+### new parameters in `openhabian.conf`
+See `/etc/openhabian.conf` for a number of new parameters such as the useful `debugmode`, a fake hardware mode, to disable ipv6 and the ability to update from some repository other than the default `master` and `stable`.
 In case you are not aware, there is a Debug Guide in the `docs/` directory.
 
 ### New Java options
-Preparing for openHAB 3, new options for the JDK that runs openHAB are now
-available:
+Preparing for openHAB 3, new options for the JDK that runs openHAB are now available:
 
--   Java Zulu 8 32-Bit OpenJDK (default on ARM based platforms)
--   Java Zulu 8 64-Bit OpenJDK (default on x86 based platforms)
--   Java Zulu 11 32-Bit OpenJDK
--   Java Zulu 11 64-Bit OpenJDK
--   AdoptOpenJDK 11 OpenJDK (potential replacement for Zulu)
+ - Java Zulu 8 32-Bit OpenJDK (default on ARM based platforms)
+ - Java Zulu 8 64-Bit OpenJDK (default on x86 based platforms)
+ - Java Zulu 11 32-Bit OpenJDK
+ - Java Zulu 11 64-Bit OpenJDK
+ - AdoptOpenJDK 11 OpenJDK (replacement for Zulu)
 
-openHAB 3 will be Java 11 only.  2.5.X is supposed to work on both, Java 8 and
-Java 11. Running the current openHAB 2.X on Java 11 however has not been tested
-on a wide scale. Please be aware that there is a small number of known issues in
-this: v1 bindings may or may not work.
+openHAB 3 will be Java 11 only.  2.5.X is supposed to work on both, Java 8 and Java 11.
+Running the current openHAB 2.X on Java 11 however has not been tested on a wide scale.
+Please be aware that there is a small number of known issues in this: v1 bindings may or may not work.
 
-Please participate in beta testing to help create a smooth transition user
-experience for all of us.
-
-See [announcement thread](https://community.openhab.org/t/Java-testdrive/99827)
-on the community forum.
-
-
-## May 31, 2020
+Please participate in beta testing to help create a smooth transition user experience for all of us.
+See [announcement thread](https://community.openhab.org/t/Java-testdrive/99827) on the community forum.
 
 ### Stable branch
-Introducing a new versioning scheme to openHABian. Please welcome the `stable`
-branch.
-
-Similar to openHAB where there's releases and snapshots, you will from now on be
-using the stable branch. It's the equivalent of an openHAB release. We will keep
-providing new changes to the master branch first as soon as we make them
-available, just like we have been doing in the past. If you want to keep living
-on the edge, want to make use of new features fast or volunteer to help a little
-in advancing openHABian, you can choose to switch back to the master branch.
-Anybody else will benefit from less frequent but well better tested updates to
-happen to the stable branch in batches, whenever the poor daring people to use
-`master` have reported their trust in these changes to work flawlessly.
-
+Introducing a new versioning scheme to openHABian. Please welcome `stable` branch.
+Similar to openHAB where there's releases and snapshots, you will from now on be using the stable branch. It's the equivalent of an openHAB release.
+We will keep providing new changes to the master branch first as soon as we make them available, just like we have been doing in the past. If you want to keep living on the edge, want to make use of new features fast or volunteer to help a little in advancing openHABian, you can choose to switch back to the master branch.
+Anybody else will benefit from less frequent but well better tested updates to happen to the stable branch in batches, whenever the poor daring people to use `master` have reported their trust in these changes to work flawlessly.
 You can switch branches at any time using the menu option 01.
+
+### Supported hardware and Operating Systems
+openHABian now fully supports all Raspberry Pi SBCs with our fast-start image. As a manual add-on, it is supposed to run on all Debian based OSs like Ubuntu.
+
+Check the [README](#README.md) to see what "supported" actually means and what you can do if you want to run on other HW or OS.
 
 ### ZRAM per default
 Swap, logs and persistence files are now put into ZRAM per default.
-See [ZRAM status thread](https://community.openhab.org/t/zram-status/80996) for
-more information.
-
-### Supported hardware and Operating Systems
-openHABian now fully supports all Raspberry Pi SBCs with our fast-start image.
-As an add-on package, it is supposed to run on all Debian based OSs.
-
-Check the [README](README.md) to see what "supported" actually means and what
-you can do if you want to run on other HW or OS.
+See [ZRAM status thread](https://community.openhab.org/t/zram-status/80996) for more information.

--- a/docs/NEWSLOG.md
+++ b/docs/NEWSLOG.md
@@ -2,8 +2,8 @@
 openhabian-config will now issue a warning if you start on unsupported hardware or OS releases.
 See [README](README.md) for supported HW and OS.
 In short, PINE A64 is no longer supported and OS releases other than the current `stable` and the previous one are deprecated.
-That's Debian / Raspbian 10 (buster) and 9 (stretch) as well as Ubuntu 20.04 (focal) and 18.04 (bionic).
-Note: Running on any of these may still work or not.
+Running on any of those may still work or not.
+The current and previous Debian / Raspbian releases are 10 ("buster") and 9 ("stretch"). Most current Ubuntu LTS releases are 20.04 ("focal") and 18.04 ("bionic").
 
 ### new parameters in `openhabian.conf`
 See `/etc/openhabian.conf` for a number of new parameters such as the useful `debugmode`, a fake hardware mode, to disable ipv6 and the ability to update from some repository other than the default `master` and `stable`.

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -220,13 +220,13 @@ is_sid() {
   [[ $(cat /etc/*release*) =~ "sid" ]]
   return $?
 }
-# Ubuntu 14, to be deprecated
+# Ubuntu 14, deprecated
 is_trusty() {
   if [[ "$release" == "trusty" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "trusty" ]]
   return $?
 }
-# Ubuntu 16
+# Ubuntu 16, deprecated
 is_xenial() {
   if [[ "$release" == "xenial" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "xenial" ]]

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -68,12 +68,6 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
   openhabVersion="$(apt-cache madison openhab2 | head -n 1 | cut -d'|' -f2 | xargs)"
 
   local APT_INST_OPTS="-y --allow-downgrades"
-  if is_jessie; then
-    # - jessie uses apt 1.0 which does not support --allow-downgrades
-    # - ubuntu should be fine starting with xenial (apt v1.2)
-    # - no support for other older distros
-    APT_INST_OPTS="-y"
-  fi
   if ! cond_redirect apt-get ${APT_INST_OPTS} install "openhab2=${openhabVersion}"; then echo "FAILED (apt)"; return 1; fi
   cond_redirect adduser openhab gpio
   cond_redirect systemctl daemon-reload

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -67,8 +67,7 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
   cond_redirect apt-get update
   openhabVersion="$(apt-cache madison openhab2 | head -n 1 | cut -d'|' -f2 | xargs)"
 
-  local APT_INST_OPTS="-y --allow-downgrades"
-  if ! cond_redirect apt-get ${APT_INST_OPTS} install "openhab2=${openhabVersion}"; then echo "FAILED (apt)"; return 1; fi
+  if ! cond_redirect apt-get -y --allow-downgrades install "openhab2=${openhabVersion}"; then echo "FAILED (apt)"; return 1; fi
   cond_redirect adduser openhab gpio
   cond_redirect systemctl daemon-reload
   if cond_redirect systemctl enable --now openhab2; then echo "OK"; else echo "FAILED (service)"; return 1; fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -50,6 +50,16 @@ openhabian_console_check() {
 openhabian_update_check() {
   local branch
   local introtext="Additions, improvements or fixes were added to the openHABian configuration tool. Would you like to update now and benefit from them? The update will not automatically apply changes to your system.\\n\\nUpdating is recommended."
+  local unsupportedhwtext="You are running on old hardware that is no longer officially supported.\\nopenHABian may still work with this or not.\\nWe recommend to replace your hardware with a current SBC such as a RPi4/2GB.\\nDo you really want to continue using openHABian on this system ?"
+  local unsupportedostext="You are running an old Linux release that is no longer officially supported.\\nWe recommend upgrading to the most current stable release of your distribution (or current Long Term Support version for distributions to offer LTS).\\nDo you really want to continue using openHABian on this system ?"
+
+  if is_pine64; then
+    if ! (whiptail --title "Unsupported hardware" --yes-button "Yes, Continue" --no-button "No, Exit" --defaultno --yesno "$unsupportedhwtext" 13 85); then echo "SKIP"; exit 0; fi
+  fi
+  if is_jessie || is_xenial; then
+    if ! (whiptail --title "Unsupported Linux release" --yes-button "Yes, Continue" --no-button "No, Exit" --defaultno --yesno "$unsupportedostext" 13 85); then echo "SKIP"; exit 0; fi
+  fi
+
   FAILED=0
   echo "$(timestamp) [openHABian] openHABian configuration tool version: $(get_git_revision)"
   branch=${clonebranch:-HEAD}

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -601,7 +601,7 @@ nginx_setup() {
   if [ "$auth" == "true" ]; then
     cond_echo "Setting up Nginx password options..."
     echo -n "$(timestamp) [openHABian] Installing Nginx password utilities... "
-    if cond_redirect apt-get install --yes install apache2-utils; then echo "OK"; else echo "FAILED"; return 1; fi
+    if cond_redirect apt-get install --yes apache2-utils; then echo "OK"; else echo "FAILED"; return 1; fi
     if cond_redirect htpasswd -b -c /etc/nginx/.htpasswd "$nginxUsername" "$nginxPass"; then echo "OK"; else echo "FAILED (password file)"; return 1; fi
     uncomment "#AUTH" /etc/nginx/sites-enabled/openhab
   fi


### PR DESCRIPTION
Removed special handling for any of these.
openhabian-config will determine if running on deprecated HW or OS and eventually issue a warning on startup.

Fixes #622
Fixes #623 

Signed-off-by: Markus Storm markus.storm@gmx.net