### PR TITLE
Fix IPv6 enabling/disabling

### DIFF
--- a/includes/S90force-ipv4
+++ b/includes/S90force-ipv4
@@ -1,0 +1,1 @@
+Acquire::ForceIPv4 "true";

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -77,7 +77,7 @@ for shfile in "$BASEDIR"/functions/*.bash; do source "$shfile"; done
 OLDWD=$(pwd) && cd /opt || exit 1
 
 # disable ipv6 if requested in openhabian.conf (eventually reboots)
-choose_ipv6
+config_ipv6
 
 if [[ -n "$UNATTENDED" ]]; then
   # apt/dpkg commands will not try interactive dialogs


### PR DESCRIPTION
The current implementation of IPv6 enabling/disabling had many issues
and could not enable IPv6 after it was disabled because of broken
functionality. This contains a simpler and fixed method to
enable/disable IPv6.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>