### PR TITLE
Add build image function to GitHub Actions

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -1,0 +1,89 @@
+name: Build Image
+
+# Trigger the workflow on push or pull request
+on:
+  push:
+    paths:
+      - 'build.bash'
+      - 'build-image/openhabian-installer.service'
+  pull_request:
+    paths:
+      - 'build.bash'
+      - 'build-image/openhabian-installer.service'
+  workflow_dispatch:
+    inputs:
+      comments:
+        description: 'Build comments'
+        default: 'Build for testing purposes' 
+
+jobs:
+  build32:
+    # Using latest Ubuntu (not the GitHub Actions default) to get latest tool versions in GitHub Actions environment
+    runs-on: ubuntu-20.04
+
+    steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+         with:
+           repository: ${{ github.event.pull_request.head.repo.full_name }}
+           ref: ${{ github.event.pull_request.head.ref }}
+       - name: Environment variables
+         run: sudo -E bash -c set
+       - name: Install required packages
+         run: sudo apt-get install git curl unzip libarchive-zip-perl dos2unix xz-utils kpartx
+       - name: getimagename
+         id: getimagename
+         run: |
+           echo "::set-output name=image::$(basename "$(curl "https://downloads.raspberrypi.org/raspios_lite_armhf_latest" -s -L -I  -o /dev/null -w '%{url_effective}')")"
+       - name: Cache Raspberry Pi OS image
+         uses: actions/cache@v2
+         with:
+           path: ${{ steps.getimagename.outputs.image }}
+           key: ${{ steps.getimagename.outputs.image }}
+       - name: Run build.bash rpi
+         run: |
+           sudo -E ./ci-setup.bash github pi-raspios32
+           sudo -E ./build.bash rpi
+       - name: getfilename
+         id: getfilename
+         run: echo "::set-output name=file::$(ls openhabian-*.img.xz)"
+       - name: Archive
+         uses: actions/upload-artifact@v2
+         with:
+           name: ${{ steps.getfilename.outputs.file }}
+           path: ${{ steps.getfilename.outputs.file }}
+  build64experimental:
+    # Using latest Ubuntu (not the GitHub Actions default) to get latest tool versions in GitHub Actions environment
+    runs-on: ubuntu-20.04
+
+    steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+         with:
+           repository: ${{ github.event.pull_request.head.repo.full_name }}
+           ref: ${{ github.event.pull_request.head.ref }}
+       - name: Environment variables
+         run: sudo -E bash -c set
+       - name: Install required packages
+         run: sudo apt-get install git curl unzip libarchive-zip-perl dos2unix xz-utils kpartx
+       - name: getimagename
+         id: getimagename
+         run: |
+           echo "::set-output name=image::$(basename "$(curl "https://downloads.raspberrypi.org/raspios_arm64_latest" -s -L -I  -o /dev/null -w '%{url_effective}')")"
+       - name: Cache Raspberry Pi OS image
+         uses: actions/cache@v2
+         with:
+           path: ${{ steps.getimagename.outputs.image }}
+           key: ${{ steps.getimagename.outputs.image }}
+       - name: Run build.bash rpi64
+         run: |
+           sudo -E ./ci-setup.bash github pi-raspios64beta
+           sudo -E ./build.bash rpi64
+       - name: getfilename
+         id: getfilename
+         run: echo "::set-output name=file::$(ls openhabian-*.img.xz)"
+       - name: Archive
+         uses: actions/upload-artifact@v2
+         with:
+           name: ${{ steps.getfilename.outputs.file }}
+           path: ${{ steps.getfilename.outputs.file }}

--- a/.github/workflows/shellcheck-action.yml
+++ b/.github/workflows/shellcheck-action.yml
@@ -1,17 +1,22 @@
-# This is a basic workflow to help you get started with Actions
+name: ShellCheck
 
-name: shellcheck
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Trigger the workflow on push or pull request
 on:
-  push
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+  push:
+    paths:
+      - '**.bash'
+      - '**.sh'
+      - '!test.bash'
+  pull_request:
+    paths:
+      - '**.bash'
+      - '**.sh'
+      - '!test.bash'
+
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+  shellcheck:
+    # Using latest Ubuntu (not the GitHub Actions default) to get latest tool versions in GitHub Actions environment
+    runs-on: ubuntu-20.04
 
     steps:
        - name: Checkout repository
@@ -20,12 +25,23 @@ jobs:
          run: sudo -E bash -c set
        - name: Install required packages
          run: sudo apt-get install shellcheck
