### PR TITLE
Use lite image for arm64 builds

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       comments:
         description: 'Build comments'
-        default: 'Build for testing purposes' 
+        default: 'Build for testing purposes'
 
 jobs:
   build32:
@@ -69,7 +69,7 @@ jobs:
        - name: getimagename
          id: getimagename
          run: |
-           echo "::set-output name=image::$(basename "$(curl "https://downloads.raspberrypi.org/raspios_arm64_latest" -s -L -I  -o /dev/null -w '%{url_effective}')")"
+           echo "::set-output name=image::$(basename "$(curl "https://downloads.raspberrypi.org/raspios_lite_arm64_latest" -s -L -I  -o /dev/null -w '%{url_effective}')")"
        - name: Cache Raspberry Pi OS image
          uses: actions/cache@v2
          with:

--- a/build.bash
+++ b/build.bash
@@ -261,7 +261,7 @@ extrasize="300"			# grow image root by this number of MB
 # Build Raspberry Pi image
 if [[ $hw_platform == "pi-raspios32" ]] || [[ $hw_platform == "pi-raspios64beta" ]]; then
   if [ "$hw_platform" == "pi-raspios64beta" ]; then
-    baseurl="https://downloads.raspberrypi.org/raspios_arm64_latest"
+    baseurl="https://downloads.raspberrypi.org/raspios_lite_arm64_latest"
     bits="64"
   else
     baseurl="https://downloads.raspberrypi.org/raspios_lite_armhf_latest"


### PR DESCRIPTION
Raspberry Pi has provided a lite image for arm64 and as such, like with
our armhf builds we will prefer it over the full image as it is less
bloated with things we don't need for openHABian images.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>