### PR TITLE
fix PARTUUID after dd copy of raw device && skip ZRAM on RPi4 8GB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ lookup.
 openHABian can automatically take daily syncs of your internal SD card to
 another card in an external port. This allows for fast swapping of cards
 to reduce impact of a failed SD card.
-The remaining space on the external device will also be used to setup openHABian's Amanda backup system.
+The remaining space on the external device can also be used to setup openHABian's Amanda backup system.
 
 
 ## July 4, 2020
@@ -20,6 +20,3 @@ to your local PC or mobile device that you want to use for access.
 Copy the configuration file '/etc/wireguard/wg0-client.conf' from this box or
 transmit QR code to load the tunnel.
 Any feedback is highly appreciated on the forum.
-
-### New Java providers now out of beta
-Java 11 has been proven to work with openHAB 2.5.

--- a/docs/NEWSLOG.md
+++ b/docs/NEWSLOG.md
@@ -3,7 +3,7 @@
 openHABian can automatically take daily syncs of your internal SD card to
 another card in an external port. This allows for fast swapping of cards
 to reduce impact of a failed SD card.
-The remaining space on the external device will also be used to setup openHABian
+The remaining space on the external device can also be used to setup openHABian
 's Amanda backup system.
 
 ## July 4, 2020

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -378,7 +378,7 @@ mirror_SD() {
   if [[ "$1" == "raw" ]]; then
     echo "Creating a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
     if ! cond_redirect dd if="${src}" bs=1M of="${dest}"; then echo "FAILED (raw device copy)"; dirty="yes"; fi
-    if ! cond_redirect set-partuuid "${dest}" random; then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
+    if ! cond_redirect echo "y" | set-partuuid "${dest}" random; then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then
       echo "OK"

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -378,7 +378,7 @@ mirror_SD() {
   if [[ "$1" == "raw" ]]; then
     echo "Creating a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
     if ! cond_redirect dd if="${src}" bs=1M of="${dest}"; then echo "FAILED (raw device copy)"; dirty="yes"; fi
-    if ! cond_redirect echo "y" | set-partuuid "${dest}" random; then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
+    if ! (yes | cond_redirect set-partuuid "${dest}" random); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then
       echo "OK"

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -440,6 +440,7 @@ setup_mirror_SD() {
   fi
 
   mkdir -p "${storageDir}"
+  if cond_redirect apt-get install --yes gdisk; then echo "OK"; else echo "FAILED (install gdisk)"; return 1; fi
 
   # shellcheck disable=SC2154
   if [[ -n "$UNATTENDED" ]] && [[ -z "$backupdrive" ]]; then return 0; fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -377,7 +377,8 @@ mirror_SD() {
   fi
   if [[ "$1" == "raw" ]]; then
     echo "Creating a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
-    if ! cond_redirect dd if="${src}" bs=1M of="${dest}"; then echo "FAILED (raw device copy)"; return 1; fi
+    if ! cond_redirect dd if="${src}" bs=1M of="${dest}"; then echo "FAILED (raw device copy)"; dirty="yes"; fi
+    if ! cond_redirect set-partuuid "${dest}" random; then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then
       echo "OK"
@@ -443,6 +444,7 @@ setup_mirror_SD() {
   # shellcheck disable=SC2154
   if [[ -n "$UNATTENDED" ]] && [[ -z "$backupdrive" ]]; then return 0; fi
 
+  if ! cond_redirect install -m 755 "${BASEDIR:-/opt/openhabian}"/includes/set-partuuid /usr/local/sbin; then echo "FAILED (install set-partuuid)"; return 1; fi
   if [[ -n "$INTERACTIVE" ]]; then
     select_blkdev "^sd" "Setup SD mirroring" "Select USB device to copy the internal SD card data to"
     if [[ -z "$retval" ]]; then return 0; fi

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -185,6 +185,10 @@ is_pifour() {
   grep -q "^Revision\\s*:\\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]11[0-9a-fA-F]$" /proc/cpuinfo
   return $?
 }
+is_pifour_8GB() {
+  totalMemory="$(awk '/MemTotal/ {print $2}' /proc/meminfo)"
+  if is_pifour && [[ $totalMemory -gt 5000000 ]]; then return 0; else return 1; fi
+}
 is_pi() {
   if is_pizero || is_pizerow || is_pione || is_cmone || is_pitwo || is_pithree || is_cmthree || is_pithreeplus || is_cmthreeplus || is_pifour; then return 0; fi
   return 1

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -129,8 +129,12 @@ init_zram_mounts() {
 }
 
 zram_setup() {
+  if is_pifour_8GB; then
+    echo -n "$(timestamp) [openHABian] We've detected you're using the 8GB model of the RPi4. It is known to not work with ZRAM."
+    zraminstall="disable"
+  fi
   if [[ -n "$UNATTENDED" ]] && [[ "${zraminstall:-enable}" == "disable" ]]; then
-    echo -n "$(timestamp) [openHABian] Skipping ZRAM install as requested per config."
+    echo -n "$(timestamp) [openHABian] Skipping ZRAM install as requested."
     return 1
   fi
   if is_arm; then

--- a/includes/set-partuuid
+++ b/includes/set-partuuid
@@ -1,0 +1,196 @@
+#!/bin/bash
+
+# shamelessly copied from https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=196778
+
+
+trap '{ stty sane; echo ""; errexit "Aborted"; }' SIGINT SIGTERM
+
+MNTPATH="/tmp/set-partuuid-mnt"
+
+mntpart()
+{
+  MNTED=TRUE
+  if [ ! -d "${MNTPATH}/" ]; then
+    mkdir "${MNTPATH}/"
+    if [ $? -ne 0 ]; then
+      errexit "Unable to make partition mount point"
+    fi
+  fi
+  mount "$1" "${MNTPATH}/"
+  if [ $? -ne 0 ]; then
+    errexit "Unable to mount $2 partition"
+  fi
+}
+
+umntpart()
+{
+  umount "${MNTPATH}/"
+  if [ $? -ne 0 ]; then
+    errexit "Unable to unmount partition"
+  fi
+  rm -r "${MNTPATH}/"
+  MNTED=FALSE
+}
+
+errexit()
+{
+  echo ""
+  echo "$1"
+  echo ""
+  if [ "${MNTED}" = "TRUE" ]; then
+    umount "${MNTPATH}/" &> /dev/null
+    rm -rf "${MNTPATH}/" &> /dev/null
+  fi
+  echo "Usage: $0 device [ hhhhhhhh-02 | hhhhhhhh-hhhh-hhhh-hhhh-hhhhhhhhhhhh | random ]"
+  echo ""
+  exit 1
+}
+
+MNTED=FALSE
+if [ $(id -u) -ne 0 ]; then
+  errexit "$0 must be run as root user"
+fi
+PGMNAME="$(basename $0)"
+for PID in $(pidof -x -o %PPID "${PGMNAME}"); do
+  if [ ${PID} -ne $$ ]; then
+    errexit "${PGMNAME} is already running"
+  fi
+done
+gdisk -l "${DEVICE}" &> /dev/null
+if [ $? -eq 127 ]; then
+  echo ""
+  echo "gdisk not installed"
+  echo ""
+  echo -n "Ok to install gdisk (y/n)? "
+  while read -r -n 1 -s answer; do
+    if [[ "${answer}" = [yYnN] ]]; then
+      echo "${answer}"
+      if [[ "${answer}" = [yY] ]]; then
+        break
+      else
+        errexit "Aborted"
+      fi
+    fi
+  done
+  echo ""
+  echo "Installing gdisk"
+  echo ""
+  apt-get update
+  apt-get install gdisk
+fi
+DEVICE="$1"
+PARTUUID="$2"
+if [[ (! "${DEVICE}" =~ ^/dev/sd[a-z]2$ && ! "${DEVICE}" = "/dev/mmcblk0p2") || ! -b "${DEVICE}" ]]; then
+  errexit "Invalid DEVICE: ${DEVICE}"
+fi
+ORIGUUID="$(blkid "${DEVICE}" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+if [ "${PARTUUID}" = "" ]; then
+  PARTUUID="${ORIGUUID}"
+else
+  DEVICE_P="$(sed 's/[0-9]\+$//' <<< "${DEVICE}")"
+  DEVICE_D="${DEVICE_P}"
+  if [ "${DEVICE_D}" = "/dev/mmcblk0p" ]; then
+    DEVICE_D="${DEVICE_D:0:(${#DEVICE_D} - 1)}"
+  fi
+  SDCBOOT=FALSE
+  if [ -b /dev/mmcblk0p1 ]; then
+    mntpart "/dev/mmcblk0p1" "BOOT"
+    CLRPART="$(sed -n '/^[[:space:]]*#/!s|^.*root=\(\S\+\)\s.*|\1|p' "${MNTPATH}/cmdline.txt")"
+    if [ "${CLRPART}" != "/dev/mmcblk0p2" ]; then
+      CLRUUID="$(sed -n 's|PARTUUID=\(\S\+\)|\1|p' <<< "${CLRPART}")"
+      if [[ "${CLRUUID}" != "$(blkid /dev/mmcblk0p2 | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"  && "${CLRUUID}" = "${ORIGUUID}" ]]; then
+        SDCBOOT=TRUE
+      fi
+    fi
+    umntpart
+  fi
+  PTTYPE="$(blkid "${DEVICE_D}" | sed -n 's|^.*PTTYPE="\(\S\+\)".*|\1|p')"
+  if [[ "${PTTYPE}" != "dos" && "${PTTYPE}" != "gpt" ]]; then
+    errexit "Unsupported partition table type: ${PTTYPE}"
+  fi
+  PARTUUID="$(tr [A-Z] [a-z] <<< "${PARTUUID}")"
+  if [[ "${PARTUUID}" != "random" && (("${PTTYPE}" = "dos" && ! "${PARTUUID}" =~ ^[[:xdigit:]]{8}-02$) || \
+("${PTTYPE}" = "gpt" && ! "${PARTUUID}" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$)) ]]; then
+    errexit "Invalid PARTUUID: ${PARTUUID}"
+  fi
+  echo ""
+  echo -n "Set PARTUUID on ${DEVICE} to ${PARTUUID} (y/n)? "
+  while read -r -n 1 -s answer; do
+    if [[ "${answer}" = [yYnN] ]]; then
+      echo "${answer}"
+      if [[ "${answer}" = [yY] ]]; then
+        break
+      else
+        errexit "Aborted"
+      fi
+    fi
+  done
+  ORIGUUID_1="$(blkid "${DEVICE_P}1" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+  ORIGUUID_2="$(blkid "${DEVICE_P}2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+  if [ "${PTTYPE}" = "dos" ]; then
+    if [ "${PARTUUID}" = "random" ]; then
+      PTUUID="$(hexdump -n 4 -e '"%08X"' /dev/random | tr [A-Z] [a-z])"
+    else
+      PTUUID="${PARTUUID:0:(${#PARTUUID} - 3)}"
+    fi
+    fdisk "${DEVICE_D}" <<EOF &> /dev/null
+x
+i
+0x${PTUUID}
+r
+w
+EOF
+  else
+    if [ "${PARTUUID}" = "random" ]; then
+      sgdisk -u 2:'R' "${DEVICE_D}" > /dev/null
+    else
+      sgdisk -u 2:${PARTUUID} "${DEVICE_D}" > /dev/null
+    fi
+  fi
+  partprobe
+  PARTUUID="$(blkid "${DEVICE}" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+  PARTUUID_1="$(blkid "${DEVICE_P}1" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+  PARTUUID_2="$(blkid "${DEVICE_P}2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+  mntpart "${DEVICE_P}2" "ROOT"
+  sed -i "/^[[:space:]]*#/!s|^\(PARTUUID=\)${ORIGUUID_1}\(\s\+/boot\s\+.*\)$|\1${PARTUUID_1}\2|" "${MNTPATH}/etc/fstab"
+  sed -i "/^[[:space:]]*#/!s|^\(PARTUUID=\)${ORIGUUID_2}\(\s\+/\s\+.*\)$|\1${PARTUUID_2}\2|" "${MNTPATH}/etc/fstab"
+  umntpart
+  mntpart "${DEVICE_P}1" "BOOT"
+  sed -i "/^[[:space:]]*#/!s|^\(.*root=PARTUUID=\)${ORIGUUID_2}\(\s\+.*\)$|\1${PARTUUID_2}\2|" "${MNTPATH}/cmdline.txt"
+  umntpart
+  if [ "${SDCBOOT}" = "TRUE" ]; then
+    mntpart "/dev/mmcblk0p1" "SD card BOOT"
+    sed -i "/^[[:space:]]*#/!s|^\(.*root=PARTUUID=\)${ORIGUUID_2}\(\s\+.*\)$|\1${PARTUUID_2}\2|" "${MNTPATH}/cmdline.txt"
+    umntpart
+  fi
+fi
+echo ""
+echo "PARTUUID on ${DEVICE} is set to ${PARTUUID}"
+if [ -b /dev/mmcblk0 ]; then
+  if [[ "${DEVICE}" != "/dev/mmcblk0p2" && "$(blkid /dev/mmcblk0p2 | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')" = "${PARTUUID}" ]]; then
+    echo ""
+    echo "WARNING : SD card (/dev/mmcblk0p2) and USB device (${DEVICE}) have the same PARTUUID (${PARTUUID}) : SD card will boot instead of USB device"
+  fi
+fi
+DEV_LIST=()
+if [ -b /dev/mmcblk0 ]; then
+  DEV_LIST+=/dev/mmcblk0p2
+fi
+DEV_LIST+=($(ls -l /dev/sd?2 2> /dev/null | sed -n 's|^.*\(/dev/.*\)|\1|p'))
+if [ ${#DEV_LIST[@]} -gt 1 ]; then
+  for i in ${!DEV_LIST[@]}; do
+    if [ ${i} -lt $((${#DEV_LIST[@]} - 1)) ]; then
+      j=$((i + 1))
+      while [ ${j} -lt ${#DEV_LIST[@]} ]; do
+        if [ "$(blkid "${DEV_LIST[i]}" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')" = "$(blkid "${DEV_LIST[j]}" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')" ];then
+          if [[ "${DEV_LIST[i]}" != "/dev/mmcblk0p2" && ("${DEV_LIST[i]}" = "${DEVICE}" || "${DEV_LIST[j]}" = "${DEVICE}") ]]; then
+            echo ""
+            echo "WARNING : ${DEV_LIST[i]} and ${DEV_LIST[j]} have the same PARTUUID : $(blkid "${DEV_LIST[i]}" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')"
+          fi
+        fi
+      ((j += 1))
+      done
+    fi
+  done
+fi
+echo ""


### PR DESCRIPTION
To avoid that the external partition is mounted on boot because it has the same PARTUUID as the internal SD.

Apologies for the zram issue I mixed in (I forgot to branch again).
Everybody with a 8GB RPi seems to have this problem for the time being so I thought I'd drop ZRAM on this HW until a fix or workaround is found.

Signed-off-by: Markus Storm <markus.storm@gmx.net>