### PR TITLE
Correct samba folder locations for openHAB3

### DIFF
--- a/includes/smb.conf
+++ b/includes/smb.conf
@@ -231,7 +231,7 @@
 
 [openHAB-conf]
   comment=openHAB site configuration
-  path=/etc/openhab2
+  path=/etc/openhab
   writeable=yes
   public=no
   create mask=0664
@@ -241,7 +241,7 @@
 
 [openHAB-userdata]
   comment=openHAB userdata
-  path=/var/lib/openhab2
+  path=/var/lib/openhab
   writeable=yes
   public=no
   create mask=0664
@@ -251,7 +251,7 @@
 
 [openHAB-sys]
   comment=openHAB application
-  path=/usr/share/openhab2
+  path=/usr/share/openhab
   writeable=yes
   public=no
   create mask=0664
@@ -261,7 +261,7 @@
 
 [openHAB-logs]
   comment=openHAB log files
-  path=/var/log/openhab2
+  path=/var/log/openhab
   writeable=yes
   public=no
   create mask=0664


### PR DESCRIPTION
This will add the correct folder names to smb.conf according to the folder changes of openHAB 3.

Fixes #1319 

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>