### PR TITLE
Move network manager install to right before hotspot setup

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -76,8 +76,6 @@ fi
 # While setup: show log to logged in user, will be overwritten by openhabian-setup.sh
 echo "watch cat /boot/first-boot.log" > "$HOME/.bash_profile"
 
-# setup networking
-apt install --yes network-manager &> /dev/null
 # shellcheck source=/etc/openhabian.conf disable=SC2154
 if [[ -z $wifi_ssid ]]; then
   # Actually check if ethernet is working

--- a/build.bash
+++ b/build.bash
@@ -2,7 +2,7 @@
 set -e
 
 ####################################################################
-#### dummy: changed this line 15 times to force another image build
+#### dummy: changed this line 17 times to force another image build
 ####################################################################
 
 usage() {

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -127,6 +127,8 @@ setup_hotspot() {
 
   if [[ $1 == "install" ]]; then
     echo -n "$(timestamp) [openHABian] Installing Comitup hotspot... "
+    # manage networking through network manager
+    apt install --yes network-manager &> /dev/null
     # get from source - the comitup package in Buster is 2yrs old
     echo "deb http://davesteele.github.io/comitup/repo comitup main" > /etc/apt/sources.list.d/comitup.list
     if ! cond_redirect apt-get --quiet update; then echo "FAILED (update apt lists)"; return 1; fi


### PR DESCRIPTION
to not deviate from standard OS setup more than necessary for the hotspot to work.

Yes I have tested using the hotspottest image:
1) w/ Ethernet
2) w/o Ethernet and WiFi SSID empty
3) w/o Ethernet and WiFi SSID fine
4) w/o Ethernet and WiFi SSID bad

The hotspot was only fired up in cases 2) and 4)

Signed-off-by: Markus Storm <markus.storm@gmx.net>