### PR TITLE
dnsutils package => bind9-dnsutils

### DIFF
--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -442,3 +442,17 @@ select_blkdev() {
     retval="$(whiptail --title "$2" --cancel-button Cancel --ok-button Select --menu "\n${3}" ${count} 76 0 "${array[@]}" 3>&1 1>&2 2>&3)"
   fi
 }
+## install bind9-dnsutils package if available (currently only in sid and focal)
+## else resort to dnsutils
+##
+##    install_dnsutils()
+##
+install_dnsutils() {
+  if apt-cache show bind9-dnsutils &>/dev/null; then
+    apt-get install bind9-dnsutils
+  else
+    apt-get install dnsutils
+  fi
+
+  return $?
+}

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -449,9 +449,9 @@ select_blkdev() {
 ##
 install_dnsutils() {
   if apt-cache show bind9-dnsutils &>/dev/null; then
-    apt-get install bind9-dnsutils
+    apt-get install --yes bind9-dnsutils
   else
-    apt-get install dnsutils
+    apt-get install --yes dnsutils
   fi
 
   return $?

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -690,11 +690,11 @@ telldus_core_setup() {
   if is_buster; then
     echo -n "$(timestamp) [openHABian] Adding libconfuse1 repository to apt... "
     echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/01release
-#    if is_raspbian ; then
-#      echo "deb http://raspbian.raspberrypi.org/raspbian/ stretch main" > /etc/apt/sources.list.d/raspbian-stretch.list
-#    else
-#      echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/debian-stretch.list
-#    fi
+    if is_raspbian ; then
+      echo "deb http://raspbian.raspberrypi.org/raspbian/ stretch main" > /etc/apt/sources.list.d/raspbian-stretch.list
+    else
+      echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/debian-stretch.list
+    fi
     echo "OK"
   fi
   echo -n "$(timestamp) [openHABian] Installing libconfuse1... "

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -699,7 +699,7 @@ telldus_core_setup() {
   fi
   echo -n "$(timestamp) [openHABian] Installing libconfuse1... "
   if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-//  if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+#  if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
   if cond_redirect apt-get install --yes libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
 
   if ! add_keys "https://s3.eu-central-1.amazonaws.com/download.telldus.com/debian/telldus-public.key"; then return 1; fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -93,10 +93,11 @@ exim_setup() {
   local logrotateFile="/etc/logrotate.d/exim4"
   local introText
 
-  if ! dpkg -s 'mailutils' 'exim4' 'bind9-dnsutils' &> /dev/null; then
-    echo -n "$(timestamp) [openHABian] Installing MTA required packages (mailutils, exim4, bind9-dnsutils,)... "
-    if cond_redirect apt-get install --yes exim4 bind9-dnsutils mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
+  if ! dpkg -s 'mailutils' 'exim4' &> /dev/null; then
+    echo -n "$(timestamp) [openHABian] Installing MTA required packages (mailutils, exim4, dnsutils)... "
+    if cond_redirect apt-get install --yes exim4 mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
+  if cond_redirect install_dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
 
   interfaces="$(dig +short "$HOSTNAME" | tr '\n' ';')127.0.0.1;::1"
   relaynets="$(dig +short "$HOSTNAME" | cut -d'.' -f1-3).0/24"
@@ -517,8 +518,8 @@ nginx_setup() {
   local validDomain="false"
 
   if ! [[ -x $(command -v dig) ]]; then
-    echo -n "$(timestamp) [openHABian] Installing nginx required packages (bind9-dnsutils)... "
-    if cond_redirect apt-get install --yes bind9-dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
+    echo -n "$(timestamp) [openHABian] Installing nginx required packages (dnsutils)... "
+    if cond_redirect install_dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
   function comment {
@@ -704,7 +705,9 @@ telldus_core_setup() {
 
   echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
   #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
-  if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  if cond_redirect apt-get install --yes libftdi; then echo "OK"; else echo "FAILED"; return 1; fi
+  if (cond_redirect apt-get download --yes libconfuse1 libconfuse-common libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  #if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
   ls -l /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core* /var/cache/apt/archives/telldus-core* libconfuse* libftdi* libtelldus-core* telldus-core*
   if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
 

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -699,8 +699,9 @@ telldus_core_setup() {
   fi
   echo -n "$(timestamp) [openHABian] Installing libconfuse1... "
   if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-#  if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
-  if cond_redirect apt-get install --yes libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+  #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core; then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  if cond_redirect dpkg --ignore-depends=libconfuse-common -i  /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
 
   if ! add_keys "https://s3.eu-central-1.amazonaws.com/download.telldus.com/debian/telldus-public.key"; then return 1; fi
 
@@ -709,7 +710,8 @@ telldus_core_setup() {
   if cond_redirect apt-get update; then echo "OK"; else echo "FAILED (update apt lists)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Installing telldus-core... "
-  if cond_redirect apt-get install --yes libjna-java telldus-core; then echo "OK"; else echo "FAILED"; return 1; fi
+  #if cond_redirect apt-get install --yes libjna-java telldus-core; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/telldus-core*; then echo "OK"; else echo "FAILED (install Telldus package)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting up telldus-core service... "
   if ! cond_redirect install -m 644 "${BASEDIR:-/opt/openhabian}"/includes/telldusd.service /etc/systemd/system/telldusd.service; then echo "FAILED (copy service)"; return 1; fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -705,9 +705,7 @@ telldus_core_setup() {
 
   echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
   #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
-  if cond_redirect apt-get install --yes libftdi; then echo "OK"; else echo "FAILED"; return 1; fi
-  if (cond_redirect apt-get download --yes libconfuse1 libconfuse-common libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
-  #if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
   ls -l /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core* /var/cache/apt/archives/telldus-core* libconfuse* libftdi* libtelldus-core* telldus-core*
   if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
 

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -690,11 +690,11 @@ telldus_core_setup() {
   if is_buster; then
     echo -n "$(timestamp) [openHABian] Adding libconfuse1 repository to apt... "
     echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/01release
-/*    if is_raspbian ; then
-      echo "deb http://raspbian.raspberrypi.org/raspbian/ stretch main" > /etc/apt/sources.list.d/raspbian-stretch.list
-    else
-      echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/debian-stretch.list
-    fi */
+#    if is_raspbian ; then
+#      echo "deb http://raspbian.raspberrypi.org/raspbian/ stretch main" > /etc/apt/sources.list.d/raspbian-stretch.list
+#    else
+#      echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/debian-stretch.list
+#    fi
     echo "OK"
   fi
   echo -n "$(timestamp) [openHABian] Installing libconfuse1... "

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -697,17 +697,15 @@ telldus_core_setup() {
     fi
     echo "OK"
   fi
-  echo -n "$(timestamp) [openHABian] Installing libconfuse1... "
-  if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-  #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
-  if cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core; then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
-  if cond_redirect dpkg --ignore-depends=libconfuse-common -i  /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
-
   if ! add_keys "https://s3.eu-central-1.amazonaws.com/download.telldus.com/debian/telldus-public.key"; then return 1; fi
-
   echo -n "$(timestamp) [openHABian] Adding telldus repository to apt... "
   echo "deb https://s3.eu-central-1.amazonaws.com/download.telldus.com unstable main" > /etc/apt/sources.list.d/telldus-unstable.list
   if cond_redirect apt-get update; then echo "OK"; else echo "FAILED (update apt lists)"; return 1; fi
+
+  echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
+  #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core; then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Installing telldus-core... "
   #if cond_redirect apt-get install --yes libjna-java telldus-core; then echo "OK"; else echo "FAILED"; return 1; fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -690,16 +690,17 @@ telldus_core_setup() {
   if is_buster; then
     echo -n "$(timestamp) [openHABian] Adding libconfuse1 repository to apt... "
     echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/01release
-    if is_raspbian ; then
+/*    if is_raspbian ; then
       echo "deb http://raspbian.raspberrypi.org/raspbian/ stretch main" > /etc/apt/sources.list.d/raspbian-stretch.list
     else
       echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/debian-stretch.list
-    fi
+    fi */
     echo "OK"
   fi
   echo -n "$(timestamp) [openHABian] Installing libconfuse1... "
   if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-  if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+//  if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect apt-get install --yes libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
 
   if ! add_keys "https://s3.eu-central-1.amazonaws.com/download.telldus.com/debian/telldus-public.key"; then return 1; fi
 

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -704,7 +704,8 @@ telldus_core_setup() {
 
   echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
   #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
-  if cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core; then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
+  ls -l /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core* /var/cache/apt/archives/telldus-core* libconfuse* libftdi* libtelldus-core* telldus-core*
   if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Installing telldus-core... "

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -705,6 +705,7 @@ telldus_core_setup() {
 
   echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
   #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect apt-get install --yes libusb; then echo "OK"; else echo "FAILED"; return 1; fi
   if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
   ls -l /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core* /var/cache/apt/archives/telldus-core* libconfuse* libftdi* libtelldus-core* telldus-core*
   if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -93,9 +93,9 @@ exim_setup() {
   local logrotateFile="/etc/logrotate.d/exim4"
   local introText
 
-  if ! dpkg -s 'mailutils' 'exim4' 'dnsutils' &> /dev/null; then
-    echo -n "$(timestamp) [openHABian] Installing MTA required packages (mailutils, exim4, dnsutils,)... "
-    if cond_redirect apt-get install --yes exim4 dnsutils mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
+  if ! dpkg -s 'mailutils' 'exim4' 'bind9-dnsutils' &> /dev/null; then
+    echo -n "$(timestamp) [openHABian] Installing MTA required packages (mailutils, exim4, bind9-dnsutils,)... "
+    if cond_redirect apt-get install --yes exim4 bind9-dnsutils mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
   interfaces="$(dig +short "$HOSTNAME" | tr '\n' ';')127.0.0.1;::1"
@@ -517,8 +517,8 @@ nginx_setup() {
   local validDomain="false"
 
   if ! [[ -x $(command -v dig) ]]; then
-    echo -n "$(timestamp) [openHABian] Installing nginx required packages (dnsutils)... "
-    if cond_redirect apt-get install --yes dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
+    echo -n "$(timestamp) [openHABian] Installing nginx required packages (bind9-dnsutils)... "
+    if cond_redirect apt-get install --yes bind9-dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
   function comment {

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -686,8 +686,8 @@ telldus_core_setup() {
     dpkg --add-architecture armhf
   fi
 
-  # Maybe add new repository to be able to install libconfuse1
-  # libconfuse1 is only available from old stretch repos, but currently still needed
+  # Tellstick is no longer supported.
+  # Need to link against libconfuse1 which is only available from old stretch repos
   if is_buster; then
     echo -n "$(timestamp) [openHABian] Adding libconfuse1 repository to apt... "
     echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/01release
@@ -704,14 +704,12 @@ telldus_core_setup() {
   if cond_redirect apt-get update; then echo "OK"; else echo "FAILED (update apt lists)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
-  #if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
   if cond_redirect apt-get install --yes libusb; then echo "OK"; else echo "FAILED"; return 1; fi
   if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
   ls -l /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core* /var/cache/apt/archives/telldus-core* libconfuse* libftdi* libtelldus-core* telldus-core*
   if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Installing telldus-core... "
-  #if cond_redirect apt-get install --yes libjna-java telldus-core; then echo "OK"; else echo "FAILED"; return 1; fi
   if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/telldus-core*; then echo "OK"; else echo "FAILED (install Telldus package)"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting up telldus-core service... "

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -95,7 +95,7 @@ exim_setup() {
 
   if ! dpkg -s 'mailutils' 'exim4' &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Installing MTA required packages (mailutils, exim4, dnsutils)... "
-    if cond_redirect apt-get install --yes exim4 mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
+    if cond_redirect apt-get install --yes exim4 dnsutils mailutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
   if cond_redirect install_dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
 
@@ -686,8 +686,8 @@ telldus_core_setup() {
     dpkg --add-architecture armhf
   fi
 
-  # Tellstick is no longer supported.
-  # Need to link against libconfuse1 which is only available from old stretch repos
+  # Maybe add new repository to be able to install libconfuse1
+  # libconfuse1 is only available from old stretch repos, but currently still needed
   if is_buster; then
     echo -n "$(timestamp) [openHABian] Adding libconfuse1 repository to apt... "
     echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/01release
@@ -698,19 +698,18 @@ telldus_core_setup() {
     fi
     echo "OK"
   fi
+  echo -n "$(timestamp) [openHABian] Installing libconfuse1... "
+  if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
+  if cond_redirect apt-get install --yes --target-release "stretch" libconfuse1; then echo "OK"; else echo "FAILED"; return 1; fi
+
   if ! add_keys "https://s3.eu-central-1.amazonaws.com/download.telldus.com/debian/telldus-public.key"; then return 1; fi
+
   echo -n "$(timestamp) [openHABian] Adding telldus repository to apt... "
   echo "deb https://s3.eu-central-1.amazonaws.com/download.telldus.com unstable main" > /etc/apt/sources.list.d/telldus-unstable.list
   if cond_redirect apt-get update; then echo "OK"; else echo "FAILED (update apt lists)"; return 1; fi
 
-  echo -n "$(timestamp) [openHABian] Downloading libconfuse1 and Telldus packages..."
-  if cond_redirect apt-get install --yes libusb; then echo "OK"; else echo "FAILED"; return 1; fi
-  if (cd /var/cache/apt/archives; cond_redirect apt-get download --yes libconfuse1 libconfuse-common libftdi1 libtelldus-core2 telldus-core); then echo "OK"; else echo "FAILED (download Telldus libs)"; return 1; fi
-  ls -l /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core* /var/cache/apt/archives/telldus-core* libconfuse* libftdi* libtelldus-core* telldus-core*
-  if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/libconfuse* /var/cache/apt/archives/libftdi* /var/cache/apt/archives/libtelldus-core*; then echo "OK"; else echo "FAILED (install Telldus libs)"; return 1; fi
-
   echo -n "$(timestamp) [openHABian] Installing telldus-core... "
-  if cond_redirect dpkg --ignore-depends=libconfuse-common -i /var/cache/apt/archives/telldus-core*; then echo "OK"; else echo "FAILED (install Telldus package)"; return 1; fi
+  if cond_redirect apt-get install --yes libjna-java telldus-core; then echo "OK"; else echo "FAILED"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting up telldus-core service... "
   if ! cond_redirect install -m 644 "${BASEDIR:-/opt/openhabian}"/includes/telldusd.service /etc/systemd/system/telldusd.service; then echo "FAILED (copy service)"; return 1; fi

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -57,7 +57,7 @@ needed_packages() {
 
   if is_pizerow || is_pithree || is_pithreeplus || is_pifour; then
     echo -n "$(timestamp) [openHABian] Installing additional bluetooth packages... "
-    # phython3-bluez is not available in stretch so only add it if we are runnning on buster or later
+    # phython3-bluez is not available in stretch so only add it if we are running on buster or later
     if ! is_stretch; then
       bluetoothPackages+=" python3-bluez"
     fi

--- a/functions/vpn.bash
+++ b/functions/vpn.bash
@@ -110,8 +110,8 @@ create_wireguard_config() {
   local SERVERPRIVATE SERVERPUBLIC CLIENTPRIVATE CLIENTPUBLIC
 
   if ! [[ -x $(command -v dig) ]]; then
-    echo -n "$(timestamp) [openHABian] Installing Wireguard required packages (bind9-dnsutils)... "
-    if cond_redirect apt-get install --yes bind9-dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
+    echo -n "$(timestamp) [openHABian] Installing Wireguard required packages (dnsutils)... "
+    if install_dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
   if ! pubIP="$(get_public_ip)"; then echo "FAILED (public ip)"; return 1; fi

--- a/functions/vpn.bash
+++ b/functions/vpn.bash
@@ -110,8 +110,8 @@ create_wireguard_config() {
   local SERVERPRIVATE SERVERPUBLIC CLIENTPRIVATE CLIENTPUBLIC
 
   if ! [[ -x $(command -v dig) ]]; then
-    echo -n "$(timestamp) [openHABian] Installing Wireguard required packages (dnsutils)... "
-    if cond_redirect apt-get install --yes dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
+    echo -n "$(timestamp) [openHABian] Installing Wireguard required packages (bind9-dnsutils)... "
+    if cond_redirect apt-get install --yes bind9-dnsutils; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
   if ! pubIP="$(get_public_ip)"; then echo "FAILED (public ip)"; return 1; fi


### PR DESCRIPTION
as 'dnsutils' no longer is available in Ubuntu.
bind9-dnsutils is there for both OS.

Signed-off-by: Markus Storm <markus.storm@gmx.net>