### PR TITLE
[Frontail] Change to openHAB3 folder locations

### DIFF
--- a/includes/frontail.service
+++ b/includes/frontail.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Frontail openHAB instance, reachable at http://%H:9001
 Documentation=https://github.com/mthenw/frontail
-After=openhab2.service
-PartOf=openhab2.service
+After=openhab.service
+PartOf=openhab.service
 
 [Service]
 Type=simple
-ExecStart=%FRONTAILBASE/bin/frontail --ui-highlight --ui-highlight-preset %FRONTAILBASE/preset/openhab.json -t openhab -l 2000 -n 200 /var/log/openhab2/openhab.log /var/log/openhab2/events.log
+ExecStart=%FRONTAILBASE/bin/frontail --ui-highlight --ui-highlight-preset %FRONTAILBASE/preset/openhab.json -t openhab -l 2000 -n 200 /var/log/openhab/openhab.log /var/log/openhab/events.log
 Restart=always
 User=frontail
 Group=openhab


### PR DESCRIPTION
This is just a shot in the dark.

I am not sure if there are any additional references that have to be changed for getting frontail to work with openHAB 3,
since i am not too familiar with this repository yet.
But i can add them of course, when you point me to the needed files and i will add them to this Pull Request.


Signed-off-by: Jerome Luckenbach <github@luckenba.ch>