-       - name: "Check 1"
-         run: shellcheck -x -s bash openhabian-setup.sh && echo "shellcheck openhabian-setup.sh - OK";
-       - name: "Check 2"
-         run: shellcheck -x -s bash functions/*.bash && echo "shellcheck functions/*.bash - OK";
-       - name: "Check 3"
-         run: shellcheck -x -s bash build-image/*.bash && echo "shellcheck build-image/*.bash - OK";
-       - name: "Check 4"
-         run: shellcheck -x -s bash build.bash && echo "shellcheck build.bash - OK"
-
+       - name: "ShellCheck openhabian-setup.sh"
+         run: |
+           echo "ShellCheck openhabian-setup.sh..."
+           if shellcheck -x -s bash openhabian-setup.sh; then echo "OK"; else echo "FAILED"; exit 1; fi
+         shell: bash
+       - name: "ShellCheck functions/*.bash"
+         run: |
+           echo "ShellCheck functions/*.bash..."
+           if shellcheck -x -s bash functions/*.bash; then echo "OK"; else echo "FAILED"; exit 1; fi
+         shell: bash
+       - name: "ShellCheck build-image/*.bash"
+         run: |
+           echo "ShellCheck build-image/*.bash..."
+           if shellcheck -x -s bash build-image/*.bash; then echo "OK"; else echo "FAILED"; exit 1; fi
+         shell: bash
+       - name: "ShellCheck build.bash and ci-setup.bash"
+         run: |
+           echo "ShellCheck build.bash..."
+           if shellcheck -x -s bash build.bash ci-setup.bash; then echo "OK"; else echo "FAILED"; exit 1; fi
+         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: shell
 os: linux
-# using latest Ubuntu (not the travis-ci default) to get latest tool versions in Travis environment
+# Using latest Ubuntu (not the Travis-CI default) to get latest tool versions in Travis environment
 dist: focal
 
 cache: false
-
-addons:
-  apt:
-    packages:
-    - shellcheck
-    update: true
 
 git:
   submodules: false
@@ -19,19 +13,19 @@ services:
   - docker
 
 stages:
-  - BATS and ShellCheck tests
+  - BATS tests
   - openHABian installation tests
 
 install:
-  - ./test.bash travis
+  - ./ci-setup.bash travis
 
 jobs:
   fast_finish: true
   allow_failures:
-    - stage: BATS and ShellCheck tests
+    - stage: BATS tests
   include:
-    - stage: BATS and ShellCheck tests
-      name: BATS and ShellCheck tests on virtual RPi4
+    - stage: BATS tests
+      name: BATS tests on virtual RPi4
       env: HW=rpi4
       arch: arm64
       script:
@@ -42,14 +36,13 @@ jobs:
         - docker run --name "unit-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "unit-." .'
         - docker run --name "installation-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "installation-." .'
         - docker run --name "destructive-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "destructive-." .'
-        - shellcheck -x -s bash openhabian-setup.sh functions/*.bash build-image/*.bash build.bash && echo "shellcheck - OK"
     - stage: openHABian installation tests
       name: openHABian installation test with 64bit Azul Java 8 on native amd64
       env: HW=amd64
       arch: amd64
       script:
         # 64bit Azul Java 8 on a 64bit amd64 virtual platform, running in a 64bit OS on Travis AMD64 HW
-        - sed -i 's/^java_opt=.*$/java_opt=Zulu8-64/' build-image/openhabian.conf
+        - sed -i 's|^java_opt=.*$|java_opt=Zulu8-64|' build-image/openhabian.conf
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.amd64 .
         - echo -e "\n\e[36mopenHABian test installation using 64bit Azul Enterprise Java 8 running on a\e[31m 64bit OS\e[36m running on native ${HW}...\e[0m\n"
         - docker run --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
@@ -59,7 +52,7 @@ jobs:
       arch: amd64
       script:
         # 64bit Azul Java 11 on a 64bit amd64 virtual platform, running in a 64bit => Ubuntu <= OS on Travis AMD64 HW
-        - sed -i 's/^java_opt=.*$/java_opt=Zulu11-64/' build-image/openhabian.conf
+        - sed -i 's|^java_opt=.*$|java_opt=Zulu11-64|' build-image/openhabian.conf
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.amd64-ubuntu .
         - echo -e "\n\e[36mopenHABian test installation using 64bit Azul Enterprise Java 11 running on a\e[31m 64bit Ubuntu\e[36m running on native ${HW}...\e[0m\n"
         - docker run --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
@@ -69,7 +62,7 @@ jobs:
       arch: arm64
       script:
         # 32bit Azul Java 8 on a 32bit ARMv7l (RPi2) virtual platform, running in a 32bit OS on Travis Arm64 HW
-        - sed -i 's/^java_opt=.*$/java_opt=Zulu8-32/' build-image/openhabian.conf
+        - sed -i 's|^java_opt=.*$|java_opt=Zulu8-32|' build-image/openhabian.conf
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.raspberry-pi2 .
         - echo -e "\n\e[36mopenHABian test installation using 32bit Azul Embedded Java 8 running on a\e[31m 32bit OS\e[36m running in a virtual ${HW}...\e[0m\n"
         - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian
@@ -79,7 +72,7 @@ jobs:
       arch: arm64
       script:
         # 32bit Azul Java 11 on a 64bit ARMv8 (RPi3) virtual platform, running in a 32bit OS on Travis Arm64 HW
-        - sed -i 's/^java_opt=.*$/java_opt=Zulu11-32/' build-image/openhabian.conf
+        - sed -i 's|^java_opt=.*$|java_opt=Zulu11-32|' build-image/openhabian.conf
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.raspberrypi3 .
         - echo -e "\n\e[36mopenHABian test installation using 32bit Azul Embedded Java 11 running on a\e[31m 32bit OS\e[36m running in a virtual ${HW}...\e[0m\n"
         - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
@@ -89,7 +82,7 @@ jobs:
       arch: arm64
       script:
         # 64bit Azul Java 8 on a 64bit ARMv8 (RPi3) virtual platform, running in a 64bit OS on Travis Arm64 HW
-        - sed -i 's/^java_opt=.*$/java_opt=Zulu8-64/' build-image/openhabian.conf
+        - sed -i 's|^java_opt=.*$|java_opt=Zulu8-64|' build-image/openhabian.conf
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.raspberrypi3-64 .
         - echo -e "\n\e[36mopenHABian test installation using 64bit Azul Embedded Java 8 running on a\e[31m 64bit OS\e[36m running in a virtual ${HW}...\e[0m\n"
         - docker run --memory="2g" --memory-reservation="2g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;
@@ -99,7 +92,7 @@ jobs:
       arch: arm64
       script:
         # AdoptOpenJDK Java 11 on a 32bit ARMv7l (RPi2) virtual platform, running in a 32bit OS on Travis Arm64 HW
-        - sed -i 's/^java_opt=.*$/java_opt=Adopt11/' build-image/openhabian.conf
+        - sed -i 's|^java_opt=.*$|java_opt=Adopt11|' build-image/openhabian.conf
         - docker build -t openhabian/${HW}-openhabian -f Dockerfile.raspberry-pi2 .
         - echo -e "\n\e[36mopenHABian test installation using AdoptOpenJDK Java 11 running on a\e[31m 32bit OS\e[36m running in a virtual ${HW}...\e[0m\n"
         - docker run --memory="1g" --memory-reservation="1g" --name "openhabian-${HW}" -d openhabian/${HW}-openhabian;

--- a/Dockerfile.amd64-ubuntu
+++ b/Dockerfile.amd64-ubuntu
@@ -1,4 +1,4 @@
-FROM balenalib/intel-nuc-ubuntu:focal-build
+FROM balenalib/amd64-ubuntu:focal-build
 
 
 ENV container docker

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -1,9 +1,11 @@
 #!/bin/bash
+# shellcheck source=/etc/openhabian.conf disable=SC1091
 
 CONFIGFILE=/etc/openhabian.conf
 
 # apt/dpkg commands will not try interactive dialogs
 export DEBIAN_FRONTEND=noninteractive
+export SILENT=1
 
 # Log everything to file
 exec &> >(tee -a "/boot/first-boot.log")
@@ -20,44 +22,35 @@ fail_inprogress() {
 
 ###### start ######
 sleep 5
-echo -e "\n\n$(timestamp) [openHABian] Starting the openHABian initial setup."
+echo -e "\\n\\n$(timestamp) [openHABian] Starting the openHABian initial setup."
 rm -f /opt/openHABian-install-failed
 touch /opt/openHABian-install-inprogress
 
 echo -n "$(timestamp) [openHABian] Storing configuration... "
-cp /boot/openhabian.conf "$CONFIGFILE"
-sed -i 's/\r$//' "$CONFIGFILE"
+if ! cp /boot/openhabian.conf "$CONFIGFILE"; then echo "FAILED (copy)"; fail_inprogress; fi
+if ! sed -i 's|\r$||' "$CONFIGFILE"; then echo "FAILED (Unix line endings)"; fail_inprogress; fi
+if ! source "$CONFIGFILE"; then echo "FAILED (source config)"; fail_inprogress; fi
+if ! source "/opt/openhabian/functions/helpers.bash"; then echo "FAILED (source helpers)"; fail_inprogress; fi
+if source "/opt/openhabian/functions/openhabian.bash"; then echo "OK"; else echo "FAILED (source openhabian)"; fail_inprogress; fi
 
-# shellcheck disable=SC1090
-source "$CONFIGFILE"
-# shellcheck disable=SC1091
-source "/boot/helpers.bash"
-# shellcheck disable=SC1091
-source "/boot/openhabian.bash"
-echo "OK"
 
-# shellcheck disable=SC2154
-if [[ "$debugmode" == "on" ]]; then
+if [[ "${debugmode:-on}" == "on" ]]; then
   unset SILENT
   unset DEBUGMAX
-elif [[ "$debugmode" == "maximum" ]]; then
+elif [[ "${debugmode:-on}" == "maximum" ]]; then
   echo "$(timestamp) [openHABian] Enable maximum debugging output"
   export DEBUGMAX=1
   set -x
 fi
 
 echo -n "$(timestamp) [openHABian] Starting webserver with installation log... "
-if hash python3 2>/dev/null; then
+if [[ -x $(command -v python3) ]]; then
   bash /boot/webif.bash start
   sleep 5
-  webifisrunning=$(ps -ef | pgrep python3)
-  if [ -z "$webifisrunning" ]; then
-    echo "FAILED"
-  else
-    echo "OK"
-  fi
+  isWebRunning=$(ps -ef | pgrep python3)
+  if [[ -n $isWebRunning ]]; then echo "OK"; else echo "FAILED"; fi
 else
-  echo "Python not found, SKIPPED"
+  echo "SKIPPED (Python not found)"
 fi
 
 userdef="openhabian"
@@ -67,7 +60,7 @@ fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "
 # shellcheck disable=SC2154
-if [ -z "${username+x}" ] || ! id $userdef &>/dev/null || id "$username" &>/dev/null; then
+if [[ -z "${username+x}" ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
   echo "SKIPPED"
 else
   usermod -l "$username" "$userdef"
@@ -80,18 +73,20 @@ fi
 # While setup: show log to logged in user, will be overwritten by openhabian-setup.sh
 echo "watch cat /boot/first-boot.log" > "$HOME/.bash_profile"
 
-# shellcheck disable=SC2154
-if [ -z "${wifi_ssid}" ]; then
-  echo "$(timestamp) [openHABian] Setting up Ethernet connection... OK"
+# shellcheck source=/etc/openhabian.conf disable=SC2154
+if [[ -z $wifi_ssid ]]; then
+  # Actually check if ethernet is working
+  echo -n "$(timestamp) [openHABian] Setting up Ethernet connection... "
+  if grep -q "up" /sys/class/net/eth0/operstate; then echo "OK"; else echo "FAILED"; fi
 elif grep -q "openHABian" /etc/wpa_supplicant/wpa_supplicant.conf && ! grep -q "^[[:space:]]*dtoverlay=disable-wifi" /boot/config.txt; then
   echo -n "$(timestamp) [openHABian] Setting up Wi-Fi connection... "
-  if iwlist wlan0 scanning 2>&1 | grep -q "Interface doesn't support scanning"; then
+  if iwlist wlan0 scanning |& grep -q "Interface doesn't support scanning"; then
     # wifi might be blocked
     rfkill unblock wifi
     ifconfig wlan0 up
-    if iwlist wlan0 scanning 2>&1 | grep -q "Interface doesn't support scanning"; then
+    if iwlist wlan0 scanning |& grep -q "Interface doesn't support scanning"; then
       echo "FAILED"
-      echo "$(timestamp) [openHABian] I was not able to turn on the wifi - here is some more information:"
+      echo "$(timestamp) [openHABian] I was not able to turn on the WiFi - here is some more information:"
       rfkill list all
       ifconfig
       fail_inprogress
@@ -103,10 +98,10 @@ else
 
   # check the user input for the country code
   # check: from the start of line, the uppercased input must be followed by a whitespace
-  if [ -z "$wifi_country" ]; then
+  if [[ -z $wifi_country ]]; then
     wifi_country="US"
   elif grep -q "^${wifi_country^^}\\s" /usr/share/zoneinfo/zone.tab; then
-    wifi_country=${wifi_country^^}
+    wifi_country="${wifi_country^^}"
   else
     echo "${wifi_country} is not a valid country code found in /usr/share/zoneinfo/zone.tab"
     echo "Defaulting to US"
@@ -117,7 +112,7 @@ else
   echo -e "country=$wifi_country\\nctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev\\nupdate_config=1" >> /etc/wpa_supplicant/wpa_supplicant.conf
   # shellcheck disable=SC2154
   if ! WNET=$(wpa_passphrase "${wifi_ssid}" "${wifi_psk}"); then
-    echo FAILED
+    echo "FAILED"
     echo "$WNET"
   else
     echo "# network config created by wpa_passphrase to ensure correct handling of special characters" >> /etc/wpa_supplicant/wpa_supplicant.conf
@@ -129,16 +124,17 @@ else
       echo "OK, rebooting... "
       reboot
     else
-      wpa_cli reconfigure &>/dev/null
+      wpa_cli reconfigure &> /dev/null
       echo "OK"
     fi
   fi
 fi
 
+
 echo -n "$(timestamp) [openHABian] Ensuring network connectivity... "
-if tryUntil "ping -c1 9.9.9.9 >/dev/null || wget -S -t 3 --waitretry=4 http://www.msftncsi.com/ncsi.txt 2>&1 | grep -q 'Microsoft NCSI'" 30 1; then
+if tryUntil "ping -c1 9.9.9.9 > /dev/null || wget -S -t 3 --waitretry=4 http://www.msftncsi.com/ncsi.txt |& grep -q 'Microsoft NCSI'" 30 1; then
     echo "FAILED"
-    if grep -q "openHABian" /etc/wpa_supplicant/wpa_supplicant.conf && iwconfig 2>&1 | grep -q "ESSID:off"; then
+    if grep -q "openHABian" /etc/wpa_supplicant/wpa_supplicant.conf && iwconfig |& grep -q "ESSID:off"; then
       echo "$(timestamp) [openHABian] I was not able to connect to the configured Wi-Fi. Please check your signal quality. Reachable Wi-Fi networks are:"
       iwlist wlan0 scanning | grep "ESSID" | sed 's/^\s*ESSID:/\t- /g'
       echo "$(timestamp) [openHABian] Please try again with your correct SSID and password. The following Wi-Fi configuration was used:"
@@ -153,44 +149,40 @@ if tryUntil "ping -c1 9.9.9.9 >/dev/null || wget -S -t 3 --waitretry=4 http://ww
 echo "OK"
 
 echo -n "$(timestamp) [openHABian] Waiting for dpkg/apt to get ready... "
-if tryUntil "apt-get update &>/dev/null" 3 1; then echo "OK"; else echo "FAILED"; fi
-echo "OK"
+if wait_for_apt_to_be_ready; then echo "OK"; else echo "FAILED"; fi
 
 echo -n "$(timestamp) [openHABian] Updating repositories and upgrading installed packages... "
-apt --yes --fix-broken install &>/dev/null
-apt-get --yes upgrade &>/dev/null
-res=$?
-if [[ $res -eq 100 ]]; then
-  cond_echo "CONTINUING..\c"
-  dpkg --configure -a
-  apt --yes --fix-broken install &>/dev/null
-  if apt-get --yes upgrade &>/dev/null; then echo "OK"; else echo "FAILED"; fi
+apt-get --yes --fix-broken install &> /dev/null
+if [[ $(eval "$(apt-get --yes upgrade &> /dev/null)") -eq 100 ]]; then
+  cond_echo "CONTINUING... ${COL_DEF}\c"
+  dpkg --configure -a &> /dev/null
+  apt-get --yes --fix-broken install &> /dev/null
+  if apt-get --yes upgrade &> /dev/null; then echo "OK"; else echo "FAILED"; fi
 else
   echo "OK"
 fi
 
-if hash python3 2>/dev/null; then bash /boot/webif.bash reinsure_running; fi
+if [[ -x $(command -v python3) ]]; then bash /boot/webif.bash reinsure_running; fi
 
-echo -n "$(timestamp) [openHABian] Installing git package... "
-if ! cond_redirect dpkg -s "git" &>/dev/null; then
-  if apt-get install --yes git &>/dev/null; then echo "OK"; else echo "FAILED"; fi
-else
-  echo "OK"
+if ! dpkg -s 'git' &> /dev/null; then
+  echo -n "$(timestamp) [openHABian] Installing git package... "
+  if apt-get install --yes git &> /dev/null; then echo "OK"; else echo "FAILED"; fi
 fi
 
-# must not remove /opt/openhabian for offline to work
-if ! [[ -d /opt/openhabian ]]; then git clone https://github.com/openhab/openhabian.git /opt/openhabian; fi
 # shellcheck disable=SC2154
-echo -n "$(timestamp) [openHABian] Cloning myself from ${repositoryurl}, ${clonebranch} branch... "
-type openhabian_update &>/dev/null && if ! openhabian_update; then
+echo -n "$(timestamp) [openHABian] Cloning myself from ${repositoryurl:-https://github.com/openhab/openhabian.git}, ${clonebranch:-stable} branch... "
+type openhabian_update &> /dev/null && if ! openhabian_update &> /dev/null; then
+  echo "FAILED"
   echo "$(timestamp) [openHABian] The git repository on the public internet is not reachable."
   echo "$(timestamp) [openHABian] We will continue trying to get your system installed, but this is not guaranteed to work."
+else
+  echo "OK"
 fi
 ln -sfn /opt/openhabian/openhabian-setup.sh /usr/local/bin/openhabian-config
 
 # shellcheck disable=SC2154
-echo "$(timestamp) [openHABian] Executing openhabian-setup.sh unattended... "
-if (/bin/bash /opt/openhabian/openhabian-setup.sh unattended); then
+echo "$(timestamp) [openHABian] Executing openhabian-setup.sh unattended..."
+if (bash /opt/openhabian/openhabian-setup.sh unattended); then
   rm -f /opt/openHABian-install-inprogress
   touch /opt/openHABian-install-successful
 else
@@ -199,26 +191,25 @@ else
 fi
 echo "$(timestamp) [openHABian] Execution of 'openhabian-setup.sh unattended' completed."
 
-echo -n "$(timestamp) [openHABian] Waiting for openHAB to become ready on $HOSTNAME ..."
+echo -n "$(timestamp) [openHABian] Waiting for openHAB to become ready on ${HOSTNAME}... "
 
 # this took ~130 seconds on a RPi2
-if tryUntil "wget -S --spider -t 3 --waitretry=4 http://${HOSTNAME}:8080/start/index 2>&1 | grep -q 'HTTP/1.1 200 OK'" 20 10; then echo "FAILED"; exit 1; fi
-echo "OK"
+if ! tryUntil "wget -S --spider -t 3 --waitretry=4 http://${HOSTNAME}:8080/start/index |& grep -q 'HTTP/1.1 200 OK'" 20 10; then echo "OK"; else echo "FAILED"; exit 1; fi
 
 echo "$(timestamp) [openHABian] Visit the openHAB dashboard now: http://${HOSTNAME:-openhab}:8080"
 echo "$(timestamp) [openHABian] To gain access to a console, simply reconnect."
 echo "$(timestamp) [openHABian] First time setup successfully finished."
 sleep 12
-if hash python3 2>/dev/null; then bash /boot/webif.bash inst_done; fi
+if [[ -x $(command -v python3) ]]; then bash /boot/webif.bash inst_done; fi
 sleep 12
 
-if [ -z "$SILENT" ]; then
+if running_in_docker; then
   PID="${OPENHAB_USERDATA}"/tmp/karaf.pid
   echo -e "\\n${COL_CYAN}Memory usage:" && free -m
   if [[ -d "$PID" ]]; then
     ps -auxq "$(cat "$PID")" | awk '/openhab/ {print "size/res="$5"/"$6" KB"}'
   else
-    echo -e "\\n${COL_RED}Karaf PID missing, openHAB process not (yet ?) running."
+    echo -e "\\n${COL_RED}Karaf PID missing, openHAB process not running (yet?)."
   fi
   echo -e "$COL_DEF"
 fi

--- a/build-image/webif.bash
+++ b/build-image/webif.bash
@@ -1,10 +1,9 @@
 #!/bin/bash
-# start:     	starts a minimalistic web server
-# 	    	shows the status of OpenHABianPi installation
-# restart:   	checks if webserver is running
-# inst_done: 	create finish message and link to http://$hostname:8080
-# cleanup:	stops the webserver
-#	     	removes all no longer needed files
+## start:  Starts a minimalistic web server that shows the status of the
+##       openHABian installation.
+## restart:  Checks if webserver is running.
+## inst_done:  Create finish message and link to http://$hostname:8080.
+## cleanup:  Stops the webserver and removes all no longer needed files.
 
 port=80 # Port the webserver is listing to
 # shellcheck source=/etc/openhabian.conf disable=SC1091
@@ -29,14 +28,14 @@ the log will be refreshed automatically every 10 seconds
 <iframe src='"/first-boot.txt"' scrolling="yes" width="100%" height="90%"></iframe>
 </body>
 </html>' >> /tmp/webif/index.html
-  (cd /tmp/webif || exit 1; python3 -m http.server $port > /dev/null 2>&1 &)
+  (cd /tmp/webif || exit 1; python3 -m http.server $port &> /dev/null &)
 fi
 
 # changed to python3 due to issues in automated testing
 if [ "$1" = "reinsure_running" ]; then
   webifrunning=$(ps -ef | pgrep python3)
   if [ -z "$webifrunning" ]; then
-    python3 -m http.server $port > /dev/null 2>&1 &
+    python3 -m http.server $port &> /dev/null &
   fi
 fi
 

--- a/ci-setup.bash
+++ b/ci-setup.bash
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+##########################
+#### Load help method ####
+##########################
+# shellcheck disable=SC1090
+source functions/helpers.bash
+
+## This function formats log messages
+##
+##    echo_process(String message)
+##
+echo_process() {
+  echo -e "${COL_CYAN}$(timestamp) [openHABian] ${*}${COL_DEF}"
+}
+
+if [[ $1 == "travis" ]]; then
+  # prepare configuration for tests, select debug level here:
+  sed -i 's#debugmode=.*$#debugmode=on#' build-image/openhabian.conf
+  #sed -i 's#debugmode=.*$#debugmode=maximum#' build-image/openhabian.conf
+  if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    echo "Cloning openHABian repo from https://github.com/${TRAVIS_PULL_REQUEST_SLUG}.git"
+    sed -i 's|repositoryurl=.*$|repositoryurl=https://github.com/'"${TRAVIS_PULL_REQUEST_SLUG}"'.git|' build-image/openhabian.conf
+    sed -i 's|clonebranch=.*$|clonebranch='"${TRAVIS_PULL_REQUEST_BRANCH}"'|' build-image/openhabian.conf
+  else
+    echo "Cloning openHABian repo from https://github.com/${TRAVIS_REPO_SLUG}.git"
+    sed -i 's|repositoryurl=.*$|repositoryurl=https://github.com/'"${TRAVIS_REPO_SLUG}"'.git|' build-image/openhabian.conf
+    sed -i 's|clonebranch=.*$|clonebranch='"${TRAVIS_BRANCH}"'|' build-image/openhabian.conf
+  fi
+elif [[ $1 == "github" ]]; then
+  repoURL="$(git remote get-url origin)"
+  repoBranch="$(git rev-parse --abbrev-ref HEAD)"
+
+  if ! [[ $repoURL == "https"* ]]; then
+    # Convert URL from SSH to HTTPS
+    username="$(echo "$repoURL" | sed -Ene's#git@github.com:([^/]*)/(.*).git#\1#p')"
+    if [[ -z $username ]]; then
+      echo_process "Could not identify git user while converting to SSH URL. Exiting."
+      exit 1
+    fi
+    reponame="$(echo "$repoURL" | sed -Ene's#git@github.com:([^/]*)/(.*).git#\2#p')"
+    if [[ -z $reponame ]]; then
+      echo_process "Could not identify git repo while converting to SSH URL. Exiting."
+      exit 1
+    fi
+    repoURL="https://github.com/${username}/${reponame}.git"
+  fi
+  sed -i 's|repositoryurl=.*$|repositoryurl='"${repoURL}"'|' build-image/openhabian."${2}".conf
+  sed -i 's|clonebranch=.*$|clonebranch='"${repoBranch}"'|' build-image/openhabian."${2}".conf
+fi

--- a/functions/helpers.bats
+++ b/functions/helpers.bats
@@ -12,14 +12,14 @@ testAppearingHost() {
   tryUntil "ping -c 1 $1" 10 1
 }
 
-@test "unit-tryExistingSite" {
+@test "inactive-tryExistingSite" {
   run testAppearingHost thiswillappear
   [ "$status" -eq 7 ]
 
   echo -e "# ${COL_GREEN}$(timestamp) [openHABian] Ping to host appearing after 3 seconds succeeded.${COL_DEF}" >&3
 }
 
-@test "unit-tryNonExistingSite" {
+@test "inactive-tryNonExistingSite" {
   run testNonExistingHost nothisdoesnotexit
   [ "$status" -eq 0 ]
 

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -74,9 +74,9 @@ Check the \"openHAB Release Notes\" and the official announcements to learn abou
   if is_pi; then
     echo -n "$(timestamp) [openHABian] Optimizing Java to run on low memory single board computers... "
     if has_lowmem; then
-      sed -i 's#^EXTRA_JAVA_OPTS=.*#EXTRA_JAVA_OPTS="-Xms16m -Xmx256m"#g' /etc/default/openhab2
+      if cond_redirect sed -i 's|^EXTRA_JAVA_OPTS=.*$|EXTRA_JAVA_OPTS="-Xms16m -Xmx256m"|g' /etc/default/openhab2; then echo "OK"; else echo "FAILED"; return 1; fi
     else
-      sed -i 's#^EXTRA_JAVA_OPTS=.*#EXTRA_JAVA_OPTS="-Xms192m -Xmx320m"#g' /etc/default/openhab2
+      if cond_redirect sed -i 's|^EXTRA_JAVA_OPTS=.*$|EXTRA_JAVA_OPTS="-Xms192m -Xmx320m"|g' /etc/default/openhab2; then echo "OK"; else echo "FAILED"; return 1; fi
     fi
   fi
   if [ -n "$INTERACTIVE" ]; then

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -9,19 +9,6 @@ get_git_revision() {
   echo "[$branch]$latesttag-$revcount($shorthash)"
 }
 
-apt_update() {
-  apt-get -q update > /dev/null 2>&1 &
-  PID_APT=$!
-}
-
-wait_for_apt_to_finish_update() {
-  echo -n "$(timestamp) [openHABian] Updating Linux package information ... "
-  if [ -z "$PID_APT" ]; then
-    apt_update
-  fi
-  if timeout 60 tail --pid=$PID_APT -f /dev/null; then echo "OK"; else echo "FAILED"; fi
-}
-
 install_cleanup() {
   echo "$(timestamp) [openHABian] Cleaning up ... "
   cond_redirect apt-get autoremove --yes

--- a/test.bash
+++ b/test.bash
@@ -4,24 +4,15 @@ set -e
 ##########################
 #### Load help method ####
 ##########################
-
-# Log with timestamp
-timestamp() { date +"%F_%T_%Z"; }
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/functions/helpers.bash
 
 ## This function formats log messages
 ##
 ##    echo_process(String message)
 ##
-echo_process() { echo -e "$(timestamp) [openHABian] $*"; }
-
-## This enables printout of both a executed command and its output
-##
-##    cond_redirect(bash command)
-##
-cond_redirect() {
-    echo -e "\\n$COL_DGRAY\$ $* $COL_DEF"
-    "$@"
-    return $?
+echo_process() {
+  echo -e "${COL_CYAN}$(timestamp) [openHABian] ${*}${COL_DEF}"
 }
 
 ###########################
@@ -29,13 +20,13 @@ cond_redirect() {
 ###########################
 
 # What test case should be run?
-if [ "$1" == "docker-full" ]; then
+if [[ $1 == "docker-full" ]]; then
   echo_process "Starting Docker installation test for amd64..."
   cond_redirect docker stop install-test || true
   cond_redirect docker rm install-test || true
   cond_redirect docker build --tag openhabian/install-openhabian -f Dockerfile.amd64 .
   cond_redirect docker run --name "install-test" --privileged -d openhabian/install-openhabian
-  cond_redirect docker exec -i "install-test" bash -c "./build.bash local-test && mv ~/.profile ~/.bash_profile && /etc/rc.local"
+  cond_redirect docker exec -i "install-test" bash -c "./build.bash local-test && mv ~/.profile ~/.bash_profile && /boot/first-boot.bash"
   echo_process "Test complete, please review result in terminal. Access tested container by executing: \"docker exec -it install-test bash\""
 
   echo_process "Starting Docker BATS tests for amd64..."
@@ -45,23 +36,11 @@ if [ "$1" == "docker-full" ]; then
   cond_redirect docker run --rm --name "destructive-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "destructive-." .'
   cond_redirect echo_process "Test complete, please review result in terminal."
   exit 0
-elif [ "$1" == "shellcheck" ]; then
+elif [[ $1 == "shellcheck" ]]; then
   shellcheck -x -s bash openhabian-setup.sh
   shellcheck -x -s bash functions/*.bash
   shellcheck -x -s bash build-image/*.bash
-elif [ "$1" == "travis" ]; then
-  # prepare configuration for tests, select debug level here:
-  sed -i 's#debugmode=.*$#debugmode=on#' build-image/openhabian.conf
-  #sed -i 's#debugmode=.*$#debugmode=maximum#' build-image/openhabian.conf
-  if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    echo "Cloning openHABian repo from https://github.com/${TRAVIS_PULL_REQUEST_SLUG}.git"
-    sed -i 's#repositoryurl=.*$#repositoryurl=https://github.com/'${TRAVIS_PULL_REQUEST_SLUG}'.git#' build-image/openhabian.conf
-    sed -i 's#clonebranch=.*$#clonebranch='${TRAVIS_PULL_REQUEST_BRANCH}'#' build-image/openhabian.conf
-  else
-    echo "Cloning openHABian repo from https://github.com/${TRAVIS_REPO_SLUG}.git"
-    sed -i 's#repositoryurl=.*$#repositoryurl=https://github.com/'${TRAVIS_REPO_SLUG}'.git#' build-image/openhabian.conf
-    sed -i 's#clonebranch=.*$#clonebranch='${TRAVIS_BRANCH}'#' build-image/openhabian.conf
-  fi
+  shellcheck -x -s bash build.bash ci-setup.bash
 else
   echo_process "Please provide a valid test profile, \"docker-full\" or \"shellcheck\". Exiting"
   exit 0


### PR DESCRIPTION
The 'Build Image' action was primarily written by Holger Friedrich and
then edited for better functionality in the openHABian core repo.

This also contains other changes to the CI setup, such as moving the
ShellCheck checks out of Travis and instead enforcing them in GitHub
Actions.

Along with theses changes, some improvements to the build script and
install output were also made. These changes to the build script include
using cURL over wget for downloading needed files and also cloning the
openHABian repo in the build process rather than the install process.
This change was made because the repo must be present for offline
install to work, and as such it makes sense to provide it with the image
to reduce points of failure on install.

Fixes #991

Co-authored-by: Holger Friedrich <mail@holger-friedrich.de>
Co-authored-by: Markus Storm <markus.storm@gmx.net>
Signed-off-by: Ethan Dye <mrtops03@gmail.com>
