### PR TITLE
Revert package installed check after #1055

### DIFF
--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -96,7 +96,7 @@ amanda_install() {
 
   if cond_redirect chsh --shell /bin/bash "$backupUser"; then echo "OK"; else echo "FAILED (chsh ${backupUser})"; return 1; fi
 
-  if ! [[ $(dpkg -s 'amanda-common' 'amanda-server' 'amanda-client') ]]; then
+  if ! dpkg -s 'amanda-common' 'amanda-server' 'amanda-client' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing Amanda backup system... "
     if cond_redirect apt-get install --yes amanda-common amanda-server amanda-client; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
@@ -141,7 +141,7 @@ amanda_setup() {
   if ! (whiptail --title "Amanda backup installation" --yes-button "Begin" --no-button "Cancel" --yesno "$introText" 14 80); then echo "CANCELED"; return 0; fi
   if (whiptail --title "Amanda backup installation" --yes-button "Continue" --no-button "Cancel" --defaultno --yesno "$queryText" 14 80); then echo "OK"; else echo "CANCELED"; return 0; fi
 
-  if ! [[ $(dpkg -s 'exim4') ]]; then
+  if ! dpkg -s 'exim4' &> /dev/null; then
     if (whiptail --title "MTA missing?" --yes-button "Install EXIM4" --no-button "Ignore" --yesno "$eximText" 12 80); then
       if ! exim_setup; then return 1; fi
     fi

--- a/functions/find.bash
+++ b/functions/find.bash
@@ -226,7 +226,7 @@ setup_monitor_mode() {
   fi
   if (whiptail --title "Monitor Mode setup" --yes-button "Begin" --no-button "Cancel" --defaultno --yesno "$introText" 15 80); then echo "OK"; else echo "CANCELED"; return 0; fi
 
-  if ! [[ $(dpkg -s 'firmware-brcm80211') ]]; then
+  if ! dpkg -s 'firmware-brcm80211' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing WiFi firmware... "
     if cond_redirect apt-get install --yes firmware-brcm80211; then echo "OK"; else echo "FAILED"; return 1; fi
   fi

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -430,5 +430,5 @@ select_blkdev() {
   done < <(lsblk -i | tr -d '`\\|' | grep -E "${1}" | tr -d '\\-')
 
   # shellcheck disable=SC2034
-  retval=$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "$3" 12 76 4 "${array[@]}" 3>&1 1>&2 2>&3)
+  retval="$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "$3" 12 76 4 "${array[@]}" 3>&1 1>&2 2>&3)"
 }

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -202,7 +202,7 @@ influxdb_install() {
   fi
   myRelease="$(lsb_release -sc)"
 
-  if ! [[ $(dpkg -s 'influxdb') ]]; then
+  if ! dpkg -s 'influxdb' &> /dev/null; then
     if ! add_keys "https://repos.influxdata.com/influxdb.key"; then return 1; fi
 
     echo "deb https://repos.influxdata.com/${myOS,,} ${myRelease,,} stable" > /etc/apt/sources.list.d/influxdb.list
@@ -245,7 +245,7 @@ grafana_install(){
 
   adminPassword="$1"
 
-  if ! [[ $(dpkg -s 'grafana') ]]; then
+  if ! dpkg -s 'grafana' &> /dev/null; then
     if ! add_keys "https://packages.grafana.com/gpg.key"; then return 1; fi
 
     echo "deb https://packages.grafana.com/oss/deb stable main" > /etc/apt/sources.list.d/grafana.list

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -114,24 +114,24 @@ java_zulu_prerequisite() {
   echo -n "$(timestamp) [openHABian] Installing Java Zulu prerequisites (libc, libstdc++, zlib1g)... "
   if [[ $1 == "Zulu8-64" ]] || [[ $1 == "Zulu11-64" ]]; then
     if is_aarch64 && [[ $(getconf LONG_BIT) == 64 ]]; then
-      if [[ $(dpkg -s 'libc6:arm64' 'libstdc++6:arm64' 'zlib1g:arm64') ]]; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:arm64' 'libstdc++6:arm64' 'zlib1g:arm64' &> /dev/null; then echo "OK"; return 0; fi
       dpkg --add-architecture arm64
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
       if cond_redirect apt-get install --yes libc6:arm64 libstdc++6:arm64 zlib1g:arm64; then echo "OK"; else echo "FAILED"; return 1; fi
     elif is_x86_64 && [[ $(getconf LONG_BIT) == 64 ]]; then
-      if [[ $(dpkg -s 'libc6:amd64' 'libstdc++6:amd64' 'zlib1g:amd64') ]]; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:amd64' 'libstdc++6:amd64' 'zlib1g:amd64' &> /dev/null; then echo "OK"; return 0; fi
       dpkg --add-architecture amd64
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
       if cond_redirect apt-get install --yes libc6:amd64 libstdc++6:amd64 zlib1g:amd64; then echo "OK"; else echo "FAILED"; return 1; fi
     fi
   else
     if is_arm; then
-      if [[ $(dpkg -s 'libc6:armhf' 'libstdc++6:armhf' 'zlib1g:armhf') ]]; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:armhf' 'libstdc++6:armhf' 'zlib1g:armhf' &> /dev/null; then echo "OK"; return 0; fi
       dpkg --add-architecture armhf
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
       if cond_redirect apt-get install --yes libc6:armhf libstdc++6:armhf zlib1g:armhf; then echo "OK"; else echo "FAILED"; return 1; fi
     else
-      if [[ $(dpkg -s 'libc6:i386' 'libstdc++6:i386' 'zlib1g:i386') ]]; then echo "OK"; return 0; fi
+      if dpkg -s 'libc6:i386' 'libstdc++6:i386' 'zlib1g:i386' &> /dev/null; then echo "OK"; return 0; fi
       dpkg --add-architecture i386
       if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
       if cond_redirect apt-get install --yes libc6:i386 libstdc++6:i386 zlib1g:i386; then echo "OK"; else echo "FAILED"; return 1; fi
@@ -410,7 +410,7 @@ java_zulu_install_crypto_extension() {
 ##    adoptopenjdk_fetch_apt()
 ##
 adoptopenjdk_fetch_apt() {
-  if ! [[ $(dpkg -s 'software-properties-common') ]]; then
+  if ! dpkg -s 'software-properties-common' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing AdoptOpenJDK prerequisites (software-properties-common)... "
     if ! cond_redirect apt-get install --yes software-properties-common; then echo "FAILED"; return 1; fi
   fi
@@ -433,12 +433,12 @@ adoptopenjdk_install_apt() {
   if openhab_is_running; then
     cond_redirect systemctl stop openhab2.service
   fi
-  if ! [[ $(dpkg -s 'adoptopenjdk-11-hotspot-jre') ]]; then # Check if already is installed
+  if ! dpkg -s 'adoptopenjdk-11-hotspot-jre' &> /dev/null; then # Check if already is installed
     adoptopenjdk_fetch_apt
     echo -n "$(timestamp) [openHABian] Installing AdoptOpenJDK 11... "
     cond_redirect java_alternatives_reset
     if cond_redirect apt-get install --yes adoptopenjdk-11-hotspot-jre; then echo "OK"; else echo "FAILED"; return 1; fi
-  elif [[ $(dpkg -s 'adoptopenjdk-11-hotspot-jre') ]]; then
+  elif dpkg -s 'adoptopenjdk-11-hotspot-jre' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Reconfiguring AdoptOpenJDK 11... "
     cond_redirect java_alternatives_reset
     if cond_redirect dpkg-reconfigure adoptopenjdk-11-hotspot-jre; then echo "OK"; else echo "FAILED"; return 1; fi

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -99,7 +99,7 @@ nodered_setup() {
     echo -n "$(timestamp) [openHABian] Installing Frontail prerequsites (NodeJS)... "
     if cond_redirect nodejs_setup; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
-  if ! [[ $(dpkg -s 'build-essential') ]]; then
+  if ! dpkg -s 'build-essential' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing Node-RED required packages (build-essential)... "
     if cond_redirect apt-get install --yes build-essential; then echo "OK"; else echo "FAILED"; return 1; fi
   fi

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -178,7 +178,7 @@ multitail_openhab_scheme() {
 ##    openhab_is_installed()
 ##
 openhab_is_installed() {
-  if [[ $(dpkg -s 'openhab2') ]]; then return 0; else return 1; fi
+  if dpkg -s 'openhab2' &> /dev/null; then return 0; else return 1; fi
 }
 
 ## Function to check if openHAB is running on the current system. Returns

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -91,7 +91,7 @@ exim_setup() {
   local logrotateFile="/etc/logrotate.d/exim4"
   local introText
 
-  if ! [[ $(dpkg -s 'mailutils' 'exim4' 'dnsutils') ]]; then
+  if ! dpkg -s 'mailutils' 'exim4' 'dnsutils' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing MTA required packages (mailutils, exim4, dnsutils,)... "
     if cond_redirect apt-get install --yes exim4 dnsutils mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
@@ -237,7 +237,7 @@ mqtt_setup() {
     if (whiptail --title "MQTT installation?" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 14 80); then echo "OK"; else echo "CANCELED"; return 0; fi
   fi
 
-  if ! [[ $(dpkg -s 'mosquitto' 'mosquitto-clients') ]]; then
+  if ! dpkg -s 'mosquitto' 'mosquitto-clients' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing MQTT... "
     if cond_redirect apt-get install --yes mosquitto mosquitto-clients; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
@@ -300,7 +300,7 @@ find_setup() {
   local successText="FIND setup was successful.\\n\\nSettings can be configured in '/etc/default/findserver'. Be sure to restart the service after.\\n\\nYou can obtain the FIND app for Android through the Play Store. There is no iOS app available, for more information see: https://www.internalpositioning.com/faq/#can-i-use-an-iphone\\n\\nCheck out your FIND server's dashboard at: http://${HOSTNAME}:8003\\n\\nFor further information: https://www.internalpositioning.com"
   local temp
 
-  if ! [[ $(dpkg -s 'libsvm-tools') ]]; then
+  if ! dpkg -s 'libsvm-tools' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing FIND required packages... "
     if cond_redirect apt-get install --yes libsvm-tools; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
@@ -414,7 +414,7 @@ knxd_setup() {
     echo "OK"
   fi
 
-  if ! [[ $(dpkg -s 'owserver' 'ow-shell' 'usbutils') ]]; then
+  if ! dpkg -s 'owserver' 'ow-shell' 'usbutils' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing owserver (1wire)... "
     if cond_redirect apt-get install --yes owserver ow-shell usbutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
@@ -439,7 +439,7 @@ miflora_setup() {
   local mifloraDir="/opt/miflora-mqtt-daemon"
   local successText="Setup was successful.\\n\\nThe Daemon was installed and the systemd service was set up just as described in it's README. Please add your MQTT broker settings in '${mifloraDir}/config.ini' and add your Mi Flora sensors. After that be sure to restart the daemon to reload it's configuration.\\n\\nAll details can be found under: https://github.com/ThomDietrich/miflora-mqtt-daemon\\nThe article also contains instructions regarding openHAB integration."
 
-  if ! [[ $(dpkg -s 'git' 'python3' 'python3-pip' 'bluetooth' 'bluez') ]]; then
+  if ! dpkg -s 'git' 'python3' 'python3-pip' 'bluetooth' 'bluez' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing miflora-mqtt-daemon required packages... "
     if cond_redirect apt-get install --yes git python3 python3-pip bluetooth bluez; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
@@ -619,7 +619,7 @@ nginx_setup() {
     if [[ $validDomain == "true" ]]; then
       echo -n "$(timestamp) [openHABian] Installing certbot... "
       if is_ubuntu; then
-        if ! [[ $(dpkg -s 'software-properties-common') ]]; then
+        if ! dpkg -s 'software-properties-common' &> /dev/null; then
           if ! cond_redirect apt-get install --yes software-properties-common; then echo "FAILED (Ubuntu prerequsites)"; return 1; fi
         fi
         if ! cond_redirect add-apt-repository universe; then echo "FAILED (add universe repo)"; return 1; fi

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -43,9 +43,7 @@ basic_packages() {
 ##    needed_packages()
 ##
 needed_packages() {
-  local bluetoothPackages
-
-  bluetoothPackages="bluez python3-dev libbluetooth-dev raspberrypi-sys-mods pi-bluetooth"
+  local bluetoothPackages="bluez python3-dev libbluetooth-dev raspberrypi-sys-mods pi-bluetooth"
 
   # Install apt-transport-https - update packages through https repository
   # Install bc + sysstat - needed for FireMotD
@@ -131,7 +129,7 @@ setup_ntp() {
 locale_setting() {
   local locale
 
-  if ! [[ $(dpkg -s 'locales') ]]; then
+  if ! dpkg -s 'locales' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing locales from apt... "
     if cond_redirect apt-get install --yes locales; then echo "OK"; else echo "FAILED"; return 1; fi
   fi

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -43,13 +43,13 @@ configure_wifi() {
     fi
 
     if is_pifour || is_pithree || is_pithreeplus || is_pizerow; then
-      if ! [[ $(dpkg -s 'firmware-brcm80211') ]]; then
+      if ! dpkg -s 'firmware-brcm80211' &> /dev/null; then
         echo -n "$(timestamp) [openHABian] Installing WiFi firmware... "
         if cond_redirect apt-get install --yes firmware-brcm80211; then echo "OK"; else echo "FAILED"; return 1; fi
       fi
     fi
 
-    if ! [[ $(dpkg -s 'wpasupplicant' 'wireless-tools') ]]; then
+    if ! dpkg -s 'wpasupplicant' 'wireless-tools' &> /dev/null; then
       echo -n "$(timestamp) [openHABian] Installing WiFi prerequisites (wpasupplicant, wireless-tools)... "
       if cond_redirect apt-get install --yes wpasupplicant wireless-tools; then echo "OK"; else echo "FAILED"; return 1; fi
     fi

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -50,7 +50,7 @@ init_zram_mounts() {
       fi
     fi
 
-    if ! [[ $(dpkg -s 'make' 'libattr1-dev') ]]; then
+    if ! dpkg -s 'make' 'libattr1-dev' &> /dev/null; then
       echo -n "$(timestamp) [openHABian] Installing ZRAM required packages (make, libattr1-dev)... "
       if cond_redirect apt-get install --yes make libattr1-dev; then echo "OK"; else echo "FAILED"; return 1; fi
     fi


### PR DESCRIPTION
The new style caused incorrect reporting of a package being installed
and thereby caused a new bug. This revert the style to how it was prior
to #1055. This bug happens because dpkg returns without errors even if
the package exists and as such causes the check to be nullified.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>