### PR TITLE
Allow image build as non-privileged user, closes #1172

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -223,7 +223,7 @@ grow_image() {
   local partition="2"
 
   qemu-img resize "$1" "+${2}M" &> /dev/null
-  echo ", +" | sfdisk -N "$partition" "$1" &> /dev/null
+  echo ", +" | PATH=$PATH:/sbin sfdisk -N "$partition" "$1" &> /dev/null
 }
 
 


### PR DESCRIPTION
Linux command sfdisk which is used to resize image file is typically
located in /sbin. This has been added to search path during image
resize.

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>