### PR TITLE
Change the documented comitup AP ip Address

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -166,7 +166,7 @@ if ! running_in_docker && tryUntil "ping -c1 8.8.8.8 &> /dev/null || curl --sile
   fi
   echo "$(timestamp) [openHABian] The public internet is not reachable. Please check your local network environment."
   echo "                          We have launched a publicly accessible hotspot named openHABian-<n>."
-  echo "                          Use your mobile to connect and go to http://raspberrypi.local or http://10.42.0.1/"
+  echo "                          Use your mobile to connect and go to http://raspberrypi.local or http://10.41.0.1/"
   echo "                          and select the WiFi network you want to connect your openHABian system to."
   echo "                          After about an hour, we will continue trying to get your system installed,"
   echo "                          but without proper Internet connectivity this is not guaranteed to work."

--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -342,7 +342,7 @@ So in addition to the setup instructions given above, uncomment and complete the
 Whenever the WiFi interface wlan0 exists but does not have connectivity, openHABian will launch a **Hotspot**.
 When you use your mobile phone to scan for WiFi networks, you should be seeing a new network called `openHABian-<n>`.
 Connecting will work without a password. Once connected, open your browser and point it at `http://raspberrypi.local` or `http://comitup-<n>`.
-This may or may not work for your mobile browser as it requires Bonjour/ZeroConf abilities. If you cannot connect to this address, go to `http://10.42.0.1`.
+This may or may not work for your mobile browser as it requires Bonjour/ZeroConf abilities. If you cannot connect to this address, go to `http://10.41.0.1`.
 On that page you can select the SSID of the network you want to connect your system to. Provide the password and press the button.
 Note that as soon as you do, the wlan0 IP address changes so your mobile browser will not be able to provide you any feedback if that worked out.
 Try to ping the new system's hostname (default is `openHABianDevice`) or check DHCP on your router if your openHABian system appeared there.


### PR DESCRIPTION
The address that the Comitup AP creates was [changed](https://github.com/davesteele/comitup/commit/25e34f923) from 10.42.0.1
to 10.41.0.1 in comitup 1.7-1, released August 2019.