### PR TITLE
Added dark theme to frontail for openHAB3 branch

### DIFF
--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2181
 
 ## Function for installing NodeJS for frontail and other addons.

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -1,4 +1,4 @@
-!/usr/bin/env bash
+#/usr/bin/env bash
 # shellcheck disable=SC2181
 
 ## Function for installing NodeJS for frontail and other addons.

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+!/usr/bin/env bash
 # shellcheck disable=SC2181
 
 ## Function for installing NodeJS for frontail and other addons.
@@ -60,6 +60,19 @@ nodejs_setup() {
 frontail_setup() {
   local frontailBase
   local frontailUser="frontail"
+  local chosenTheme
+
+  # ask for light or dark theme
+if [[ -n $INTERACTIVE ]]; then
+    chosenTheme=$(whiptail --title "openHAB Log Viewer (frontail)" --menu "select theme" 18 116 2 --cancel-button Back --ok-button Execute \
+    "21 | light theme"           "frontail light theme, the openHABian default" \
+    "22 | dark theme"            "frontail dark theme" \
+    3>&1 1>&2 2>&3)
+    if [ $? -eq 1 ] || [ $? -eq 255 ]; then return 0; fi
+  else
+    echo "$(timestamp) [openHABian] openHAB Log Viewer Theme can only be chosen in interactive mode! Setting to default light theme."
+    chosenTheme=21 # set to default light theme when no user input
+  fi
 
   if ! [[ -x $(command -v npm) ]] || [[ $(node --version) != "v12"* ]] || is_armv6l; then
     echo -n "$(timestamp) [openHABian] Installing Frontail prerequsites (NodeJS)... "
@@ -86,14 +99,34 @@ frontail_setup() {
   echo -n "$(timestamp) [openHABian] Configuring openHAB Log Viewer (frontail)... "
   if ! cond_redirect mkdir -p "$frontailBase"/preset "$frontailBase"/web/assets/styles; then echo "FAILED (create directory)"; return 1; fi
   if ! cond_redirect rm -rf "${frontailBase:?}"/preset/* "${frontailBase:?}"/web/assets/styles/*; then echo "FAILED (clean directory)"; return 1; fi
-  if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail-preset.json "$frontailBase"/preset/openhab.json; then echo "FAILED (copy presets)"; return 1; fi
-  if cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail-theme.css "$frontailBase"/web/assets/styles/openhab.css; then echo "OK"; else echo "FAILED (copy theme)"; return 1; fi
+  if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail-preset.json "$frontailBase"/preset/openhab.json; then echo "FAILED (copy light presets)"; return 1; fi
+  if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail-preset_dark.json "$frontailBase"/preset/openhab_dark.json; then echo "FAILED (copy dark presets)"; return 1; fi
+  if cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail_default.css "$frontailBase"/web/assets/styles/default.css; then echo "OK"; else echo "FAILED (copy default.css)"; return 1; fi
+  if cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail-theme.css "$frontailBase"/web/assets/styles/openhab.css; then echo "OK"; else echo "FAILED (copy light theme)"; return 1; fi
+  if cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/frontail-theme_dark.css "$frontailBase"/web/assets/styles/openhab_dark.css; then echo "OK"; else echo "FAILED (copy dark theme)"; return 1; fi
 
-  echo -n "$(timestamp) [openHABian] Setting up openHAB Log Viewer (frontail) service... "
-  if ! (sed -e "s|%FRONTAILBASE|${frontailBase}|g" "${BASEDIR:-/opt/openhabian}"/includes/frontail.service > /etc/systemd/system/frontail.service); then echo "FAILED (service file creation)"; return 1; fi
+  # copy the service file for the previous chosen theme
+  case "$chosenTheme" in
+      21\ *)  echo -n "$(timestamp) [openHABian] Setting up openHAB Log Viewer (frontail) service... light theme..."
+              if ! (sed -e "s|%FRONTAILBASE|${frontailBase}|g" "${BASEDIR:-/opt/openhabian}"/includes/frontail.service > /etc/systemd/system/frontail.service); then echo "FAILED (service file creation)"; return 1; fi;
+              ;;
+      22\ *)  echo -n "$(timestamp) [openHABian] Setting up openHAB Log Viewer (frontail) service with dark theme..."
+              if ! (sed -e "s|%FRONTAILBASE|${frontailBase}|g" "${BASEDIR:-/opt/openhabian}"/includes/frontail_dark.service > /etc/systemd/system/frontail.service); then echo "FAILED (service file creation)"; return 1; fi;
+              ;;
+      21)     echo -n "$(timestamp) [openHABian] Setting up openHAB Log Viewer (frontail) service with light theme..."
+              if ! (sed -e "s|%FRONTAILBASE|${frontailBase}|g" "${BASEDIR:-/opt/openhabian}"/includes/frontail.service > /etc/systemd/system/frontail.service); then echo "FAILED (service file creation)"; return 1; fi;
+              ;;
+      "") return 0 ;;
+      *)  echo -n "A not supported option was selected (probably a programming error)"
+          echo -n "$(timestamp) [openHABian] Setting up openHAB Log Viewer (frontail) service with default theme..."
+          if ! (sed -e "s|%FRONTAILBASE|${frontailBase}|g" "${BASEDIR:-/opt/openhabian}"/includes/frontail.service > /etc/systemd/system/frontail.service); then echo "FAILED (service file creation)"; return 1; fi;
+          ;;
+    esac
+
   if ! cond_redirect chmod 644 /etc/systemd/system/frontail.service; then echo "FAILED (permissions)"; return 1; fi
   if ! cond_redirect systemctl -q daemon-reload &> /dev/null; then echo "FAILED (daemon-reload)"; return 1; fi
   if cond_redirect systemctl enable --now frontail.service; then echo "OK"; else echo "FAILED (enable service)"; return 1; fi
+  if cond_redirect systemctl restart frontail.service; then echo "OK"; else echo "Failed (restart service)"; return 1; fi
 
   if openhab_is_installed; then
     dashboard_add_tile "frontail"

--- a/includes/frontail-preset_dark.json
+++ b/includes/frontail-preset_dark.json
@@ -1,0 +1,24 @@
+{
+  "words": {
+    "[ERROR]": "color: #ff0000;",
+    "[WARN ]": "color: #ffa500;",
+    "[INFO ]": "color: #00ff00;",
+    "Node is DEAD": "color: red;",
+    "[GroupItemStateChangedEvent]": "color: #c2d2ff; font-weight: bold;",
+    "[ItemStateChangedEvent     ]": "color: #c2d2ff;",
+    "[vent.ItemStateChangedEvent]": "color: #c2d2ff;",
+    "[ItemCommandEvent          ]": "color: #84c3ff;",
+    "[ome.event.ItemCommandEvent]": "color: #84c3ff;",
+    "[hingStatusInfoChangedEvent]": "color: #00bf66;",
+    "received command ON": "color: white;",
+    "received command OFF": "color: white;",
+    "received command": "color: white;"
+  },
+  "lines": {
+    "/var/log/openhab2/openhab.log": "text-align: right; font-size: 0.8em; border-top: 2px solid #F8F8F8;",
+    "/var/log/openhab2/events.log": "text-align: right; font-size: 0.8em; border-top: 2px solid #F8F8F8;",
+    "ERROR": "background-color: #4c1f25;",
+    "model.script": "background-color: #4b6c8d; font-weight: bold;",
+    "ModelRepositoryImpl": "background-color: #4b6c8d; font-weight: bold"
+  }
+}

--- a/includes/frontail-theme.css
+++ b/includes/frontail-theme.css
@@ -21,7 +21,7 @@ body {
 }
 
 .navbar .navbar-brand::before {
-  content: "openHAB 3 Log Viewer (frontail)";
+  content: "openHAB Log Viewer (frontail)";
   font-size: 150%;
   padding-right: 30px;
 }

--- a/includes/frontail-theme.css
+++ b/includes/frontail-theme.css
@@ -1,4 +1,4 @@
-@import url('//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css');
+@import 'default.css';
 
 body {
   padding-top: 7em;
@@ -21,15 +21,9 @@ body {
 }
 
 .navbar .navbar-brand::before {
-  content: "openHAB Log Viewer (frontail)";
+  content: "openHAB 3 Log Viewer (frontail)";
   font-size: 150%;
   padding-right: 30px;
-}
-
-.navbar .text-right::before {
-  color: white;
-  content: "Pause/Play Log";
-  font-size: 100%;
 }
 
 .form-control {

--- a/includes/frontail-theme_dark.css
+++ b/includes/frontail-theme_dark.css
@@ -1,0 +1,76 @@
+@import 'default.css';
+
+body {
+  padding-top: 4em;
+  background-color: #2f3238;
+}
+
+.no-topbar {
+  padding-top: 10px;
+}
+
+.navbar {
+  background-color: #26292e;
+  border: 0;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.15);
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.navbar-inverse .navbar-brand,
+.navbar-inverse .navbar-brand:hover {
+  color: #efefef; /* #999; */
+}
+
+.navbar .navbar-brand::before {
+  content: "openHAB 3 Log Viewer (frontail)";
+  font-size: 150%;
+  padding-right: 30px;
+}
+
+.btn-pause {
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='%237f8289' viewBox='0 0 8 8'><path d='M1 1v6h2v-6h-2zm4 0v6h2v-6h-2z'></path></svg>") no-repeat center center;
+    background-color: #2f3238;
+    border: 1px solid transparent;
+}
+
+.btn-pause.play {
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='%237f8289' viewBox='0 0 8 8'><path d='M1 1v6l6-3-6-3z'></path></svg>") no-repeat center center;
+    background-color: #2f3238;
+}
+
+.form-control {
+  border: 0;
+  color: #7f8289;
+  background-color: #2f3238;
+}
+
+.log {
+  white-space: pre-wrap;
+  color: #f2f2f2; /* #7f8289; */
+  font-size: 0.85em;
+  background: inherit;
+  border: 0;
+  padding: 0;
+}
+
+.log .inner-line {
+  padding: 0 15px;
+  margin-left: 84pt;
+  text-indent: -84pt;
+  margin-bottom: 0;
+}
+
+.log .inner-line:empty::after {
+  content: '.';
+  visibility: hidden;
+}
+
+.log.no-indent .inner-line {
+  margin-left: 0;
+  text-indent: 0;
+}
+
+.log .line-selected {
+  background-color: #4f204c; /* #302436; */
+}

--- a/includes/frontail-theme_dark.css
+++ b/includes/frontail-theme_dark.css
@@ -23,7 +23,7 @@ body {
 }
 
 .navbar .navbar-brand::before {
-  content: "openHAB 3 Log Viewer (frontail)";
+  content: "openHAB Log Viewer (frontail)";
   font-size: 150%;
   padding-right: 30px;
 }

--- a/includes/frontail_dark.service
+++ b/includes/frontail_dark.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Frontail openHAB instance, reachable at http://%H:9001
+Documentation=https://github.com/mthenw/frontail
+After=openhab.service
+PartOf=openhab.service
+
+[Service]
+Type=simple
+ExecStart=%FRONTAILBASE/bin/frontail --ui-highlight --ui-highlight-preset %FRONTAILBASE/preset/openhab_dark.json -t openhab_dark -l 2000 -n 200 /var/log/openhab/openhab.log /var/log/openhab/events.log
+Restart=always
+User=frontail
+Group=openhab
+Environment=PATH=/usr/bin/
+Environment=NODE_ENV=production
+WorkingDirectory=/usr/bin/
+
+[Install]
+WantedBy=multi-user.target

--- a/includes/frontail_default.css
+++ b/includes/frontail_default.css
@@ -1,0 +1,80 @@
+@import url('//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css');
+
+body {
+  padding-top: 60px;
+}
+@media screen and (max-width: 768px) {
+  body {
+    padding-top: 120px;
+  }
+}
+
+.navbar-brand {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.btn-pause {
+    margin: 8px 0 8px;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='%23999' viewBox='0 0 8 8'><path d='M1 1v6h2v-6h-2zm4 0v6h2v-6h-2z'></path></svg>") no-repeat center center;
+    background-color: #e2e6ea;
+    background-size: contain;
+    cursor: pointer;
+    display: inline-block;
+    height: 34px;
+    width: 34px;
+    border: 1px solid #ccc;
+}
+
+.btn-pause.play {
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='%23999' viewBox='0 0 8 8'><path d='M1 1v6l6-3-6-3z'></path></svg>") no-repeat center center;
+    background-color: #e2e6ea;
+}
+
+.navbar-form-custom {
+  padding: 8px 0;
+}
+
+.no-horiz-padding {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.no-topbar {
+  padding-top: 10px;
+}
+
+.navbar-inverse .navbar-brand {
+  color: white;
+}
+
+.log {
+  white-space: pre-wrap;
+  color: black;
+  font-size: 0.85em;
+  background: inherit;
+  border: 0;
+  padding: 0;
+}
+
+.log .inner-line {
+  padding: 0 15px;
+  margin-left: 84pt;
+  text-indent: -84pt;
+  margin-bottom: 0;
+}
+
+.log .inner-line:empty::after {
+  content: '.';
+  visibility: hidden;
+}
+
+.log.no-indent .inner-line {
+  margin-left: 0;
+  text-indent: 0;
+}
+
+.log .line-selected {
+  background-color: #ffb2b0;
+}


### PR DESCRIPTION
I have added a dark theme for the openHAB log viewer (frontail) in the openHAB3 branch.

You can select the darkmode by using the openhabian-config tool, when running in unattended mode the theme is set to the light theme as a default.

This is the new version of #1388, hopefully correct this time

Sorry that I have messed everything up a few times but I am new to GitHub and so I have to learn a much