### PR TITLE
Add admin user and group for non Raspi OS

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -62,7 +62,7 @@ else
   # THEN create default user AND default group (use $userdef for both, "openhabian" if not on RaspiOS that is)
   # Both, user and group, will be *renamed* below
   if ! [[ $(getent group "${userdef}") ]] || cond_redirect groupadd ${userdef}; then echo "FAILED (add default group $userdef)"; return 1; fi
-  if ! (id -u ${userdef} &> /dev/null || cond_redirect useradd --groups "${userdef}",openhab -s /bin/bash -d /var/tmp ${userdef}); then echo "FAILED (add default usergroup $userdef)"; return 1; fi
+  if ! (id -u ${userdef} &> /dev/null || cond_redirect useradd --groups "${userdef}",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp ${userdef}); then echo "FAILED (add default usergroup $userdef)"; return 1; fi
 fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -79,9 +79,9 @@ echo -n "$(timestamp) [openHABian] Changing default username and password... "
 # (2) did there exist a default user in generic Debian on x86 ? If no why did it work there before ? did it ?
 # (3) what happens on generic Debian on x86 ? Ubuntu on x86 ? Ubuntu,Armbian on RPi ?
 #
-# according to Elias on non image installs the user is queried ?
+# according to Elias on non image installs the end user is queried to input the username ?
 # https://github.com/openhab/openhabian/issues/665#issuecomment-522261443
-# is he? Is that only true fopr interactive installs ?
+# is he really ? Is that true for interactive installs ? I have not seen where.
 
 # shellcheck disable=SC2154
 #if [[ -z "${username+x}" ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -54,7 +54,7 @@ fi
 
 defaultUserAndGroup="openhabian"
 userName="${adminusername:-openhabian}"
-groupName="${admingroupname:-openhabian}"
+groupName="${userName}"
 if is_raspbian || is_raspios; then
   defaultUserAndGroup="pi"
   rm -f "/etc/sudoers.d/010_pi-nopasswd"

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -57,6 +57,7 @@ userName="${adminusername:-openhabian}"
 groupName="${admingroupname:-openhabian}"
 if is_raspbian || is_raspios; then
   defaultUserAndGroup="pi"
+  rm -f "/etc/sudoers.d/010_pi-nopasswd"
 fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -52,7 +52,7 @@ else
   echo "SKIPPED (Python not found)"
 fi
 
-defaultUserAndGroup=""openhabian"
+defaultUserAndGroup="openhabian"
 userName="${adminusername:-openhabian}"
 groupName="${admingroupname:-openhabian}"
 if is_raspbian || is_raspios; then
@@ -61,7 +61,7 @@ fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "
 # shellcheck disable=SC2154
