### PR TITLE
Fixed non-abolute path in WiFi disabling script

### DIFF
--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -18,7 +18,7 @@ enable_disable_wifi() {
   elif [[ $1 == "disable" ]]; then
     echo -n "$(timestamp) [openHABian] Disabling WiFi... "
     if ! grep -qsE "^[[:space:]]*dtoverlay=(pi3-)?disable-wifi" /boot/config.txt; then
-      if echo "dtoverlay=disable-wifi" >> boot/config.txt; then echo "OK (Reboot needed)"; else echo "FAILED"; return 1; fi
+      if echo "dtoverlay=disable-wifi" >> /boot/config.txt; then echo "OK (Reboot needed)"; else echo "FAILED"; return 1; fi
     else
       echo "OK"
     fi


### PR DESCRIPTION
Fixed the relative path which made it impossible to disable the WiFi through openhabian-config.

Signed-off-by: Konrad Ponichtera <konpon96@gmail.com>