### PR TITLE
Add `zlib1g` to required packages for Zulu install

### DIFF
--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -118,30 +118,30 @@ java_install_or_update() {
 ##    java_zulu_prerequisite(String arch)
 ##
 java_zulu_prerequisite() {
-  echo -n "$(timestamp) [openHABian] Installing Java Zulu prerequisites (libc)... "
+  echo -n "$(timestamp) [openHABian] Installing Java Zulu prerequisites (libc, libstdc++, zlib1g)... "
   if [ "$1" == "Zulu8-64" ] || [ "$1" == "Zulu11-64" ]; then
     if is_aarch64 && [ "$(getconf LONG_BIT)" == "64" ]; then
-      if dpkg -s 'libc6:arm64' 'libncurses5:arm64' 'libstdc++6:arm64' > /dev/null 2>&1; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:arm64' 'libstdc++6:arm64' 'zlib1g:arm64' > /dev/null 2>&1; then echo "OK"; return 0; fi
       dpkg --add-architecture arm64
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-      if cond_redirect apt-get install --yes libc6:arm64 libncurses5:arm64 libstdc++6:arm64; then echo "OK"; else echo "FAILED"; return 1; fi
+      if cond_redirect apt-get install --yes libc6:arm64 libstdc++6:arm64 zlib1g:arm64; then echo "OK"; else echo "FAILED"; return 1; fi
     elif is_x86_64 && [ "$(getconf LONG_BIT)" == "64" ]; then
-      if dpkg -s 'libc6:amd64' 'libncurses5:amd64' 'libstdc++6:amd64' > /dev/null 2>&1; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:amd64' 'libstdc++6:amd64' 'zlib1g:amd64' > /dev/null 2>&1; then echo "OK"; return 0; fi
       dpkg --add-architecture amd64
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-      if cond_redirect apt-get install --yes libc6:amd64 libncurses5:amd64 libstdc++6:amd64; then echo "OK"; else echo "FAILED"; return 1; fi
+      if cond_redirect apt-get install --yes libc6:amd64 libstdc++6:amd64 zlib1g:amd64; then echo "OK"; else echo "FAILED"; return 1; fi
     fi
   else
     if is_arm; then
-      if dpkg -s 'libc6:armhf' 'libncurses5:armhf' 'libstdc++6:armhf' > /dev/null 2>&1; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:armhf' 'libstdc++6:armhf' 'zlib1g:armhf' > /dev/null 2>&1; then echo "OK"; return 0; fi
       dpkg --add-architecture armhf
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-      if cond_redirect apt-get install --yes libc6:armhf libncurses5:armhf libstdc++6:armhf; then echo "OK"; else echo "FAILED"; return 1; fi
+      if cond_redirect apt-get install --yes libc6:armhf libstdc++6:armhf zlib1g:armhf; then echo "OK"; else echo "FAILED"; return 1; fi
     else
-      if dpkg -s 'libc6:i386' 'libncurses5:i386' 'libstdc++6:i386' > /dev/null 2>&1; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:i386' 'libstdc++6:i386' 'zlib1g:i386' > /dev/null 2>&1; then echo "OK"; return 0; fi
       dpkg --add-architecture i386
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-      if cond_redirect apt-get install --yes libc6:i386 libncurses5:i386 libstdc++6:i386; then echo "OK"; else echo "FAILED"; return 1; fi
+      if cond_redirect apt-get install --yes libc6:i386 libstdc++6:i386 zlib1g:i386; then echo "OK"; else echo "FAILED"; return 1; fi
     fi
   fi
 }


### PR DESCRIPTION
This also removes unneeded packages from the Java install (libncurses5)
to simplify the install and reduce bloat.

Fixes #981

Signed-off-by: Ethan Dye <mrtops03@gmail.com>