### PR TITLE
modify SD dump to dump single partitions only 

### DIFF
--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -386,8 +386,8 @@ mirror_SD() {
       fi
     done
     echo "Taking a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
-    if ! cond_redirect dd if="${src}1" bs=1M of="${dest}1"; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
-    if ! cond_redirect dd if="${src}2" bs=1M of="${dest}2"; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
+    if ! cond_redirect dd if="${src}p1" bs=1M of="${dest}1"; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
+    if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2"; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
     if ! (yes | cond_redirect set-partuuid "${dest}2" random); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -491,7 +491,7 @@ setup_mirror_SD() {
   fi
 
   if [[ -n $INTERACTIVE ]]; then
-    if ! (whiptail --title "Copy internal SD to $dest" --yes-button "Continue" --no-button "Back" --yesno "$infoText" 22 116); then echo "CANCELED"; return 0; fi
+    if ! (whiptail --title "Copy internal SD to $dest" --yes-button "Continue" --no-button "Back" --yesno "$infoText" 12 116); then echo "CANCELED"; return 0; fi
   fi
 
   mountUnit="$(basename "${storageDir}").mount"

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -353,7 +353,7 @@ mirror_SD() {
   local storageDir="${storagedir:-/storage}"
   local syncMount="${storageDir}/syncmount"
   local dirty="no"
-  local dumpInfoText="For your information as the operator of this openHABian system:\\A timed background job to run semiannually has just created a full raw device copy of your RPI's internal SD card.\\nOnly partitions to contain openHABian (/boot and / partitions 1 & 2) were copied."
+  local dumpInfoText="For your information as the operator of this openHABian system:\\nA timed background job to run semiannually has just created a full raw device copy of your RPI's internal SD card.\\nOnly partitions to contain openHABian (/boot and / partitions 1 & 2) were copied."
   # shellcheck disable=SC2154
   if [[ -n "$INTERACTIVE" ]]; then
     select_blkdev "^sd" "Setup SD mirroring" "Select the USB attached disk device to copy the internal SD card data to"

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -348,7 +348,7 @@ amanda_setup() {
 ##
 mirror_SD() {
   local src="/dev/mmcblk0"
-  local dest
+  local dest="${2:-${backupdrive}}"
   local start
   local storageDir="${storagedir:-/storage}"
   local syncMount="${storageDir}/syncmount"
@@ -357,14 +357,6 @@ mirror_SD() {
   local partUUID
   local origUUID
 
-  # shellcheck disable=SC2154
-  if [[ -n "$INTERACTIVE" ]]; then
-    select_blkdev "^sd" "Setup SD mirroring" "Select the USB attached disk device to copy the internal SD card data to"
-    if [[ -z "$retval" ]]; then return 0; fi
-    dest="/dev/$retval"
-  else
-    dest="${2:-${backupdrive}}"
-  fi
   if [[ "${src}" == "${dest}" ]]; then
     echo "FAILED (source = destination)"
     return 1

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -353,7 +353,7 @@ mirror_SD() {
   local storageDir="${storagedir:-/storage}"
   local syncMount="${storageDir}/syncmount"
   local dirty="no"
-  local dumpInfoText="For your information as the operator of this openHABian system:\\nA timed background job to run semiannually has just created a full raw device copy of your RPI's internal SD card.\\nOnly partitions to contain openHABian (/boot and / partitions 1 & 2) were copied."
+  local dumpInfoText="For your information as the operator of this openHABian system:\nA timed background job to run semiannually has just created a full raw device copy of your RPI's internal SD card.\nOnly partitions to contain openHABian (/boot and / partitions 1 & 2) were copied."
   local partUUID
   local origUUID
 

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -394,7 +394,7 @@ mirror_SD() {
     umount "$syncMount"
     mount "${dest}2" "$syncMount"
     sed -i "s|${origPartUUID}|${partUUID}|g" "${syncMount}"/etc/fstab
-    rm -f "/mnt/etc/systemd/system/${storageDir}".mount
+    rm -f "${syncMount}/etc/systemd/system/${storageDir}".mount
     umount "$syncMount"
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -394,6 +394,8 @@ mirror_SD() {
     umount "$syncMount"
     mount "${dest}2" "$syncMount"
     rm -f "/mnt/etc/systemd/system/${storageDir}".mount
+    if ! cp "${BASEDIR:-/opt/openhabian}"/includes/gen-by-uuid.service "${serviceTargetDir}/"; then echo "FAILED (create uuid links on boot)"; return 1; fi
+    ln -s ../gen-by-uuid.service /mnt/etc/systemd/system/basic.target.wants/gen-by-uuid.service
     umount "$syncMount"
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -393,9 +393,8 @@ mirror_SD() {
     sed -i "s|${origPartUUID}|${partUUID}|g" "${syncMount}"/cmdline.txt
     umount "$syncMount"
     mount "${dest}2" "$syncMount"
+    sed -i "s|${origPartUUID}|${partUUID}|g" "${syncMount}"/etc/fstab
     rm -f "/mnt/etc/systemd/system/${storageDir}".mount
-    if ! cp "${BASEDIR:-/opt/openhabian}"/includes/gen-by-uuid.service "${serviceTargetDir}/"; then echo "FAILED (create uuid links on boot)"; return 1; fi
-    ln -s ../gen-by-uuid.service /mnt/etc/systemd/system/basic.target.wants/gen-by-uuid.service
     umount "$syncMount"
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -376,7 +376,16 @@ mirror_SD() {
     return 1
   fi
   if [[ "$1" == "raw" ]]; then
-    echo "Creating a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
+
+    for i in 1 2; do
+      srcSize="$(blockdev --getsize64 "$src"p${i})"
+      destSize="$(blockdev --getsize64 "$dest"${i})"
+      if [[ "$destSize" -lt "$destSize" ]]; then
+        echo "FAILED (raw device copy of ${src}${i})"
+        return 1
+      fi
+    done
+    echo "Taking a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
     if ! cond_redirect dd if="${src}1" bs=1M of="${dest}1"; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
     if ! cond_redirect dd if="${src}2" bs=1M of="${dest}2"; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
     if ! (yes | cond_redirect set-partuuid "${dest}2" random); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -387,7 +387,7 @@ mirror_SD() {
     if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2" status=progress; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
     #origPartUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')
     origPartUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p' | sed -e 's/-02//g')
-    if ! partUUID=$(yes | cond_redirect set-partuuid "${dest}2" random | awk '/^PARTUUID/ { print $7 }'); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
+    if ! partUUID=$(yes | cond_redirect set-partuuid "${dest}2" random | awk '/^PARTUUID/ { print substr($7,1,length($7) - 3) }'); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect tune2fs "${dest}2" -U random; then echo "FAILED (set random UUID)"; dirty="yes"; fi
     mount "${dest}1" "$syncMount"
     sed -i "s|${origPartUUID}|${partUUID}|g" "${syncMount}"/cmdline.txt

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -494,7 +494,8 @@ setup_mirror_SD() {
     if ! (whiptail --title "Copy internal SD to $dest" --yes-button "Continue" --no-button "Back" --yesno "$infoText" 22 116); then echo "CANCELED"; return 0; fi
   fi
 
-  systemctl stop "$(basename "${storageDir}").mount"
+  mountUnit="$(basename "${storageDir}").mount"
+  systemctl stop "${mountUnit}"
   # copy partition table
   start="$(fdisk -l /dev/mmcblk0 | head -1 | cut -d' ' -f7)"
   ((destSize-=start))
@@ -503,7 +504,6 @@ setup_mirror_SD() {
   cond_redirect mke2fs -F -t ext4 "${dest}3"
   mirror_SD "raw" "${dest}"
 
-  mountUnit="$(basename "${storageDir}").mount"
   # shellcheck disable=SC2154
   if ! sed -e "s|%DEVICE|${dest}3|g" -e "s|%STORAGE|${storageDir}|g" "${BASEDIR:-/opt/openhabian}"/includes/storage.mount > "${serviceTargetDir}"/"${mountUnit}"; then echo "FAILED (create storage mount)"; fi
   if ! cond_redirect systemctl enable --now "${mountUnit}"; then echo "FAILED (enable storage mount)"; return 1; fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -383,10 +383,8 @@ mirror_SD() {
       fi
     done
     echo "Taking a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
-    ((srcSize="$(blockdev --getsize64 "$src"p1)" / 1024 / 1024))
-    if ! cond_redirect dd if="${src}p1" bs=1M count="${srcSize}" of="${dest}1" status=progress; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
-    ((srcSize="$(blockdev --getsize64 "$src"p2)" / 1024 / 1024))
-    if ! cond_redirect dd if="${src}p2" bs=1M count="${srcSize}" of="${dest}2" status=progress; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
+    if ! cond_redirect dd if="${src}p1" bs=1M of="${dest}1" status=progress; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
+    if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2" status=progress; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
     #origPartUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')
     origPartUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p' | sed -e 's/-02//g')
     if ! partUUID=$(yes | cond_redirect set-partuuid "${dest}2" random | awk '/^PARTUUID/ { print $7 }'); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -394,7 +394,7 @@ mirror_SD() {
       echo "OK"
     fi
     # shellcheck disable=SC2154
-    echo "${dumpInfoText}" | Mail -s "SD card raw copy dump" "$adminmail"
+    echo "${dumpInfoText}" | mail -s "SD card raw copy dump" "$adminmail"
     return 0
   fi
 

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -494,7 +494,7 @@ setup_mirror_SD() {
   # copy partition table
   start="$(fdisk -l /dev/mmcblk0 | head -1 | cut -d' ' -f7)"
   ((destSize-=start))
-  (sfdisk -d /dev/mmcblk0; echo "/dev/mmcblk0p3 : start=${start},size=${destSize}, type=83") | sfdisk "$dest"
+  (sfdisk -d /dev/mmcblk0; echo "/dev/mmcblk0p3 : start=${start},size=${destSize}, type=83") | sfdisk --force "$dest"
   partprobe
   cond_redirect mke2fs -F -t ext4 "${dest}3"
   mirror_SD "raw" "${dest}"

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -380,7 +380,7 @@ mirror_SD() {
     for i in 1 2; do
       srcSize="$(blockdev --getsize64 "$src"p${i})"
       destSize="$(blockdev --getsize64 "$dest"${i})"
-      if [[ "$destSize" -lt "$destSize" ]]; then
+      if [[ "$destSize" -lt "$srcSize" ]]; then
         echo "FAILED (raw device copy of ${src}${i} larger than ${dest}${i})"
         return 1
       fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -384,8 +384,8 @@ mirror_SD() {
       fi
     done
     echo "Taking a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
-    if ! cond_redirect dd if="${src}p1" bs=1M of="${dest}1"; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
-    if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2"; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
+    if ! cond_redirect dd if="${src}p1" bs=1M of="${dest}1" status=progress; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
+    if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2" status=progress; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
     if ! partUUID=$(yes | cond_redirect set-partuuid "${dest}2" random | awk '/^PARTUUID/ { print $7 }'); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     origUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')
     mount "${dest}1" "$syncMount"

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -381,7 +381,7 @@ mirror_SD() {
       srcSize="$(blockdev --getsize64 "$src"p${i})"
       destSize="$(blockdev --getsize64 "$dest"${i})"
       if [[ "$destSize" -lt "$destSize" ]]; then
-        echo "FAILED (raw device copy of ${src}${i})"
+        echo "FAILED (raw device copy of ${src}${i} larger than ${dest}${i})"
         return 1
       fi
     done

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -385,7 +385,6 @@ mirror_SD() {
     echo "Taking a raw partition copy, be prepared this may take long such as 20-30 minutes for a 16 GB SD card"
     if ! cond_redirect dd if="${src}p1" bs=1M of="${dest}1" status=progress; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
     if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2" status=progress; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
-    #origPartUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p')
     origPartUUID=$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p' | sed -e 's/-02//g')
     if ! partUUID=$(yes | cond_redirect set-partuuid "${dest}2" random | awk '/^PARTUUID/ { print substr($7,1,length($7) - 3) }'); then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect tune2fs "${dest}2" -U random; then echo "FAILED (set random UUID)"; dirty="yes"; fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -491,6 +491,9 @@ setup_mirror_SD() {
     echo "FAILED (insufficient space)"; return 1;
   fi
 
+  if [[ -n $INTERACTIVE ]]; then
+    if ! (whiptail --title "Copy internal SD to $dest" --yes-button "Continue" --no-button "Back" --yesno "$infoText" 22 116); then echo "CANCELED"; return 0; fi
+  fi
   # copy partition table
   start="$(fdisk -l /dev/mmcblk0 | head -1 | cut -d' ' -f7)"
   ((destSize-=start))
@@ -504,9 +507,6 @@ setup_mirror_SD() {
   if ! sed -e "s|%DEVICE|${dest}3|g" -e "s|%STORAGE|${storageDir}|g" "${BASEDIR:-/opt/openhabian}"/includes/storage.mount > "${serviceTargetDir}"/"${mountUnit}"; then echo "FAILED (create storage mount)"; fi
   if ! cond_redirect systemctl enable --now "${mountUnit}"; then echo "FAILED (enable storage mount)"; return 1; fi
 
-  if [[ -n $INTERACTIVE ]]; then
-    if ! (whiptail --title "Copy system root to $dest" --yes-button "Continue" --no-button "Back" --yesno "$infoText" 22 116); then echo "CANCELED"; return 0; fi
-  fi
 
   if ! sed -e "s|%DEST|${dest}|g" "${BASEDIR:-/opt/openhabian}"/includes/sdrawcopy.service_template > "${serviceTargetDir}"/sdrawcopy.service; then echo "FAILED (create raw SD copy service)"; fi
   if ! sed -e "s|%DEST|${dest}|g" "${BASEDIR:-/opt/openhabian}"/includes/sdrsync.service_template > "${serviceTargetDir}"/sdrsync.service; then echo "FAILED (create rsync service)"; fi

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -353,7 +353,7 @@ mirror_SD() {
   local storageDir="${storagedir:-/storage}"
   local syncMount="${storageDir}/syncmount"
   local dirty="no"
-  local dumpInfoText="For your information as the operator of this openHABian system:\nA timed background job to run semiannually has just created a full raw device copy of your RPI's internal SD card.\nOnly partitions to contain openHABian (/boot and / partitions 1 & 2) were copied."
+  local dumpInfoText="For your information as the operator of this openHABian system:\\nA timed background job to run semiannually has just created a full raw device copy of your RPI's internal SD card.\\nOnly partitions to contain openHABian (/boot and / partitions 1 & 2) were copied."
   local partUUID
   local origUUID
 
@@ -396,7 +396,7 @@ mirror_SD() {
       echo "OK"
     fi
     # shellcheck disable=SC2154
-    echo "${dumpInfoText}" | mail -s "SD card raw copy dump" "$adminmail"
+    echo -e "${dumpInfoText}" | mail -s "SD card raw copy dump" "$adminmail"
     return 0
   fi
 

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -384,7 +384,8 @@ mirror_SD() {
     if [[ "$dirty" == "no" ]]; then
       echo "OK"
     fi
-    echo "${dumpInfoText}" | Mail -s "SD card raw copy dump" $adminmail
+    # shellcheck disable=SC2154
+    echo "${dumpInfoText}" | Mail -s "SD card raw copy dump" "$adminmail"
     return 0
   fi
 

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -394,7 +394,7 @@ mirror_SD() {
     umount "$syncMount"
     mount "${dest}2" "$syncMount"
     sed -i "s|${origPartUUID}|${partUUID}|g" "${syncMount}"/etc/fstab
-    rm -f "${syncMount}/etc/systemd/system/${storageDir}".mount
+    sed -i 's|^What=.*|What=/dev/mmcblk0p3|g' "${syncMount}/etc/systemd/system/${storageDir}".mount
     umount "$syncMount"
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -439,6 +439,6 @@ select_blkdev() {
   else
     ((count=${#array[@]} + 8))
     # shellcheck disable=SC2034
-    retval="$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "$3" ${count} 76 0 "${array[@]}" 3>&1 1>&2 2>&3)"
+    retval="$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "\n${3}" ${count} 76 0 "${array[@]}" 3>&1 1>&2 2>&3)"
   fi
 }

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -437,7 +437,8 @@ select_blkdev() {
     retval=0
     whiptail --title "$2" --msgbox "No block device to match pattern \"${1}\" found." 7 75 3>&1 1>&2 2>&3
   else
+    ((count=${#array[@]} + 8))
     # shellcheck disable=SC2034
-    retval="$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "$3" 12 76 4 "${array[@]}" 3>&1 1>&2 2>&3)"
+    retval="$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "$3" ${count} 76 0 "${array[@]}" 3>&1 1>&2 2>&3)"
   fi
 }

--- a/includes/sdrawcopy.timer
+++ b/includes/sdrawcopy.timer
@@ -2,7 +2,7 @@
 Description=Run SD raw dump 1st of month
 
 [Timer]
-OnCalendar=*-01,07-01 01:30:00
+OnCalendar=*-01,07-01 01:15:00
 Persistent=true
 
 [Install]

--- a/includes/sdrawcopy.timer
+++ b/includes/sdrawcopy.timer
@@ -2,7 +2,7 @@
 Description=Run SD raw dump 1st of month
 
 [Timer]
-OnCalendar=*-*-01 02:00:00
+OnCalendar=*-01,07-01 01:30:00
 Persistent=true
 
 [Install]

--- a/includes/sdrsync.timer
+++ b/includes/sdrsync.timer
@@ -2,7 +2,7 @@
 Description=Run SD sync daily except on 1st of month (when a raw dump is made)
 
 [Timer]
-OnCalendar=*-*-02..31 02:00:00
+OnCalendar=*-*-02,09,16,23 02:00:00
 Persistent=true
 
 [Install]

--- a/includes/storage.mount
+++ b/includes/storage.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=/storage mount
+Description=%STORAGE mount
 Before=zram-config.service
 
 [Mount]


### PR DESCRIPTION
Fixes: #1151  
(hopefully)
raw device partitions 1 (/boot) and 2 (/) only to avoid overwriting partition table or subsequent partitions

Signed-off-by: Markus Storm <markus.storm@gmx.net>