-if [[ -v ${userName} ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
+if [[ -v ${userName} ]] || ! id "$defaultUserAndGroup" &> /dev/null || id "$userName" &> /dev/null; then
   echo "SKIPPED"
 else
   usermod -l "$userName" "$defaultUserAndGroup"

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -53,7 +53,7 @@ else
 fi
 
 defaultUserAndGroup="openhabian"
-userName="${adminusername:-openhabian}"
+userName="${username:-openhabian}"
 groupName="${userName}"
 if is_raspbian || is_raspios; then
   defaultUserAndGroup="pi"

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -52,46 +52,22 @@ else
   echo "SKIPPED (Python not found)"
 fi
 
-userdef="openhabian"
-
-# needs to work for non-RaspiOS (Ubuntu, Armbian) on RPi, too (was: "if is_pi")
+defaultUserAndGroup=""openhabian"
+userName="${adminusername:-openhabian}"
+groupName="${admingroupname:-openhabian}"
 if is_raspbian || is_raspios; then
-  userdef="pi"
-else
-  # IF not on RaspiOS (because in that case we have an image that the "pi" user exists in and we can rename that user)
-  # THEN create default user AND default group (use $userdef for both, "openhabian" if not on RaspiOS that is)
-  # Both, user and group, will be *renamed* below
-  if ! [[ $(getent group "${userdef}") ]] || cond_redirect groupadd ${userdef}; then echo "FAILED (add default group $userdef)"; return 1; fi
-  if ! (id -u ${userdef} &> /dev/null || cond_redirect useradd --groups "${userdef}",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp ${userdef}); then echo "FAILED (add default usergroup $userdef)"; return 1; fi
+  defaultUserAndGroup="pi"
 fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "
-
-# IF
-# (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
-# (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR
-# (3) the user whose name the end user entered as "username=" in openhabian.conf *exists* (and isn't empty because (1) applies, too)
-# THEN skip
-# ELSE rename the default user and default group to what is defined as username= in openhabian.conf
-#
-# QUESTIONS:
-# (1) will that do what we want it to
-# (2) did there exist a default user in generic Debian on x86 ? If no why did it work there before ? did it ?
-# (3) what happens on generic Debian on x86 ? Ubuntu on x86 ? Ubuntu,Armbian on RPi ?
-#
-# according to Elias on non image installs the end user is queried to input the username ?
-# https://github.com/openhab/openhabian/issues/665#issuecomment-522261443
-# is he really ? Is that true for interactive installs ? I have not seen where.
-
 # shellcheck disable=SC2154
-#if [[ -z "${username+x}" ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
-if [[ -v ${username} ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
+if [[ -v ${userName} ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
   echo "SKIPPED"
 else
-  usermod -l "$username" "$userdef"
-  usermod -m -d "/home/$username" "$username"
-  groupmod -n "$username" "$userdef"
-  echo "${username}:${userpw:-$username}" | chpasswd
+  usermod -l "$userName" "$defaultUserAndGroup"
+  usermod -m -d "/home/$userName" "$userName"
+  groupmod -n "$groupName" "$defaultUserAndGroup"
+  echo "${userName}:${userpw:-$userName}" | chpasswd
   echo "OK"
 fi
 

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -67,7 +67,6 @@ fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "
 
-# was macht der folgende Code ?
 # IF
 # (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
 # (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR

--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -53,13 +53,38 @@ else
 fi
 
 userdef="openhabian"
-if is_pi; then
+
+# ersetzt damit es auch für Ubuntu auf RPi funktioniert
+#if is_pi; then
+if is_raspbian || is_raspios; then
   userdef="pi"
 fi
+# was fehlt hier ?
+# WENN nicht auf RaspiOS (dann existiert "pi" und wird in userdef umbenannt)
+# DANN erzeuge Default-User UND Default-Group
+# da hinterher in *jedem* Fall der User $userdef und auch die Gruppe $userdef
+# umbenannt werden, sollten User $userdef und Group $userdef angelegt werden
+#
+if ! (id -u ${userdef} &> /dev/null || cond_redirect useradd --groups openhabian,openhab -s /bin/bash -d /var/tmp ${username}); then echo "FAILED (add default user)"; return 1; fi
 
 echo -n "$(timestamp) [openHABian] Changing default username and password... "
+
+# was macht der folgende Code ?
+# WENN
+# (1) der vom Benutzer in openhabian.conf eingetragene Usernamen-String *leer* ist ODER
+# (2) der Defaultuser ("pi" auf RaspiOS, "openhabian" auf anderen OS) nicht existiert ODER
+# (3) der vom Benutzer in die openhabian.conf eingetragene User *existiert* (und nicht leer ist wegen (1))
+# DANN mache nicht
+# ANSONSTEN benenne den Default-User in den in die openhabian.conf eingetragenen User um.
+#
+# ABER: was passiert auf non-rpi sowie bei Ubuntu auf RPi wenn es den user nicht gibt ?
+#       was passiert auf debian auf x86?
+#
+# laut Elias wird bei manueller Installation nach dem Usernamen gefragt ?
+
 # shellcheck disable=SC2154
-if [[ -z "${username+x}" ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
+#if [[ -z "${username+x}" ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
+if [[ -v ${username} ]] || ! id $userdef &> /dev/null || id "$username" &> /dev/null; then
   echo "SKIPPED"
 else
   usermod -l "$username" "$userdef"

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -7,8 +7,6 @@
 hostname=openHABianDevice
 # if exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
-# ... assigned to this group ...
-admingroupname=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -5,8 +5,10 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# the default user (with its working environment) will be renamed to this username given here ...
-username=openhabian
+# if exists, the default user (with its working environment) will be renamed to this username given here ...
+adminusername=openhabian
+# ... assigned to this group ...
+admingroupname=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -5,7 +5,7 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# if exists, the default user (with its working environment) will be renamed to this username given here ...
+# if it exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -6,7 +6,7 @@
 # Hostname to set this one to
 hostname=openHABianDevice
 # if it exists, the default user (with its working environment) will be renamed to this username given here ...
-adminusername=openhabian
+username=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.pi-raspios32.conf
+++ b/build-image/openhabian.pi-raspios32.conf
@@ -7,8 +7,6 @@
 hostname=openHABianDevice
 # if exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
-# ... assigned to this group ...
-admingroupname=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.pi-raspios32.conf
+++ b/build-image/openhabian.pi-raspios32.conf
@@ -5,8 +5,10 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# the default user (with its working environment) will be renamed to this username given here ...
-username=openhabian
+# if exists, the default user (with its working environment) will be renamed to this username given here ...
+adminusername=openhabian
+# ... assigned to this group ...
+admingroupname=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.pi-raspios32.conf
+++ b/build-image/openhabian.pi-raspios32.conf
@@ -5,7 +5,7 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# if exists, the default user (with its working environment) will be renamed to this username given here ...
+# if it exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian

--- a/build-image/openhabian.pi-raspios32.conf
+++ b/build-image/openhabian.pi-raspios32.conf
@@ -6,7 +6,7 @@
 # Hostname to set this one to
 hostname=openHABianDevice
 # if it exists, the default user (with its working environment) will be renamed to this username given here ...
-adminusername=openhabian
+username=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.pi-raspios64beta.conf
+++ b/build-image/openhabian.pi-raspios64beta.conf
@@ -7,8 +7,6 @@
 hostname=openHABianDevice
 # if exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
-# ... assigned to this group ...
-admingroupname=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.pi-raspios64beta.conf
+++ b/build-image/openhabian.pi-raspios64beta.conf
@@ -5,8 +5,10 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# the default user (with its working environment) will be renamed to this username given here ...
-username=openhabian
+# if exists, the default user (with its working environment) will be renamed to this username given here ...
+adminusername=openhabian
+# ... assigned to this group ...
+admingroupname=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/build-image/openhabian.pi-raspios64beta.conf
+++ b/build-image/openhabian.pi-raspios64beta.conf
@@ -5,7 +5,7 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# if exists, the default user (with its working environment) will be renamed to this username given here ...
+# if it exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian

--- a/build-image/openhabian.pi-raspios64beta.conf
+++ b/build-image/openhabian.pi-raspios64beta.conf
@@ -6,7 +6,7 @@
 # Hostname to set this one to
 hostname=openHABianDevice
 # if it exists, the default user (with its working environment) will be renamed to this username given here ...
-adminusername=openhabian
+username=openhabian
 # ... and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/functions/config.bash
+++ b/functions/config.bash
@@ -12,7 +12,7 @@ load_create_config() {
   if [[ -f $CONFIGFILE ]]; then
     echo -n "$(timestamp) [openHABian] Loading configuration file '${CONFIGFILE}'... "
     # on non Raspi OS image installations the admin user may be missing
-    if [[ ! $(getent group "${adminusername:-openhabian}") ]] || ! id -u "${adminusername:-openhabian}" &> /dev/null; then
+    if [[ ! $(getent group "${username:-openhabian}") ]] || ! id -u "${username:-openhabian}" &> /dev/null; then
       create_user_and_group
     fi
   elif ! [[ -f $CONFIGFILE ]] && [[ -f /boot/installer-config.txt ]]; then
@@ -25,7 +25,7 @@ load_create_config() {
     echo -n "$(timestamp) [openHABian] Setting up and loading configuration file '$CONFIGFILE' in manual setup... "
     if input="$(whiptail --title "openHABian Configuration Tool - Manual Setup" --inputbox "$questionText" 14 80 3>&1 1>&2 2>&3)" && id -u "$input" &> /dev/null; then
       if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/openhabian.conf.dist "$CONFIGFILE"; then echo "FAILED (copy configuration)"; exit 1; fi
-      if ! cond_redirect sed -i -e 's|^adminusername=.*$|adminusername='"${input}"'|g' "$CONFIGFILE"; then echo "FAILED (configure adminusername)"; exit 1; fi
+      if ! cond_redirect sed -i -e 's|^username=.*$|username='"${input}"'|g' "$CONFIGFILE"; then echo "FAILED (configure admin username)"; exit 1; fi
     else
       echo "FAILED"
       echo "$(timestamp) [openHABian] Error: The provided user name is not a valid system user. Please try again. Exiting..." 1>&2

--- a/functions/config.bash
+++ b/functions/config.bash
@@ -11,6 +11,10 @@ load_create_config() {
 
   if [[ -f $CONFIGFILE ]]; then
     echo -n "$(timestamp) [openHABian] Loading configuration file '${CONFIGFILE}'... "
+    # on non Raspi OS image installations the admin user may be missing
+    if [[ ! $(getent group "${adminusername:-openhabian}") ]] || ! id -u "${adminusername:-openhabian}" &> /dev/null; then
+      create_user_and_group
+    fi
   elif ! [[ -f $CONFIGFILE ]] && [[ -f /boot/installer-config.txt ]]; then
     echo -n "$(timestamp) [openHABian] Copying and loading configuration file '${CONFIGFILE}'... "
     if ! cond_redirect cp /boot/installer-config.txt "$CONFIGFILE"; then echo "FAILED (copy configuration)"; exit 1; fi
@@ -21,7 +25,7 @@ load_create_config() {
     echo -n "$(timestamp) [openHABian] Setting up and loading configuration file '$CONFIGFILE' in manual setup... "
     if input="$(whiptail --title "openHABian Configuration Tool - Manual Setup" --inputbox "$questionText" 14 80 3>&1 1>&2 2>&3)" && id -u "$input" &> /dev/null; then
       if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/openhabian.conf.dist "$CONFIGFILE"; then echo "FAILED (copy configuration)"; exit 1; fi
-      if ! cond_redirect sed -i -e 's|^username=.*$|username='"${input}"'|g' "$CONFIGFILE"; then echo "FAILED (configure username)"; exit 1; fi
+      if ! cond_redirect sed -i -e 's|^adminusername=.*$|adminusername='"${input}"'|g' "$CONFIGFILE"; then echo "FAILED (configure adminusername)"; exit 1; fi
     else
       echo "FAILED"
       echo "$(timestamp) [openHABian] Error: The provided user name is not a valid system user. Please try again. Exiting..." 1>&2

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -99,8 +99,8 @@ openhab_setup() {
 
   # shellcheck disable=SC2154
   gid="$(id -g "$username")"
-  usermod -g "openhab" "$username"
-  usermod -aG "$gid" "$username"
+  cond_redirect usermod -g "openhab" "$username" &> /dev/null
+  cond_redirect usermod -aG "$gid" "$username" &> /dev/null
 
   echo -n "$(timestamp) [openHABian] Setting up openHAB service... "
   if ! cond_redirect systemctl -q daemon-reload &> /dev/null; then echo "FAILED (daemon-reload)"; return 1; fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -340,13 +340,11 @@ config_ipv6() {
 
 ## Create UNIX user and group for openHABian administration purposes
 ##
-##    create_user()
+##    create_user_and_group()
 ##
-create_user() {
+create_user_and_group() {
 
-  # TODO: rename to source admin.... from .conf in first-boot.bash
-  #       rework first-boot.bash to not create user there
-  #       add calling this routine in openhabian-setup.bash ()??)
+# TODO: add calling this routine in openhabian-setup.bash (or elsewhere ?)
 
 # IF
 # (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -370,8 +370,8 @@ create_user() {
   if ! [[ $(getent group "$groupName") ]]; then
     if ! cond_redirect groupadd "$groupName"; then echo "FAILED (add default group $groupName)"; return 1; fi
   fi
-  if ! [[ $(id -u $userName &> /dev/null) ]]; then
-    if ! cond_redirect useradd --groups "$groupName",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp "$userName"); then echo "FAILED (add default usergroup $userName)"; return 1; fi
+  if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
+    if ! cond_redirect useradd --groups "$groupName",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
   else
     usermod --append --groups "$groupName" "$userName";
   fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -365,7 +365,7 @@ create_user_and_group() {
   local userName="${adminusername:-openhabian}"
 
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
-    if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${username}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
+    if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${userName}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
     echo "${userName}:${userpw:-$userName}" | chpasswd
   fi
   usermod --append --groups "$groupName" "$userName";

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -342,26 +342,20 @@ config_ipv6() {
 ##
 ##    create_user_and_group()
 ##
-create_user_and_group() {
-
-# TODO: add calling this routine in openhabian-setup.bash (or elsewhere ?)
-
 # IF
-# (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
+# (1) the string/username that the end user entered as "adminusername=" in openhabian.conf is *empty* OR
 # (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR
-# (3) the user whose name the end user entered as "username=" in openhabian.conf *exists* (and isn't empty because (1) applies, too)
+# (3) the user whose name the end user entered as "adminusername=" in openhabian.conf *exists*
+#     (and isn't empty because (1) applies, too)
 # THEN skip
 # ELSE rename the default user and default group to what is defined as username= in openhabian.conf
 #
-# QUESTIONS:
-# (1) will that do what we want it to
-# (2) did there exist a default user in generic Debian on x86 ? If no why did it work there before ? did it ?
-# (3) what happens on generic Debian on x86 ? Ubuntu on x86 ? Ubuntu,Armbian on RPi ?
-#
-# according to Elias on non image installs the end user is queried to input the username ?
+# COMMENT:
+# according to Elias on non image installs the end user is queried to input the username:
 # https://github.com/openhab/openhabian/issues/665#issuecomment-522261443
 # is he really ? Is that true for interactive installs ? I have not seen where.
-
+##
+create_user_and_group() {
   local userName="${adminusername:-openhabian}"
 
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -24,7 +24,6 @@ get_git_revision() {
 ##
 install_cleanup() {
   echo -n "$(timestamp) [openHABian] Cleaning up... "
-  clean_config_userpw
   if ! cond_redirect systemctl -q daemon-reload &> /dev/null; then echo "FAILED (daemon-reload)"; return 1; fi
   if ! cond_redirect apt-get clean; then echo "FAILED (apt-get clean)"; return 1; fi
   if cond_redirect apt-get autoremove --yes; then echo "OK"; else echo "FAILED"; return 1; fi
@@ -343,18 +342,13 @@ config_ipv6() {
 ##
 ##    create_user_and_group()
 ##
-# IF
-# (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
-# (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR
-# (3) the user whose name the end user entered as "username=" in openhabian.conf *exists*
-#     (and isn't empty because (1) applies, too)
-# THEN skip
-# ELSE rename the default user and default group to what is defined as username= in openhabian.conf
-#
-# COMMENT:
-# according to Elias on non image installs the end user is queried to input the username:
-# https://github.com/openhab/openhabian/issues/665#issuecomment-522261443
-# is he really ? Is that true for interactive installs ? I have not seen where.
+## IF
+## (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
+## (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR
+## (3) the user whose name the end user entered as "username=" in openhabian.conf *exists*
+##     (and isn't empty because (1) applies, too)
+## THEN skip
+## ELSE rename the default user and default group to what is defined as username= in openhabian.conf
 ##
 create_user_and_group() {
   local userName="${username:-openhabian}"

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -369,9 +369,9 @@ create_user_and_group() {
     if ! cond_redirect groupadd "$groupName"; then echo "FAILED (add default group $groupName)"; return 1; fi
   fi
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
-    if ! cond_redirect adduser --groups "$groupName",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
-  else
-    usermod --append --groups "$groupName" "$userName";
+    if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${username}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
+    echo "${userName}:${userpw:-$userName}" | chpasswd
   fi
+  usermod --append --groups "$groupName" "$userName";
 }
 

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -303,7 +303,7 @@ system_check_default_password() {
   generatedPassword="$(perl -le 'print crypt("$ENV{defaultPassword}","\$$ENV{algo}\$$ENV{salt}\$")')"
 
   echo -n "$(timestamp) [openHABian] Checking for default openHABian username:password combination... "
-  if ! [[ $(id -u $defaultUser) ]]; then echo "OK (unknown user)"; return 0; fi
+  if ! [[ $(id -u "$defaultUser") ]]; then echo "OK (unknown user)"; return 0; fi
   if [[ $generatedPassword == "$originalPassword" ]]; then
     if [[ -n $INTERACTIVE ]]; then
       whiptail --title "Default Password Detected!" --msgbox "$introText" 11 80
@@ -367,7 +367,7 @@ create_user_and_group() {
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
     if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${userName}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
     echo "${userName}:${userpw:-openhabian}" | chpasswd
+    usermod --append --groups openhab "$userName";
   fi
-  usermod --append --groups "$groupName" "$userName";
 }
 

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -362,7 +362,7 @@ create_user_and_group() {
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
     if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${userName}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
     echo "${userName}:${userpw:-openhabian}" | chpasswd
-    usermod --append --groups openhab,sudo "$userName";
+    cond_redirect usermod --append --groups openhab,sudo "$userName" &> /dev/null
   fi
 }
 

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -24,6 +24,7 @@ get_git_revision() {
 ##
 install_cleanup() {
   echo -n "$(timestamp) [openHABian] Cleaning up... "
+  clean_config_userpw
   if ! cond_redirect systemctl -q daemon-reload &> /dev/null; then echo "FAILED (daemon-reload)"; return 1; fi
   if ! cond_redirect apt-get clean; then echo "FAILED (apt-get clean)"; return 1; fi
   if cond_redirect apt-get autoremove --yes; then echo "OK"; else echo "FAILED"; return 1; fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -292,7 +292,7 @@ system_check_default_password() {
     defaultUser="pi"
     defaultPassword="raspberry"
   elif is_pi; then
-    defaultUser="openhabian"
+    defaultUser="${adminusername:-openhabian}"
     defaultPassword="openhabian"
   fi
   originalPassword="$(grep -w "$defaultUser" /etc/shadow | cut -d: -f2)"

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -369,7 +369,7 @@ create_user_and_group() {
     if ! cond_redirect groupadd "$groupName"; then echo "FAILED (add default group $groupName)"; return 1; fi
   fi
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
-    if ! cond_redirect useradd --groups "$groupName",openhab -s /bin/bash -d /var/tmp "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
+    if ! cond_redirect adduser --groups "$groupName",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
   else
     usermod --append --groups "$groupName" "$userName";
   fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -369,7 +369,7 @@ create_user_and_group() {
     if ! cond_redirect groupadd "$groupName"; then echo "FAILED (add default group $groupName)"; return 1; fi
   fi
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
-    if ! cond_redirect useradd --groups "$groupName",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
+    if ! cond_redirect useradd --groups "$groupName",openhab -s /bin/bash -d /var/tmp "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
   else
     usermod --append --groups "$groupName" "$userName";
   fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -293,7 +293,7 @@ system_check_default_password() {
     defaultUser="pi"
     defaultPassword="raspberry"
   elif is_pi; then
-    defaultUser="${adminusername:-openhabian}"
+    defaultUser="${username:-openhabian}"
     defaultPassword="openhabian"
   fi
   originalPassword="$(grep -w "$defaultUser" /etc/shadow | cut -d: -f2)"
@@ -344,9 +344,9 @@ config_ipv6() {
 ##    create_user_and_group()
 ##
 # IF
-# (1) the string/username that the end user entered as "adminusername=" in openhabian.conf is *empty* OR
+# (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
 # (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR
-# (3) the user whose name the end user entered as "adminusername=" in openhabian.conf *exists*
+# (3) the user whose name the end user entered as "username=" in openhabian.conf *exists*
 #     (and isn't empty because (1) applies, too)
 # THEN skip
 # ELSE rename the default user and default group to what is defined as username= in openhabian.conf
@@ -357,7 +357,7 @@ config_ipv6() {
 # is he really ? Is that true for interactive installs ? I have not seen where.
 ##
 create_user_and_group() {
-  local userName="${adminusername:-openhabian}"
+  local userName="${username:-openhabian}"
 
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
     if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${userName}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -367,7 +367,7 @@ create_user_and_group() {
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
     if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${userName}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
     echo "${userName}:${userpw:-openhabian}" | chpasswd
-    usermod --append --groups openhab "$userName";
+    usermod --append --groups openhab,sudo "$userName";
   fi
 }
 

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -363,11 +363,7 @@ create_user_and_group() {
 # is he really ? Is that true for interactive installs ? I have not seen where.
 
   local userName="${adminusername:-openhabian}"
-  local groupName="${admingroupname:-openhabian}"
 
-  if ! [[ $(getent group "$groupName") ]]; then
-    if ! cond_redirect groupadd "$groupName"; then echo "FAILED (add default group $groupName)"; return 1; fi
-  fi
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
     if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${username}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
     echo "${userName}:${userpw:-$userName}" | chpasswd

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -366,7 +366,7 @@ create_user_and_group() {
 
   if ! [[ $(id -u "$userName" &> /dev/null) ]]; then
     if ! cond_redirect adduser --quiet --disabled-password --gecos "openHABian,,,,openHAB admin user" --shell /bin/bash --home "/home/${userName}" "$userName"; then echo "FAILED (add default usergroup $userName)"; return 1; fi
-    echo "${userName}:${userpw:-$userName}" | chpasswd
+    echo "${userName}:${userpw:-openhabian}" | chpasswd
   fi
   usermod --append --groups "$groupName" "$userName";
 }

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -336,3 +336,44 @@ config_ipv6() {
     if cond_redirect sysctl --load; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 }
+
+
+## Create UNIX user and group for openHABian administration purposes
+##
+##    create_user()
+##
+create_user() {
+
+  # TODO: rename to source admin.... from .conf in first-boot.bash
+  #       rework first-boot.bash to not create user there
+  #       add calling this routine in openhabian-setup.bash ()??)
+
+# IF
+# (1) the string/username that the end user entered as "username=" in openhabian.conf is *empty* OR
+# (2) the default user ("pi" on RaspiOS, "openhabian" on other OS) does not exist OR
+# (3) the user whose name the end user entered as "username=" in openhabian.conf *exists* (and isn't empty because (1) applies, too)
+# THEN skip
+# ELSE rename the default user and default group to what is defined as username= in openhabian.conf
+#
+# QUESTIONS:
+# (1) will that do what we want it to
+# (2) did there exist a default user in generic Debian on x86 ? If no why did it work there before ? did it ?
+# (3) what happens on generic Debian on x86 ? Ubuntu on x86 ? Ubuntu,Armbian on RPi ?
+#
+# according to Elias on non image installs the end user is queried to input the username ?
+# https://github.com/openhab/openhabian/issues/665#issuecomment-522261443
+# is he really ? Is that true for interactive installs ? I have not seen where.
+
+  local userName="${adminusername:-openhabian}"
+  local groupName="${admingroupname:-openhabian}"
+
+  if ! [[ $(getent group "$groupName") ]]; then
+    if ! cond_redirect groupadd "$groupName"; then echo "FAILED (add default group $groupName)"; return 1; fi
+  fi
+  if ! [[ $(id -u $userName &> /dev/null) ]]; then
+    if ! cond_redirect useradd --groups "$groupName",openhab --gecos "openHABian,,,,openHAB admin user" -s /bin/bash -d /var/tmp "$userName"); then echo "FAILED (add default usergroup $userName)"; return 1; fi
+  else
+    usermod --append --groups "$groupName" "$userName";
+  fi
+}
+

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -78,7 +78,7 @@ OLDWD="$(pwd)"
 cd /opt || exit 1
 
 # on non Raspi OS the admin user may be missing
-if [[ ! $(getent group "${adminusername:-openhabian}") ]] || ! id -u "${admingroupname:-openhabian}" &> /dev/null; then
+if [[ ! $(getent group "${adminusername:-openhabian}") ]] || ! id -u "${adminusername:-openhabian}" &> /dev/null; then
     create_user_and_group
 fi
 

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -77,6 +77,11 @@ for shfile in "${BASEDIR:-/opt/openhabian}"/functions/*.bash; do source "$shfile
 OLDWD="$(pwd)"
 cd /opt || exit 1
 
+# on non Raspi OS the admin user may be missing
+if [[ ! $(getent group "${adminusername:-openhabian}") ]] || ! id -u "${admingroupname:-openhabian}" &> /dev/null; then
+    create_user_and_group
+fi
+
 # disable ipv6 if requested in openhabian.conf (eventually reboots)
 config_ipv6
 

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -77,11 +77,6 @@ for shfile in "${BASEDIR:-/opt/openhabian}"/functions/*.bash; do source "$shfile
 OLDWD="$(pwd)"
 cd /opt || exit 1
 
-# on non Raspi OS the admin user may be missing
-if [[ ! $(getent group "${adminusername:-openhabian}") ]] || ! id -u "${adminusername:-openhabian}" &> /dev/null; then
-    create_user_and_group
-fi
-
 # disable ipv6 if requested in openhabian.conf (eventually reboots)
 config_ipv6
 

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -6,7 +6,7 @@
 # Hostname to set this one to
 hostname=openHABianDevice
 # if it exists, the default user (with its working environment) will be renamed to this username given here ...
-adminusername=openhabian
+username=openhabian
 # and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -5,7 +5,7 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# if exists, the default user (with its working environment) will be renamed to this username given here ...
+# if it exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
 # and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -7,8 +7,6 @@
 hostname=openHABianDevice
 # if exists, the default user (with its working environment) will be renamed to this username given here ...
 adminusername=openhabian
-# ... assigned to this group ...
-admingroupname=openhabian
 # and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -5,9 +5,11 @@
 
 # Hostname to set this one to
 hostname=openHABianDevice
-# the default user (with its working environment) will be renamed to this username given here ...
-username=openhabian
-# ... and given this password. The password will be removed from this file after completion for security reasons.
+# if exists, the default user (with its working environment) will be renamed to this username given here ...
+adminusername=openhabian
+# ... assigned to this group ...
+admingroupname=openhabian
+# and given this password. The password will be removed from this file after completion for security reasons.
 userpw=openhabian
 # set this to download a SSH key and authorize the owner to login as the admin user
 #adminkeyurl=https://github.com/openhab/openhabian/adminkey.pub


### PR DESCRIPTION
A major reason for lack of Ubuntu support (and other Unices) is the absence of the admin user and its group.
It's in the RaspiOS image and we create it in CI but it's missing in the real world.

I'm not fully sure I got this fix for that right. This is why I've spent so many comments on the code.

Please give it an extra thought or three if you would also fix it that way.
Also check out the questions in there. I don't understand how it can have worked on generic Debian so far (which has no "pi" user).

Signed-off-by: Markus Storm <markus.storm@gmx.net>