### PR TITLE
Fix download branch for installation instruction

### DIFF
--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -120,7 +120,7 @@ apt-get update
 apt-get install git
 
 # download, link and create config file
-git clone -b stable https://github.com/openhab/openhabian.git /opt/openhabian
+git clone -b openHAB3 https://github.com/openhab/openhabian.git /opt/openhabian
 ln -s /opt/openhabian/openhabian-setup.sh /usr/local/bin/openhabian-config
 cp /opt/openhabian/openhabian.conf.dist /etc/openhabian.conf
 ```


### PR DESCRIPTION
See discussion @ openhab/openhabian#1318

Fix here will be pulled into the docs repo with one of the next builds.
Please also note that the docs are always fetched on the master branch.
Pull Request target is done on purpose here.


Signed-off-by: Jerome Luckenbach <github@luckenba.ch>