### PR TITLE
take 0.5GB off root fs 

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -367,6 +367,11 @@ if [[ $hwPlatform == "pi-raspios32" ]] || [[ $hwPlatform == "pi-raspios64beta" ]
   sed -i "s/127.0.1.1.*/127.0.1.1 $hostname/" "$buildFolder"/root/etc/hosts
   echo "$hostname" > "$buildFolder"/root/etc/hostname
 
+  echo_process "Cutting 1GB off rootfs... "
+  sed -i "16 i size=(( $(blockdev --getsize64) - 1024 * 1024 * 1024 ))" "${buildFolder}/root/etc/init.d/resize2fs_once"
+  # shellcheck disable=SC2154
+  sed -i "s|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV $size|g" "${buildFolder}/root/etc/init.d/resize2fs_once"
+
   echo_process "Injecting 'openhabian-installer.service', 'first-boot.bash' and 'openhabian.conf'... "
   cp "$sourceFolder"/openhabian-installer.service "$buildFolder"/root/etc/systemd/system/
   ln -s "$buildFolder"/root/etc/systemd/system/openhabian-installer.service "$buildFolder"/root/etc/systemd/system/multi-user.target.wants/openhabian-installer.service

--- a/build.bash
+++ b/build.bash
@@ -367,9 +367,10 @@ if [[ $hwPlatform == "pi-raspios32" ]] || [[ $hwPlatform == "pi-raspios64beta" ]
   sed -i "s/127.0.1.1.*/127.0.1.1 $hostname/" "$buildFolder"/root/etc/hosts
   echo "$hostname" > "$buildFolder"/root/etc/hostname
 
-  echo_process "Cutting 1G sectors (0.5GB) off rootfs to make copies fit into smaller SD cards... "
+  echo_process "Cutting 1M sectors (0.5GB) off rootfs to make copies fit into smaller SD cards... "
+  blocksize=512
   # shellcheck disable=SC2016
-  sed -i '16 i \    size=$(( $(blockdev --getsize64 $ROOT_DEV) / 512 - 1024 * 1024 ))' "${buildFolder}/root/etc/init.d/resize2fs_once"
+  sed -i '16 i \    size=$(( $(blockdev --getsize64 $ROOT_DEV) / $blocksize - 1024 * 1024 ))' "${buildFolder}/root/etc/init.d/resize2fs_once"
   # shellcheck disable=SC2016
   sed -i 's|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV ${size}s|g' "${buildFolder}/root/etc/init.d/resize2fs_once"
   sed -i 's|bin/sh|bin/bash|g' "${buildFolder}/root/etc/init.d/resize2fs_once"

--- a/build.bash
+++ b/build.bash
@@ -2,7 +2,7 @@
 set -e
 
 ####################################################################
-#### dummy: changed this line 15 times to force another image build
+#### dummy: changed this line 16 times to force another image build
 ####################################################################
 
 usage() {

--- a/build.bash
+++ b/build.bash
@@ -367,11 +367,12 @@ if [[ $hwPlatform == "pi-raspios32" ]] || [[ $hwPlatform == "pi-raspios64beta" ]
   sed -i "s/127.0.1.1.*/127.0.1.1 $hostname/" "$buildFolder"/root/etc/hosts
   echo "$hostname" > "$buildFolder"/root/etc/hostname
 
-  echo_process "Cutting 1GB (2G sectors) off rootfs... "
+  echo_process "Cutting 1G sectors (0.5GB) off rootfs to make copies fit into smaller SD cards... "
   # shellcheck disable=SC2016
-  sed -i '16 i \    size=(( $(blockdev --getsize64 $ROOT_DEV) / 512 - 2 * 1024 * 1024 ))" "${buildFolder}/root/etc/init.d/resize2fs_once'
+  sed -i '16 i \    size=$(( $(blockdev --getsize64 $ROOT_DEV) / 512 - 1024 * 1024 ))' "${buildFolder}/root/etc/init.d/resize2fs_once"
   # shellcheck disable=SC2016
-  sed -i 's|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV ${size}s|g" "${buildFolder}/root/etc/init.d/resize2fs_once'
+  sed -i 's|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV ${size}s|g' "${buildFolder}/root/etc/init.d/resize2fs_once"
+  sed -i 's|bin/sh|bin/bash|g' "${buildFolder}/root/etc/init.d/resize2fs_once"
 
   echo_process "Injecting 'openhabian-installer.service', 'first-boot.bash' and 'openhabian.conf'... "
   cp "$sourceFolder"/openhabian-installer.service "$buildFolder"/root/etc/systemd/system/

--- a/build.bash
+++ b/build.bash
@@ -367,10 +367,10 @@ if [[ $hwPlatform == "pi-raspios32" ]] || [[ $hwPlatform == "pi-raspios64beta" ]
   sed -i "s/127.0.1.1.*/127.0.1.1 $hostname/" "$buildFolder"/root/etc/hosts
   echo "$hostname" > "$buildFolder"/root/etc/hostname
 
-  echo_process "Cutting 1GB off rootfs... "
-  sed -i "16 i size=(( $(blockdev --getsize64) - 1024 * 1024 * 1024 ))" "${buildFolder}/root/etc/init.d/resize2fs_once"
+  echo_process "Cutting 1GB (2G sectors) off rootfs... "
+  sed -i '16 i \    size=(( $(blockdev --getsize64 $ROOT_DEV) / 512 - 2 * 1024 * 1024 ))" "${buildFolder}/root/etc/init.d/resize2fs_once'
   # shellcheck disable=SC2154
-  sed -i "s|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV $size|g" "${buildFolder}/root/etc/init.d/resize2fs_once"
+  sed -i 's|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV ${size}s|g" "${buildFolder}/root/etc/init.d/resize2fs_once'
 
   echo_process "Injecting 'openhabian-installer.service', 'first-boot.bash' and 'openhabian.conf'... "
   cp "$sourceFolder"/openhabian-installer.service "$buildFolder"/root/etc/systemd/system/

--- a/build.bash
+++ b/build.bash
@@ -368,8 +368,9 @@ if [[ $hwPlatform == "pi-raspios32" ]] || [[ $hwPlatform == "pi-raspios64beta" ]
   echo "$hostname" > "$buildFolder"/root/etc/hostname
 
   echo_process "Cutting 1GB (2G sectors) off rootfs... "
+  # shellcheck disable=SC2016
   sed -i '16 i \    size=(( $(blockdev --getsize64 $ROOT_DEV) / 512 - 2 * 1024 * 1024 ))" "${buildFolder}/root/etc/init.d/resize2fs_once'
-  # shellcheck disable=SC2154
+  # shellcheck disable=SC2016
   sed -i 's|resize2fs $ROOT_DEV|resize2fs $ROOT_DEV ${size}s|g" "${buildFolder}/root/etc/init.d/resize2fs_once'
 
   echo_process "Injecting 'openhabian-installer.service', 'first-boot.bash' and 'openhabian.conf'... "


### PR DESCRIPTION
so when we need to copy the SD card it is more likely to fit into the destination even if that one has a number of bytes less.

Fixes: #1254 

Drafting because preliminary testing results in a reboot loop, reason t.b.d.