### PR TITLE
Update all documentation for clarity and accuracy

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -13,7 +13,7 @@ bar to let you see closed issues). Please follow the guidelines outlined in the
 ## Debug information:
 Please provide all of the output provided by utilizing the `debugmode=maximum`
 parameter in the `/etc/openhabian.conf` file. For more information on how to
-accomplish this, please see [openhabian-DEBUG.md](https://github.com/openhab/openhabian/blob/master/docs/openhabian-DEBUG.md#create-a-debug-log).
+accomplish this, please see [openhabian-DEBUG.md](https://github.com/openhab/openhabian/blob/main/docs/openhabian-DEBUG.md#create-a-debug-log).
 
 ## System information:
 Please tell us what OS you are running (Raspberry Pi OS, Debian, Ubuntu), what

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,71 +2,60 @@
 
 ## Pull requests are always welcome
 
-We are always thrilled to receive pull requests, and do our best to
-process them as fast as possible. Not sure if that typo is worth a pull
-request? Do it! We will appreciate it.
+We are always thrilled to receive pull requests, and do our best to process them as fast as possible.
+Not sure if that typo is worth a pull request?
+Do it!
+We will appreciate it.
 
 If your pull request is not accepted on the first try, don't be discouraged!
-If there's a problem with the implementation, you will receive feedback on what
-to improve.
+If there's a problem with the implementation, you will receive feedback on what to improve.
 
-We might decide against incorporating a new feature that does not match the
-scope of this project. Get in contact early in the development to propose your
-idea.
+We might decide against incorporating a new feature that does not match the scope of this project.
+Get in contact early in the development to propose your idea.
 
 ## Conventions
 
-Fork the repo and make changes on your fork in a feature branch. Then be sure to
-update the documentation when creating or modifying features. Test your changes
-for clarity, concision, and correctness, as well as a clean documentation build.
+Fork the repo and make changes on your fork in a feature branch.
+Then be sure to update the documentation when creating or modifying features.
+Test your changes for clarity, concision, and correctness, as well as a clean documentation build.
 
-Always write clean, modular and testable code. We have a simple
-[code-style](#codestyle) which in combination with the static linter
-[ShellCheck](https://www.shellcheck.net/) works as our coding guidelines.
+Always write clean, modular and testable code.
+We have a simple [code-style](#codestyle) which in combination with the static linter [ShellCheck](https://www.shellcheck.net/) works as our coding guidelines.
 
-Pull requests descriptions should be as clear as possible and include a
-reference to all the issues that they address.
+Pull requests descriptions should be as clear as possible and include a reference to all the issues that they address.
 
 Pull requests must not contain commits from other users or branches.
 
-Commit messages **must** start with a capitalized and short summary (max. 50
-chars) written in the imperative, followed by an optional, more detailed
-explanatory text which is separated from the summary by an empty line. See
-[here](https://chris.beams.io/posts/git-commit) for great explanation as to why.
+Commit messages **must** start with a capitalized and short summary (max. 50 chars) written in the imperative, followed by an optional, more detailed explanatory text which is separated from the summary by an empty line.
+See [here](https://chris.beams.io/posts/git-commit) for great explanation as to why.
 
-Code review comments may be added to your pull request. Discuss, then make the
-suggested modifications and push additional commits to your feature branch. Be
-sure to post a comment after pushing. The new commits will show up in the pull
-request automatically, but the reviewers will not be notified unless you
-comment.
+Code review comments may be added to your pull request.
+Discuss, then make the suggested modifications and push additional commits to your feature branch.
+Be sure to post a comment after pushing.
+The new commits will show up in the pull request automatically, but the reviewers will not be notified unless you comment.
 
-Pull requests will be tested on the Travis CI platform which **shall** pass.
+Pull requests will be tested on the GitHub Actions platform which **shall** pass.
 
 Any install routine for a new feature must
-* equally work in a) unattended and b) interactive mode
-* be tested to execute with a) 'install' and b) 'remove' string arguments,
+*   Equally work in a) unattended and b) interactive mode
+*   Be tested to execute with a) 'install' and b) 'remove' string arguments,
 resulting in installation or removal, respectively.
 
 Please provide BATS test cases for new features to be executed on every build.
-The minimum test set to provide is a test to run an unattended installation and
-automatically validate the feature is working _in principle_.
+The minimum test set to provide is a test to run an unattended installation and automatically validate the feature is working _in principle_.
 See [Test Architecture](#test-architecture) below.
 Of course, more and more specific test cases are always welcome.
 
-Commits that fix or close an issue should include a reference like `Closes #XXX`
-or `Fixes #XXX`, which will automatically close the issue when merged.
+Commits that fix or close an issue should include a reference like `Closes #XXX` or `Fixes #XXX`, which will automatically close the issue when merged.
 
-Before the pull request is merged, your commits might get squashed, based on the
-size and style of your contribution. Include documentation changes in the same
-pull request, so that a revert would remove all traces of the feature or fix.
+Before the pull request is merged, your commits might get squashed, based on the size and style of your contribution.
+Include documentation changes in the same pull request, so that a revert would remove all traces of the feature or fix.
 
 ### Sign your work
 
-The sign-off is a simple line at the end of the explanation for the
-patch, which certifies that you wrote it or otherwise have the right to
-pass it on as an open-source patch.  The rules are pretty simple: if you
-can certify the below (from
-[developercertificate.org](http://developercertificate.org/)):
+The sign-off is a simple line at the end of the explanation for the patch, which certifies that you wrote it or otherwise have the right to pass it on as an open-source patch.
+The rules are pretty simple: if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
+
 ```
 Developer Certificate of Origin
 Version 1.1
@@ -107,18 +96,17 @@ By making a contribution to this project, I certify that:
 ```
 
 then you just add a line to every git commit message:
+
 ```
 Signed-off-by: Joe Smith <joe.smith@email.com>
 ```
 
-using your real name (sorry, no pseudonyms or anonymous contributions.) and an
-e-mail address under which you can be reached (sorry, no github noreply e-mail
-addresses (such as username@users.noreply.github.com) or other non-reachable
-addresses are allowed).
+using your real name (sorry, no pseudonyms or anonymous contributions) and an e-mail address under which you can be reached (sorry, no github noreply e-mail addresses (such as username@users.noreply.github.com) or other non-reachable addresses are allowed).
 
 #### Small patch exception
 
-There are several exceptions to the signing requirement. Currently these are:
+There are several exceptions to the signing requirement.
+Currently these are:
 
 *   Your patch fixes spelling or grammar errors.
 *   Your patch is a single line change to documentation.
@@ -126,10 +114,8 @@ There are several exceptions to the signing requirement. Currently these are:
 #### Sign your Work using GPG
 
 You can additionally sign your contribution using GPG.
-Have a look at the
-[git documentation](https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work)
-for more details. This step is optional and not needed for the acceptance of
-your pull request.
+Have a look at the [git documentation](https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work) for more details.
+This step is optional and not needed for the acceptance of your pull request.
 
 ## Codestyle
 
@@ -138,49 +124,26 @@ Universally formatted code promotes ease of writing, reading, and maintenance.
 ### Guidelines
 
 *   Use two (2) spaces when indenting code.
-
-*   use `local variable` declarations of variables wherever possible.
+*   Use `local variable` declarations of variables wherever possible.
     Always start a function with the declarations of variables.
-    The only exception you may have before that is 'short cut' checks that exit
-    the function early if there's conditions in effect that prohibit to proceed
-    with executing the function.
-*   use the short form `local variable=value` to define constants.
-
+    The only exception you may have before that is 'short cut' checks that exit the function early if there's conditions in effect that prohibit to proceedwith executing the function.
+*   Use the short form `local variable=value` to define constants.
 *   When using colored output, always use the colors defined in `helpers.bash`.
-    For example, `${COL_RED}`, additionally always be sure to reset to standard
-    color at the end of your output statement by using `${COL_DEF}`.
-
-*   Never use absolute paths for binaries, always use the standard paths
-    instead. For example, use `apt-get` instead of `/usr/bin/apt-get`.
-
-*   When a function is used across multiple files, include it in the `helpers.bash`
-    file.
-
-*   Functions should be named using underscores. For example, `new_function`, or
-    `openhabian_update`.
-
-*   Variables should be named using camelCase. For example, `newVariable`, or
-    `requestedArch`.
-
-*   use all-lowercase global variables for all parametrization in `openhabian.conf`.
-    You may not directly read these from inside installation routines (but write if
-    required e.g. to hide passwords after processing). Global variables are sourced
-    in as one batch at the beginning of code execution in both run modes.
-    Use local variables of the same name but applying camelCase in the install routine
-    and initialize them with the all-lowercase global equivalent's contents before use.
-    This is in preparation of a future migration from Shell CLI to a web based
-    interface.
-
-*   Always refuse to allow the running of package setup scripts that require
-    user input in unattended mode.
-
-*   Wrap Markdown code at 80 columns. Links and code examples may cross 80
-    columns when necessary.
+    For example, `${COL_RED}`, additionally always be sure to reset to standard color at the end of your output statement by using `${COL_DEF}`.
+*   Never use absolute paths for binaries, always use the standard paths instead. For example, use `apt-get` instead of `/usr/bin/apt-get`.
+*   When a function is used across multiple files, include it in the `helpers.bash` file.
+*   Functions should be named using underscores. For example, `new_function`, or `openhabian_update`.
+*   Variables should be named using camelCase. For example, `newVariable`, or `requestedArch`.
+*   Use all-lowercase global variables for all parametrization in `openhabian.conf`.
+    You may not directly read these from inside installation routines (but write if required e.g. to hide passwords after processing).
+    Global variables are sourced in as one batch at the beginning of code execution in both run modes.
+    Use local variables of the same name but applying camelCase in the install routine and initialize them with the all-lowercase global equivalent's contents before use.
+    This is in preparation of a future migration from Shell CLI to a web based interface.
+*   Always refuse to allow the running of package setup scripts that require user input in unattended mode.
 
 ### Usage of `apt-get update` command
 
-To minimize unnecessary updates of the local apt database running
-`apt-get update` is only permitted under the following circumstances:
+To minimize unnecessary updates of the local apt database running `apt-get update` is only permitted under the following circumstances:
 
 1) Once in the `first-boot.bash` file prior to installing the system first time.
 
@@ -192,133 +155,127 @@ To minimize unnecessary updates of the local apt database running
 
 Testing is based on three pillars:
 
-A) *Installation of base system*
+A) _Installation of base system_
 
-B) *Test Cases using [BATS](https://github.com/bats-core/bats-core)*
+B) _Test Cases using [BATS](https://github.com/bats-core/bats-core)_
 
-C) *Static analysis using the [ShellCheck](https://www.shellcheck.net/) linter*
+C) _Static analysis using the [ShellCheck](https://www.shellcheck.net/) linter_
 
 ### Test installation
-Test installations are done continuously using Docker on a Travis Virtual
-Machine and by testing on actual hardware, eg. Raspberry Pi. A Docker
-installation can be performed by three commands. Firstly a Docker image is built
-where the `openhabian` code is injected (see `Dockerfile.*` for details).
+Test installations are done continuously using Docker on GitHub and by testing on actual hardware, eg. Raspberry Pi.
+A Docker installation can be performed by three commands.
+Firstly a Docker image is built where the `openhabian` code is injected (see `Dockerfile.*` for details).
 
-To begin, first make a Docker container for your platform. An example Docker
-container build for `amd64` would look like:
-```
-docker build --tag openhabian/install-openhabian -f Dockerfile.amd64 .
+To begin, first make a Docker container for your platform.
+An example Docker container build for `amd64` would look like:
+
+``` bash
+docker build --tag openhabian/install-openhabian -f Dockerfile.amd64-installation .
 ```
 
-While not a problem in the final container-less deployment, with more than one
-container running, all but one of them will have a `systemd` running with a PID
-other than 1. That will break openHABian in a number of locations when we use
-`systemctl` to start/stop/check `systemd` controlled services.
-This is why we replace the `systemctl` binary in `Dockerfile.*` during Travis
-testing.`systemctl.py` is a Python replacement that does not complain about
-`systemd` running with an arbitrary PID.
+While not a problem in the final container-less deployment, with more than one container running, all but one of them will have a `systemd` running with a PID other than 1.
+That will break openHABian in a number of locations when we use `systemctl` to start/stop/check `systemd` controlled services.
+This is why we replace the `systemctl` binary in `Dockerfile.*` during testing.`systemctl.py` is a Python replacement that does not complain about `systemd` running with an arbitrary PID.
 
 This is done by executing:
-```
-docker run --name "install-test" --privileged -d openhabian/install-openhabian
+
+``` bash
+docker run --privileged --rm --name "openhabian-install" -d openhabian/install-openhabian
 ```
 
 Lastly the installation is invoked by executing:
-```
-docker exec -i "install-test" bash -c "./build.bash local-test && mv ~/.profile ~/.bash_profile && /boot/first-boot.bash"
+
+``` bash
+docker exec -i "openhabian-install" bash -c "./build.bash local-test && mv ~/.profile ~/.bash_profile && /boot/first-boot.bash"
 ```
 
 Be sure to cleanup the tests after you are finished by executing:
-```
-docker stop install-test
-docker rm install-test
+
+``` bash
+docker stop openhabian-install
 ```
 
-Notice that the "Docker system" mimics a hardware SD-card installation with the
-command `./build.bash local-test`.
+Notice that the "Docker system" mimics a hardware SD-card installation with the command `./build.bash local-test`.
 
 ### Test Cases
-The test cases are further divided into three categories and can be individually
-invoked by the [BATS](https://github.com/bats-core/bats-core) framework. The
-tests' categories can be identified in the naming of the test. The tests' code
-are held in a corresponding file to the code itself.
+The test cases are further divided into three categories and can be individually invoked by the [BATS](https://github.com/bats-core/bats-core) framework.
+The tests' categories can be identified in the naming of the test.
+The tests' code are held in a corresponding file to the code itself.
 For example, code would reside in `helpers.bash` with tests in `helpers.bats`.
 
-To begin, first make a Docker container for your platform. An example Docker
-container build for `amd64` would look like:
+To begin, first make a Docker container for your platform.
+An example Docker container build for `amd64` would look like:
+
 ```
-docker build --tag openhabian/bats-openhabian -f Dockerfile.amd64 .
+docker build --tag openhabian/bats-openhabian -f Dockerfile.ubuntu-BATS .
+docker run --privileged --rm --name "openhabian-bats" -d openhabian/bats-openhabian
 ```
 
 Now that we have a functioning Docker container, the categories are as follows:
 
-#### Unit Tests `unit-<name>`
-These tests do not alter the host system, the test is executed and is isolated
-to a specific function. These tests are not required on a installed base system
-of openHABian.
+#### Development Tests `development-<name>`
+These tests run first and allow you to test the fuctionality of code you are actively developing quickly.
+
+``` bash
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "development-." .'
 ```
-docker run --rm --name "unit-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "unit-." .'
+
+#### Unit Tests `unit-<name>`
+These tests do not alter the host system, the test is executed and is isolated to a specific function.
+These tests are not required on a installed base system of openHABian.
+
+``` bash
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "unit-." .'
 ```
 
 #### Installation Verification `installation-<name>`
 This is a suite of tests designed to verify a normal installation.
 These tests **shall** not alter the base openHABian system.
-```
-docker run --rm --name "installation-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "installation-." .'
+
+``` bash
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "installation-." .'
 ```
 
 #### Destructive Verification Tests `destructive-<name>`
-These tests install new functionality and are therefore destructive to the
-openHABian base system. Typical use-cases are testing of optional
-packages or a specific configuration of a baseline package.
-```
-docker run --rm --name "destructive-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "destructive-." .'
+These tests install new functionality and are therefore destructive to the openHABian base system.
+Typical use-cases are testing of optional packages or a specific configuration of a baseline package.
+
+``` bash
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "destructive-." .'
 ```
 
 ### Linter
-The [ShellCheck](https://www.shellcheck.net/) linter can be run by using the
-following commands:
-```
+The [ShellCheck](https://www.shellcheck.net/) linter can be run by using the following commands:
+
+``` bash
 shellcheck -x -s bash openhabian-setup.sh
 shellcheck -x -s bash functions/*.bash
 shellcheck -x -s bash build-image/*.bash
 shellcheck -x -s bash build.bash ci-setup.bash
 ```
 
-### Test Script
-The above tests can all be run as a single script. To run the installation and
-and [BATS](https://github.com/bats-core/bats-core) tests run:
-```
-./test.bash docker-full
-```
+To run the [ShellCheck](https://www.shellcheck.net/) tests automatically run:
 
-To run the [ShellCheck](https://www.shellcheck.net/) tests run:
-```
-./test.bash docker-full
+``` bash
+./test.bash shellcheck
 ```
 
 ## Community Guidelines
 
-We want to keep the openHAB community awesome, growing and collaborative. We
-need your help to keep it that way. To help with this we've come up with some
-general guidelines for the community as a whole.
+We want to keep the openHAB community awesome, growing and collaborative.
+We need your help to keep it that way.
+To help with this we've come up with some general guidelines for the community as a whole.
 The official guidelines are [located here](https://community.openhab.org/guidelines), the essentials are:
 
-*   Be nice: Be courteous, respectful and polite to fellow community members: no
-    regional, racial, gender, or other abuse will be tolerated. We like nice
-    people way better than mean ones!
+*   Be nice: Be courteous, respectful and polite to fellow community members: no regional, racial, gender, or other abuse will be tolerated.
+    We like nice people way better than mean ones!
 
-*   Encourage diversity and participation: Make everyone in our community
-    feel welcome, regardless of their background and the extent of their
-    contributions, and do everything possible to encourage participation in
-    our community.
+*   Encourage diversity and participation: Make everyone in our community feel welcome, regardless of their background and the extent of their contributions, and do everything possible to encourage participation in our community.
 
-*   Keep it legal: Basically, don't get us in trouble. Share only content that
-    you own, do not share private or sensitive information, and don't break the
-    law.
+*   Keep it legal: Basically, don't get us in trouble.
+    Share only content that you own, do not share private or sensitive information, and don't break the law.
 
-*   Stay on topic: Make sure that you are posting to the correct channel
-    and avoid off-topic discussions. Remember when you update an issue or
-    respond to an email you are potentially sending to a large number of
-    people.  Please consider this before you update.  Also remember that
-    nobody likes spam.
+*   Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic discussions.
+    Remember when you update an issue or respond to an email you are potentially sending to a large number of people.
+    Please consider this before you update.
+    Also remember that nobody likes spam.

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ You can change branches at any time use menu option 01.
 In the darkest of times (midwinter for most of us), openHAB 3 gets released.
 See [documentation](docs/openhabian.md#on-openhab3) and [www.openhab.org](http://www.openhab.org) for details.
 
-Merry Christmas and a healthy New Year !
+Merry Christmas and a healthy New Year!
 
 
 ## WiFi Hotspot ## November 14, 2020

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-﻿As an **openHABian end user**, please check out the official openHAB
-documentation:  
+﻿As an **openHABian end user**, please check out the official openHAB documentation:  
 -   <https://www.openhab.org/docs/installation/openhabian.html>
 
 # openHABian - Hassle-free openHAB Setup
@@ -9,174 +8,141 @@ documentation:
 ![Build](https://github.com/openhab/openhabian/workflows/Build/badge.svg)
 
 
-Setting up a fully working Linux system with all needed packages and useful
-tooling is a boring, lengthy albeit challenging task. Fortunately,
+Setting up a fully working Linux system with all needed packages and useful tooling is a boring, lengthy albeit challenging task.
+Fortunately,
 
 ***A home automation enthusiast doesn't have to be a Linux enthusiast!***
 
-openHABian is here to provide a **self-configuring** Linux system setup to meet
-the needs of every openHAB user, in two flavours:
+openHABian is here to provide a **self-configuring** Linux system setup to meet the needs of every openHAB user, in two flavours:
 
-* a **SD-card image pre-configured with openHAB** for all *Raspberry Pi* models
-* as a set of scripts that sets up openHAB and tools on any Debian based system
+*   A **SD-card image pre-configured with openHAB** for all *Raspberry Pi* models
+*   As a set of scripts that sets up openHAB and tools on any Debian based system
 
 ## openHAB versions 2 and 3
 openHABian was created to provide a seamless User eXperience with openHAB.
-Now that openHAB 3 is released to the public, we have incorporated changes to run
-on and migrate to openHAB 3 from within openHABian.
+Now that openHAB 3 is released to the public, we have incorporated changes to run on and migrate to openHAB 3 from within openHABian.
 
 ## Hardware recommendation
-Let's put this first: our current recommendation is to get a RPi 4 with 2 or 4 GB,
-a 3 A power supply and a 16 GB SD card.
-Also get another 32 GB or larger SD card and a USB card reader to make use of the
-["auto backup" feature](docs/openhabian.md#Auto-Backup).
-***
-ATTENTION:<br>
-Avoid getting the 8 GB model of RPi 4.<br>
-8 GB of RAM is a waste of money and it has issues, you must [disable ZRAM](https://github.com/openhab/openhabian/blob/master/docs/openhabian.md#disable-zram) or use the 64bit image (untested).
-***
+Let's put this first: our current recommendation is to get a RPi 4 with 2 or 4 GB, a 3 A power supply and a 16 GB SD card.
+Also get another 32 GB or larger SD card and a USB card reader to make use of the ["auto backup" feature](docs/openhabian.md#Auto-Backup).
+
 ## Hardware support
-As of openHABian version 1.6 and later, all Raspberry Pi models are supported as
-hardware. Anything x86 based may work or not. Anything else ARM based such as ODroids,
-OrangePis and the like may work or not. NAS servers such as QNAP and Synology
-boxes will not work. Support for PINEA64 was dropped in this current release.<br>
-We strongly recommend that users choose Raspberry Pi 2, 3 or 4 systems to have
-1 GB of RAM or more. RPi 1 and 0/0W only have a single CPU core and 512 MB.
-This can be sufficient to run a smallish openHAB setup, but it will
-not be enough to run a full-blown system with many bindings and memory consuming
-openHABian features/components such as ZRAM, InfluxDB or Grafana.
-We do not actively prohibit installation on any hardware, including unsupported
-systems, but we might skip or deny to install specific extensions such as those
-memory hungry applications named above.
+As of openHABian version 1.6 and later, all Raspberry Pi models are supported as hardware.
+Anything x86 based may work or not.
+Anything else ARM based such as ODroids, OrangePis and the like may work or not.
+NAS servers such as QNAP and Synology boxes will not work.
+Support for PINEA64 was dropped in this current release.
 
-Supporting hardware means testing every single patch and every release. There
-are simply too many combinations of SBCs, peripherals and OS flavors that
-maintainers do not have available, or, even if they did, the time to spend on
-the testing efforts that is required to make openHABian a reliable system.<br>
-Let's make sure you understand the implications of these statements: it means
-that to run on hardware other than RPi 2/3/4 or (bare metal i.e. not virtualized)
-x86 may work but this is **not** supported.
+We strongly recommend that users choose Raspberry Pi 2, 3 or 4 systems to have 1 GB of RAM or more.
+RPi 1 and 0/0W only have a single CPU core and 512 MB.
+This can be sufficient to run a smallish openHAB setup, but it will not be enough to run a full-blown system with many bindings and memory consuming openHABian features/components such as zram, InfluxDB or Grafana.
+We do not actively prohibit installation on any hardware, including unsupported systems, but we might skip or deny to install specific extensions such as those memory hungry applications named above.
 
-It may work to install and run openHABian on unsupported hardware. If it does
-not work, you are welcome to find out what's missing and contribute it back to
-the community with a Pull Request. It is sometimes simple things like a naming
-string. We'll be happy to include that in openHABian so you can use your box
-with openHABian unless there's a valid reason to change or remove it.
-However, that does not make your box a "supported" one as we don't have it
-available for our further development and testing. So there remains a risk that
-future openHABian releases will fail to work on your SBC because we changed a
-thing that broke support for your HW - unintentionally so however inevitable.
+Supporting hardware means testing every single patch and every release.
+There are simply too many combinations of SBCs, peripherals and OS flavors that maintainers do not have available, or, even if they did, the time to spend on the testing efforts that is required to make openHABian a reliable system.
 
-For ARM hardware that we don't support, you can try any of the [fake hardware parameters](openhabian.md/#fake-hardware-mode)
-to 'simulate' RPi hardware and Raspi OS. If that still doesn't work for
-you, give [Ubuntu](https://ubuntu.com/download/iot) or [ARMbian](https://www.armbian.com/) a try.
+Let's make sure you understand the implications of these statements: it means that to run on hardware other than RPi 2/3/4 or (bare metal i.e. not virtualized) x86 may work but this is **not** supported.
+
+It may work to install and run openHABian on unsupported hardware.
+If it does not work, you are welcome to find out what's missing and contribute it back to the community with a Pull Request.
+It is sometimes simple things like a naming string.
+We'll be happy to include that in openHABian so you can use your box with openHABian unless there's a valid reason to change or remove it.
+However, that does not make your box a "supported" one as we don't have it available for our further development and testing.
+So there remains a risk that future openHABian releases will fail to work on your SBC because we changed a thing that broke support for your HW - unintentionally so however inevitable.
+
+For ARM hardware that we don't support, you can try any of the [fake hardware parameters](openhabian.md/#fake-hardware-mode) to 'simulate' RPi hardware and Raspi OS. If that still doesn't work for you, give [Ubuntu](https://ubuntu.com/download/iot) or [ARMbian](https://www.armbian.com/) a try.
 
 ## OS support
-Going beyond what the RPi image provides, as a manually installed set of
-scripts, we support running openHABian on x86 hardware on generic Debian.
+Going beyond what the RPi image provides, as a manually installed set of scripts, we support running openHABian on x86 hardware on generic Debian.
 On ARM, we only support Raspberry Pi OS.
 These are what we develop and test openHABian against.
 We do **not support Ubuntu** so no promises. We provide code "as-is", it may work or not.
 Several optional components such as WireGuard or Homegear are known to expose problems.
 
-We expect you to use the current stable distribution, 'buster' for Raspberry
-Pi OS (ARM) and Debian (x86).
-To install openHABian on anything older or newer may work or not. If you
-encounter issues, you may need to upgrade first or to live with the consequences
-of running an OS on the edge of software development.
+We expect you to use the current stable distribution, 'buster' for Raspberry Pi OS (ARM) and Debian (x86).
+To install openHABian on anything older or newer may work or not.
+If you encounter issues, you may need to upgrade first or to live with the consequences of running an OS on the edge of software development.
 
-Either way, please note that you're on your own when it comes to configuring and
-installing the HW with the proper OS yourself.
+Either way, please note that you're on your own when it comes to configuring and installing the HW with the proper OS yourself.
 
-### 64 bit ?
+### 64 bit?
 RPi3 and 4 have a 64 bit processor and you may want to run openHAB in 64 bit.
-We provide a 64bit version of the image but it is unsupported so use it at your
-own risk. Please don't ask for support if it does not work for you.
+We provide a 64bit version of the image but it is unsupported so use it at your own risk.
+Please don't ask for support if it does not work for you.
 It's just provided as-is.
 Be aware that to run in 64 bit has a major drawback: increased memory usage.
 That is not a good idea on a heavily memory constrained platform like a RPi.
-Also remember openHABian makes use of Raspberry Pi OS which as per today still
-is a 32 bit OS.
-We are closely observing development and will adapt openHABian once it will
-reliably work on 64 bit.<br/>
+Also remember openHABian makes use of Raspberry Pi OS which as per today still is a 32 bit OS.
+We are closely observing development and will adapt openHABian once it will reliably work on 64 bit.
 
 On x86 hardware, 64 bit is the standard.
 
 ## Installation and Setup
-Please check the [official documentation article](https://www.openhab.org/docs/installation/openhabian.html)
-to learn about openHABian and please visit and subscribe to our
-[community forum thread](https://community.openhab.org/t/13379).
+Please check the [official documentation article](https://www.openhab.org/docs/installation/openhabian.html) to learn about openHABian and please visit and subscribe to our [community forum thread](https://community.openhab.org/t/13379).
 
-If you want to install openHABian on non-supported hardware, you can actually
-fake it to make openHABian treat your box as if it was one of the supported
-ones. Needless to say that that may work out or not, but it's worth a try. See
-[openhabian](openhabian.md) for how to edit openhabian.conf before booting. Set
-the hw, hwarch and release parameters to match your system best.
+If you want to install openHABian on non-supported hardware, you can actually fake it to make openHABian treat your box as if it was one of the supported ones.
+Needless to say that that may work out or not, but it's worth a try.
+See [openhabian](openhabian.md) for how to edit openhabian.conf before booting.
+Set the `hw`, `hwarch` and `release` parameters to match your system best.
 
 ## Development
-openHABian is foremost a collection of `bash` scripts versioned and deployed
-using git. In the current state the scripts can only be invoked through the
-terminal menu system [whiptail](https://en.wikibooks.org/wiki/Bash_Shell_Scripting/Whiptail).
-There is a longterm need to better separate the UI part from the script code. A
-work has started to define conventions and further explain the code base in the
-document [CONTRIBUTING](CONTRIBUTING.md) along with development guidelines in
-general.
+openHABian is foremost a collection of `bash` scripts versioned and deployed using git.
+In the current state the scripts can only be invoked through the terminal menu system [whiptail](https://en.wikibooks.org/wiki/Bash_Shell_Scripting/Whiptail).
+There is a longterm need to better separate the UI part from the script code.
+A work has started to define conventions and further explain the code base in the document [CONTRIBUTING](CONTRIBUTING.md) along with development guidelines in general.
 
-A good place to look at to start to understand the code is the file
-`openhabian-setup.sh`.
+A good place to look at to start to understand the code is the file `openhabian-setup.sh`.
 
 ### Building Hardware Images
 Take a look at the `build.bash` script to get an idea of the process.
 Run the code below with `platform` being `rpi`.
-The RPi image is based on the [Raspberry Pi OS Lite](https://www.raspberrypi.org/downloads/raspberry-pi-os/)
-(previously called Raspbian) standard image.
-```
+The RPi image is based on the [Raspberry Pi OS Lite](https://www.raspberrypi.org/downloads/raspberry-pi-os/) (previously called Raspbian) standard image.
+
+``` bash
 sudo bash ./build.bash platform
 ```
 
-As the script uses `openhab/openhabian` git repository during installation it
-must sometimes be changed to test code from other repositories, like a new
-feature in a fork. There are two commands for replacing the git repo with a
-custom one. The first command uses the current checked-out repository used in
-the filesystem:
-```
+As the script uses `openhab/openhabian` git repository during installation it must sometimes be changed to test code from other repositories, like a new feature in a fork.
+There are two commands for replacing the git repo with a custom one.
+
+The first command uses the current checked-out repository used in the filesystem:
+
+``` bash
 sudo bash build.bash platform dev-git
 ```
+
 The second command uses a fully customizable repository:
-```
+
+``` bash
 sudo bash build.bash platform dev-url branch url
 ```
 
 ### Testing
-Testing is done continuously with GitHub Actions using the test framework
-[BATS](https://github.com/bats-core/bats-core) and the linter
-[ShellCheck](https://www.shellcheck.net/).  As the tests focus on installing
-software, a [Docker](https://www.docker.com/) solution is used for easy build-up
-and teardown.
+Testing is done continuously with GitHub Actions using the test framework [BATS](https://github.com/bats-core/bats-core) and the linter [ShellCheck](https://www.shellcheck.net/).
+As the tests focus on installing software, a [Docker](https://www.docker.com/) solution is used for easy build-up and teardown.
 
 To run the test suite on a `amd64` platform execute the commands below.
-[Docker](https://www.docker.com/) and [ShellCheck](https://www.shellcheck.net/)
-need to be installed first. For more details regarding the tests see
-[Test Architecture](https://github.com/openhab/openhabian/blob/master/CONTRIBUTING.md#test-architecture)
-in CONTRIBUTING.md.
+[Docker](https://www.docker.com/) and [ShellCheck](https://www.shellcheck.net/) need to be installed first.
+For more details regarding the tests see [Test Architecture](https://github.com/openhab/openhabian/blob/main/CONTRIBUTING.md#test-architecture) in CONTRIBUTING.md.
 
-```
+``` bash
 docker build --tag openhabian/bats-openhabian -f Dockerfile.ubuntu-BATS .
-docker run --rm --name "unit-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "unit-." .'
-docker run --rm --name "installation-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "installation-." .'
-docker run --rm --name "destructive-tests" -i openhabian/bats-openhabian bash -c 'bats --tap --recursive --filter "destructive-." .'
+docker run --privileged --rm --name "openhabian-bats" -d openhabian/bats-openhabian
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "development-." .'
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "unit-." .'
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "installation-." .'
+docker exec -i "openhabian-bats" bash -c 'bats --tap --recursive --filter "destructive-." .'
+docker stop openhabian-bats
 
 docker build --tag openhabian/install-openhabian -f Dockerfile.amd64-installation .
-docker run --name "install-test" --privileged -d openhabian/bats-openhabian
-docker exec -i "install-test" bash -c "./build.bash local-test && mv ~/.profile ~/.bash_profile && /boot/first-boot.bash"
-
-docker stop install-test
-docker rm install-test
+docker run --privileged --rm --name "openhabian-install" -d openhabian/install-openhabian
+docker exec -i "openhabian-install" bash -c "./build.bash local-test && mv ~/.profile ~/.bash_profile && /boot/first-boot.bash"
+docker stop openhabian-install
 ```
 
-The [ShellCheck](https://www.shellcheck.net/) linter can be run by using the
-following commands:
-```
+The [ShellCheck](https://www.shellcheck.net/) linter can be run by using the following commands:
+
+``` bash
 shellcheck -x -s bash openhabian-setup.sh
 shellcheck -x -s bash functions/*.bash
 shellcheck -x -s bash build-image/*.bash

--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -66,7 +66,7 @@ java_opt=Zulu11-32
 # Valid arguments: "light", "dark"
 frontailtheme=light
 
-# install ZRAM per default, set to "disable" to skip installation
+# install zram per default, set to "disable" to skip installation
 zraminstall=enable
 
 # start comitup hotspot if internet is not reachable

--- a/build-image/openhabian.pi-raspios32.conf
+++ b/build-image/openhabian.pi-raspios32.conf
@@ -68,7 +68,7 @@ java_opt=Zulu11-32
 # Valid arguments: "light", "dark"
 frontailtheme=light
 
-# install ZRAM per default, set to "disable" to skip installation
+# install zram per default, set to "disable" to skip installation
 zraminstall=enable
 
 # start comitup hotspot if internet is not reachable

--- a/build-image/openhabian.pi-raspios64beta.conf
+++ b/build-image/openhabian.pi-raspios64beta.conf
@@ -68,7 +68,7 @@ java_opt=Zulu11-64
 # Valid arguments: "light", "dark"
 frontailtheme=light
 
-# install ZRAM per default, set to "disable" to skip installation
+# install zram per default, set to "disable" to skip installation
 zraminstall=enable
 
 # start comitup hotspot if internet is not reachable

--- a/docs/NEWSLOG.md
+++ b/docs/NEWSLOG.md
@@ -9,7 +9,7 @@ You can change branches at any time use menu option 01.
 In the darkest of times (midwinter for most of us), openHAB 3 was released.
 See [documentation](docs/openhabian.md#on-openhab3) and [www.openhab.org](http://www.openhab.org) for details.
 
-Merry Christmas and a healthy New Year !
+Merry Christmas and a healthy New Year!
 
 
 ## WiFi hotspot ## November 14, 2020
@@ -122,9 +122,9 @@ happen to the stable branch in batches, whenever the poor daring people to use
 You can switch branches at any time using the menu option 01.
 
 
-## ZRAM per default
-Swap, logs and persistence files are now put into ZRAM per default.
-See [ZRAM status thread](https://community.openhab.org/t/zram-status/80996) for
+## zram per default
+Swap, logs and persistence files are now put into zram per default.
+See [zram status thread](https://community.openhab.org/t/zram-status/80996) for
 more information.
 
 

--- a/docs/openhabian-DEBUG.md
+++ b/docs/openhabian-DEBUG.md
@@ -1,227 +1,142 @@
 ---
 layout: documentation
 title: openHABian
-source: https://github.com/openhab/openhabian/blob/master/docs/openhabian-DEBUG.md
+source: https://github.com/openhab/openhabian/blob/main/docs/openhabian-DEBUG.md
 ---
 
 <!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository -->
 
-This document is meant to give a guiding hand to users when their openHABian
-install fails either on initial image installation or later on when running menu
-options that install or configure optional components.
+This document is meant to give a guiding hand to users when their openHABian install fails either on initial image installation or later on when running menu options that install or configure optional components.
 
-TL;DR:<br>
-set `debugmode=maximum`in `/etc/openhabian.conf` and see `/boot/first-boot.log` for
-image installation else record the terminal output.<br>
-Do not ask for help on the forum unless you have FULLY read this guide.
+::: tip [TLDR](https://www.howtogeek.com/435266/what-does-tldr-mean-and-how-do-you-use-it/)
+Set `debugmode=maximum`in `/etc/openhabian.conf` and see `/boot/first-boot.log` for image installation else record the terminal output.
+:::
+
+**Do not ask for help on the forum unless you have _FULLY_ read this guide.**
 
 **Attention:**
-If you do not use the image but use `openhabian-config` manually - either to run
-`openhabian-config unattended` or interactive use -, **there is no logfile**.
-To record output in this case, you need to configure your terminal client to record
-and save the command line output.
-In PuTTy there's a field called 'Lines of scrollback' under the 'Window' option in
-settings that you should increase to at least some thousand lines else you might not
-capture everything you need to. Configure any other terminal client likewise.
+If you do not use the image but use `openhabian-config` manually - either to run `openhabian-config unattended` or interactive use -, **there is no logfile**.
+To record output in this case, you need to configure your terminal client to record and save the command line output.
+In PuTTy there's a field called 'Lines of scrollback' under the 'Window' option in settings that you should increase to at least some thousand lines else you might not capture everything you need to.
+Configure any other terminal client likewise.
 
-Keep in mind that parts of the following information such as for example WiFi and
-IPv6 setup don't apply to manually installed systems because they happen at or
-before boot time.
+Keep in mind that parts of the following information such as for example WiFi and IPv6 setup don't apply to manually installed systems because they happen at or before boot time.
 
 ## Prerequisites
-First, please make sure you use the proper host hardware that is supported as
-per [README](https://github.com/openhab/openhabian/blob/master/README.md).
+First, please make sure you use the proper host hardware that is supported as per [README](https://github.com/openhab/openhabian/blob/main/README.md).
 
-openHABian requires a minimum of 1GB of RAM to run well. While you can get away
-with a 512MB box like a RPi0W, you must not run anything other than openHAB
-itself, in particular do **not** run memory hogs such as InfluxDB or Grafana.
+openHABian requires a minimum of 1GB of RAM to run well. While you can get away with a 512MB box like a RPi0W, you must not run anything other than openHAB itself, in particular do **not** run memory hogs such as InfluxDB or Grafana.
 
-openHABian requires you to provide direct Internet access. Using private IP
-addresses is fine as long as your router properly provides NAT (Network Address
-Translation) services.
-Either Ethernet or WiFi is supported at install time, however, Ethernet tends to
-be more reliable and WiFi requires user configuration prior to the first boot of
-openHABian. To configure WiFi, simply edit the `wifi_psk=` and `wifi_ssid=`
-fields in the `boot/openhabian.conf` file on your new SD card.
+openHABian requires you to provide direct Internet access.
+Using private IP addresses is fine as long as your router properly provides NAT (Network Address Translation) services.
+Either Ethernet or WiFi is supported at install time, however, Ethernet tends to be more reliable and WiFi requires user configuration prior to the first boot of openHABian.
+To configure WiFi, simply edit the `wifi_psk=` and `wifi_ssid=` fields in the `boot/openhabian.conf` file on your new SD card.
 
-Your router (or a different device) needs to to provide properly configured DHCP
-services so your openHABian box gets an IP address assigned when you boot it for
-the first time.
-The DHCP server also has to announce which DNS resolver to use so your box
-knows how to translate DNS names into IP addresses.
-It also needs to announce which IP address to use as the default gateway to the
-internet - a typical access router is also the DHCP server will announce it's
-own address here.
-Finally, the DHCP server should also announce the NTP server(s) to use for
-proper time services. Lack thereof will not break the installation procedure but
-can lead to all sorts of long term issues so we recommend to setup DHCP to
-announce a reachable and working NTP server.
+Your router (or a different device) needs to to provide properly configured DHCP services so your openHABian box gets an IP address assigned when you boot it for the first time.
+The DHCP server also has to announce which DNS resolver to use so your box knows how to translate DNS names into IP addresses.
+It also needs to announce which IP address to use as the default gateway to the internet - a typical access router is also the DHCP server will announce it's own address here.
+Finally, the DHCP server should also announce the NTP server(s) to use for proper time services.
+Lack thereof will not break the installation procedure but can lead to all sorts of long term issues so we recommend to setup DHCP to announce a reachable and working NTP server.
 
-A note on IPv6: openHABian was reported failing to boot in some environments
-that make use of IPv6. If basic IP initialization fails (you cannot `ping`
-your box) or installation gets stuck trying to download software packages, you
-might want to try disabling IPv6. You can also do that before the very first
-install attempt if you're sure you don't need any IPv6 connectivity on your
-openHABian box. See [this section of openhabian.md](https://github.com/openhab/openhabian/blob/master/docs/openhabian.md#ipv6-notes)
-how to disable IPv6 on your system.
+A note on IPv6: openHABian was reported failing to boot in some environments that make use of IPv6.
+If basic IP initialization fails (you cannot `ping` your box) or installation gets stuck trying to download software packages, you might want to try disabling IPv6.
+You can also do that before the very first install attempt if you're sure you don't need any IPv6 connectivity on your openHABian box.
+See [this section of openhabian.md](https://github.com/openhab/openhabian/blob/main/docs/openhabian.md#ipv6-notes) how to disable IPv6 on your system.
 Note that this is just a summary to cover the most commonly encountered cases.
-The full boot procedure and how to obtain IP addresses, DNS resolver, default
-route and NTP server addresses are highly complex and widely customizable and a
-comprehensive description on how to properly configure your Internet access and
-router are out of scope of openHABian. Please ask G\*\*gle how to accomplish that.
+The full boot procedure and how to obtain IP addresses, DNS resolver, default route and NTP server addresses are highly complex and widely customizable and a comprehensive description on how to properly configure your Internet access and router are out of scope of openHABian.
+Please use an internet search to find more on your own.
 
 ## Install
 Proceed to installation: Etch-Burn-d(isk)d(ump)-Flash-whatever the image to an SD card.
 
-NOW, read [openhabian.md](https://github.com/openhab/openhabian/blob/master/docs/openhabian.md#openhabianconf)
-how to mount your SD card and how to modify the openHABian config file.
-Some parameters are self-explanatory but please nonetheless read the full explanation
-in the linked document.
-Given that you're already reading the debug guide, the most important parameter
-to set is likely `debugmode=maximum`.
-Once you have passed the first time boot initialization phase and you can login
-to the system, `/etc/openhabian.conf` will be used from there on. You can change
-it at any time to get output on future boot runs or if you use `openhabian-config`
-interactively.
-_At this stage, read the first paragraph on the logfile and interactive use again._
-To see debug output during the image installation process, you need to use the
-procedure from your PC **before** you power your box on.
+NOW, read [openhabian.md](https://github.com/openhab/openhabian/blob/main/docs/openhabian.md#openhabianconf)how to mount your SD card and how to modify the openHABian config file.
+Some parameters are self-explanatory but please nonetheless read the full explanation in the linked document.
+Given that you're already reading the debug guide, the most important parameter to set is likely `debugmode=maximum`.
+Once you have passed the first time boot initialization phase and you can login to the system, `/etc/openhabian.conf` will be used from there on.
+You can change it at any time to get output on future boot runs or if you use `openhabian-config` interactively.
 
-If you have a console available (monitor and keyboard), attach it to follow
-the install process. Now insert the SD card and turn on your system.
-If you don't have any console, try to access the web console at
-`http://<yourhostip>:80/`.
-It will display the contents of `/boot/first-log.boot` at intervals of some seconds
-while installing.
-Mind you that if installation fails, network access may or may not be possible
-so you might need to access the box via console anyway in order to find out what
-went wrong.
+_At this stage, read the first paragraph on the logfile and interactive use again._
+To see debug output during the image installation process, you need to use the procedure from your PC **before** you power your box on.
+
+If you have a console available (monitor and keyboard), attach it to follow the install process.
+Now insert the SD card and turn on your system.
+If you don't have any console, try to access the web console at `http://<yourhostip>:80/`.
+It will display the contents of `/boot/first-log.boot` at intervals of some seconds while installing.
+Mind you that if installation fails, network access may or may not be possible so you might need to access the box via console anyway in order to find out what went wrong.
 
 Login to your box via network using `ssh openhabian@<hostname>`.
-The default hostname is `openhabiandevice`, and the default username and password
-both are `openhabian` unless you changed either of these in `openhabian.conf`
-before you started the installation run.
-If that step fails, try to `ping openhabiandevice`. If that's failing, find out
-the system's IP address (usually by looking at your router's running configuration
-or using the command `arp -a` which is available on either Windows or Linux.
+The default hostname is `openhabian`, and the default username and password both are `openhabian` unless you changed either of these in `openhabian.conf` before you started the installation run.
+If that step fails, try to `ping openhabian`.
+If that's failing, find out the system's IP address (usually by looking at your router's running configuration or using the command `arp -a` which is available on either Windows or Linux).
 If you can login, there probably is an issue with your DHCP server.
 If you cannot ping the system's IP address, try to login on the console.
-In this case you will have to resort to debug the network setup which is beyond
-the scope of this document. There's nothing specific about networking though -
-openHABian just uses the setup of the underlying OS, Raspi OS for RPis that is or
-whatever OS you chose to manually install upon. So again go ask G\*\*gle for help
+In this case you will have to resort to debug the network setup which is beyond the scope of this document.
+There's nothing specific about networking though - openHABian just uses the setup of the underlying OS, Raspi OS for RPis that is or whatever OS you chose to manually install upon.
+So again, use an internet search to find more on your own.
 
 Once logged in, enter `sudo bash` to become the root user.
-Check if your install fails at some stage (also if it seems to hang forever):
-there will exist a file either `/opt/openHABian-install-failed` or
-`/opt/openHABian-install-inprogress` to reflect these states (to check,
-`ls -l /opt/openHABian-install*`).
-As a first troubleshooting step, you should reboot your box to see if the same
-problems occurs on a second attempt.
+Check if your install fails at some stage (also if it seems to hang forever): there will exist a file either `/opt/openHABian-install-failed` or `/opt/openHABian-install-inprogress` to reflect these states (to check, `ls -l /opt/openHABian-install*`).
+As a first troubleshooting step, you should reboot your box to see if the same problems occurs on a second attempt.
 
 ## Debug
-If the problem persists after booting succeeded at least in principle, login and
-check `/boot/first-boot.log` to get an indication what went wrong in the install
-process. You can avoid openHABian to start reinstalling on future reboots by
-removing the status file, i.e. `rm -f /opt/openHABian-install*`, **but** be aware
-that your installation is incomplete and that you should not run openHAB on a box
-in that state.
-You can use this state to debug, you can also use the menu options in
-`openhabian-config` to manually install everything that failed or is missing.
-See `/opt/openhabian/openhabian-setup.sh` and the corresponding code in
-`/opt/openhabian/functions/*.bash` what usually gets installed on an unattended
-installation. Note that if you keep or recreate the status file (just `touch
-/opt/openhabian-install-failed`), you can reboot at any time to continue
-unattended installation. So if say Java install fails (Java being a prerequisite
-to installation of openHAB), you can use `openhabian-config` or manual install,
-then continue installation by rebooting.
-Should you succeed at some point in time - great! Let us know what you did to
-make it work please through a Github issue (see below).
-As we cannot be sure everything on your box is 100% the same what an
-unattended install gets you, please also do a complete reinstall before you
-start operating openHAB. If possible start with the flash step. If that does
-not work, at least delete all the packages that openhabian-setup had installed
-before you reboot. Use `apt purge` (and not just `apt remove`).
+If the problem persists after booting succeeded at least in principle, login and check `/boot/first-boot.log` to get an indication what went wrong in the install process.
+You can avoid openHABian to start reinstalling on future reboots by removing the status file, i.e. `rm -f /opt/openHABian-install*`, **but** be aware that your installation is incomplete and that you should not run openHAB on a box in that state.
+You can use this state to debug, you can also use the menu options in `openhabian-config` to manually install everything that failed or is missing.
+See `/opt/openhabian/openhabian-setup.sh` and the corresponding code in `/opt/openhabian/functions/*.bash` what usually gets installed on an unattended installation.
+Note that if you keep or recreate the status file (just `touch /opt/openhabian-install-failed`), you can reboot at any time to continue unattended installation.
+So if say Java install fails (Java being a prerequisite to installation of openHAB), you can use `openhabian-config` or manual install, then continue installation by rebooting.
+Should you succeed at some point in time - great! Let us know what you did to make it work please through a Github issue (see below).
+As we cannot be sure everything on your box is 100% the same what an unattended install gets you, please also do a complete reinstall before you start operating openHAB.
+If possible start with the flash step.
+If that does not work, at least delete all the packages that openhabian-setup had installed before you reboot.
+Use `apt purge` (and not just `apt remove`).
 
 ### Create a debug log
-You can put openHABian into a more verbose debug level **at any time** after
-the very first installation run: edit the config file `/etc/openhabian.conf`
-using the editor of your choice (use `nano` if you have no idea) and change
-the `debugmode` parameter to either `on` or `maximum` right away (default
-is `off`). If it's missing there, just add it.
-Specifying `maximum` is usually your best choice as it will have
-`openhabian-config` show every single command it executes so you might spot
-the problem right away. If you open an issue, always provide the maintainers
-with a logfile at `maximum` detail level.
+You can put openHABian into a more verbose debug level **at any time** after the very first installation run: edit the config file `/etc/openhabian.conf` using the editor of your choice (use `nano` if you have no idea) and change the `debugmode` parameter to either `on` or `maximum` right away (default is `off`).
+Specifying `maximum` is usually your best choice as it will have `openhabian-config` show every single command it executes so you might spot the problem right away.
+If you open an issue, always provide the maintainers with a logfile at `maximum` detail level.
 
-Your next boot run will also exhibit much more verbose logging. Remember boot
-time output will be appended to `/boot/first-boot.log`.
-If installation still fails to finish, please retrieve that file from your box,
-open a GitHub issue (see next paragraph), thoroughly describe the environment
-conditions and your findings so far and upload the log.
+Your next boot run will also exhibit much more verbose logging.
+Remember boot time output will be appended to `/boot/first-boot.log`.
+If installation still fails to finish, please retrieve that file from your box, open a GitHub issue (see next paragraph), thoroughly describe the environment conditions and your findings so far and upload the log.
 
 ### How to open a Github issue
-While written for openHAB, the guideline at <https://community.openhab.org/t/how-to-file-an-issue/68464>
-also applies to openHABian issues.
-Please proceed as told there. openHABian has its own repository at <https://github.com/openhab/openhabian>.
-Search the issues listed there first if 'your' problem has already been seen and
-eventually opened as an issue by someone else (you should remove the `is:open` filter from the search
-bar to let you see closed issues). If so, you may leave a "me too"
-comment there but please do not open another issue to avoid duplicates.
-You can reference other issues (eventually also request to reopen closed ones)
-and Pull Requests by their number (just type #XXX along with your text,
-GitHub will insert the proper link).
-If you open an issue, we kindly ask you to deliver as much information as
-possible. It is awkward and annoying if we need to spend time asking and asking
-what the real problem is about. Please avoid that situation, be proactive and
-tell us in the first place.
-Once you opened the issue, copy `/boot/first-boot.log` from your openHABian box
-over to your desktop and upload it to GitHub.
-If you succeed logging on and get to see a banner with system information,
-please also copy that as part of your issue.
+While written for openHAB, the guideline at <https://community.openhab.org/t/how-to-file-an-issue/68464> also applies to openHABian issues.
+Please proceed as told there.
+openHABian has its own repository at <https://github.com/openhab/openhabian>.
+Search the issues listed there first if 'your' problem has already been seen and eventually opened as an issue by someone else (you should remove the `is:open` filter from the search bar to let you see closed issues).
+If so, you may leave a "me too" comment there but please do not open another issue to avoid duplicates.
+You can reference other issues (eventually also request to reopen closed ones) and Pull Requests by their number (just type #XXX along with your text, GitHub will insert the proper link).
+If you open an issue, we kindly ask you to deliver as much information as possible.
+It is awkward and annoying if we need to spend time asking and asking what the real problem is about.
+Please avoid that situation, be proactive and tell us in the first place.
+Once you opened the issue, copy `/boot/first-boot.log` from your openHABian box over to your desktop and upload it to GitHub.
+If you succeed logging on and get to see a banner with system information, please also copy that as part of your issue.
 
-If you're able to help in producing a fix to problems, we happily take any
-Pull Request.
-Explaining git and Github unfortunately is out of our scope (Google is your
-friend).
-See the guidelines outlined in [CONTRIBUTING.md](https://github.com/openhab/openhabian/blob/master/CONTRIBUTING.md)
-as well.
-For simple fixes to a single file only, you can click through the source
-starting at <https://github.com/openhab/openhabian> and edit the file online,
-GitHub will then offer to create the PR.
-You can also clone the openHABian repository, make your changes locally and use
-git to check in your changes and upload them to a repo copy of yours, then
-follow the git-offered link to create the PR.
+If you're able to help in producing a fix to problems, we happily take any Pull Request.
+Explaining git and Github unfortunately is out of our scope (the internet is your friend).
+See the guidelines outlined in [CONTRIBUTING.md](https://github.com/openhab/openhabian/blob/main/CONTRIBUTING.md) as well.
+For simple fixes to a single file only, you can click through the source starting at <https://github.com/openhab/openhabian> and edit the file online, GitHub will then offer to create the PR.
+You can also clone the openHABian repository, make your changes locally and use git to check in your changes and upload them to a repo copy of yours, then follow the git-offered link to create the PR.
 
 ## Checkpoint
 Remember to always let `openhabian-config` update itself on start.
 
-If you want to change anything to work around some not yet fixed bug, you can
-directly edit the files in and below `/opt/openhabian` on your box. Just do not
-let `openhabian-config` update itself on start as that would overwrite your
-changes.
-You can also clone (download) a different openHABian version than the most
-current one, e.g. if a maintainer or contributor to openHABian offers or asks
-you to test-drive a development version. Set the `clonebranch` parameter in
-`/etc/openhabian.conf` to the branch name to load, then update `openhabian-config`
-on start.
-**Note**: You must not modify `repositoryurl` to point elsewhere than the
-official repo. openHABian will only ever update from there so you can only
-test drive a test branch that a developer has provided you on the official site.
+If you want to change anything to work around some not yet fixed bug, you can directly edit the files in and below `/opt/openhabian` on your box.
+Just do not let `openhabian-config` update itself on start as that would overwrite your changes.
+You can also clone (download) a different openHABian version than the most current one, e.g. if a maintainer or contributor to openHABian offers or asks you to test-drive a development version.
+Set the `clonebranch` parameter in `/etc/openhabian.conf` to the branch name to load, then update `openhabian-config` on start.
+**Note**: You must not modify `repositoryurl` to point elsewhere than the official repo.
+openHABian will only ever update from there so you can only test drive a test branch that a developer has provided you on the official site.
 
 The main program is in `openhabian-setup.sh`.
-If the initial unattended install fails again and again at the same step (say
-Java installation), you may try to comment that step out. But mind the code in
-`build-image/first-boot.bash` towards the end starting with `git clone`.
-This is where openHABian updates itself. If you don't comment that out as well,
-it'll overwrite your changes on the next install run.
+If the initial unattended install fails again and again at the same step (say Java installation), you may try to comment that step out.
+But mind the code in `build-image/first-boot.bash` towards the end starting with `git clone`.
+This is where openHABian updates itself.
+If you don't comment that out as well, it'll overwrite your changes on the next install run.
 
 ## Disclaimer
 For obvious reasons, changing openHABian code is not a supported procedure.
-We just want to give you a hint what you _could_ try doing if your install fails
-and you're sitting there, desperately looking for a fix.
-Google and learn for yourself how to edit a file, learn to understand shell
-programming basics, you're on your own here.
-If you change openHABian code on your box, remember for the time it takes to get
-openHABian officially fixed, you must not let `openhabian-config` update itself
-on start as that would overwrite your changes.
+We just want to give you a hint what you _could_ try doing if your install fails and you're sitting there, desperately looking for a fix.
+Search the internet and learn for yourself how to edit a file, learn to understand shell programming basics, you're on your own here.
+If you change openHABian code on your box, remember for the time it takes to get openHABian officially fixed, you must not let `openhabian-config` update itself on start as that would overwrite your changes.

--- a/docs/openhabian-amanda.md
+++ b/docs/openhabian-amanda.md
@@ -1,145 +1,145 @@
 # How to backup your openHABian server using Amanda
 
 ## The need for recovery
+
 First, make yourself aware how important a comprehensive backup and recovery concept is.
-Yes, this text is the README on the backup software part for openHABian that you're reading, but take a couple of minutes to
-read and think about recovery in a generic sense first. This might avoid a LOT of frustration.
+Yes, this text is the README on the backup software part for openHABian that you're reading, but take a couple of minutes to read and think about recovery in a generic sense first.
+This might avoid a LOT of frustration.
 
-So you have your smart home working thanks to openHAB(ian).... but what if a component of your system fails ?
+So you have your smart home working thanks to openHAB(ian).... but what if a component of your system fails?
 First thing is: you need spare hardware of EVERY component that needs to work for your smart home to work.
-Think of EVERY relevant component and not just the obvious ones. Think of your Internet router, switch, server, NAS and required
-addons such as a ZWave or 433MHz radio or WiFi USB stick, proper power supplies and the SD card writer.
+Think of EVERY relevant component and not just the obvious ones.
+Think of your Internet router, switch, server, NAS and required addons such as a ZWave or 433MHz radio or WiFi USB stick, proper power supplies and the SD card writer.
 
-Now think of a recovery concept for each of these components: what do you have to do if it fails ?
-If the SD card in your Pi fails because of SD corruption (a very common problem), you need to have a PREinstalled, at least
-somewhat current clone SD card to contain all your current OS packages, including all helper programs you might be using (such
-as say mosquitto or any scripts you might have installed yourself), and your matching CURRENT openHAB config, and more.
+Now think of a recovery concept for each of these components: what do you have to do if it fails?
+If the SD card in your RPi fails because of SD corruption (a very common problem), you need to have a PREinstalled, at least somewhat current clone SD card that contains all your current OS packages, including all helper programs you might be using (such as say mosquitto or any scripts you might have installed yourself), and your matching CURRENT openHAB config, and more.
 If you believe "in case of SD card crash, I'll simply reinstall my server from scratch", then think first!
-How long will that take you? Are you even capable of doing that ? Will the latest version of openHABian/Linux packages be
-guaranteed to work with each other and with your hardware ?
-Do you REALLY remember all the parts and places of your system where you configured something related to your server/home
-network and smart home ? If you're honest to yourself, the answer will often be "NO".
-Yes, you can get your smart home back up working somehow, but it will take several hours, and it will not be a complete
-restoration of all features and setups you used to have in operation before the crash.
+How long will that take you?
+Are you even capable of doing that?
+Will the latest version of openHABian/Linux packages be guaranteed to work with each other and with your hardware?
+Do you REALLY remember all the parts and places of your system where you configured something related to your server/home network and smart home?
+If you're honest to yourself, the answer will often be **NO**.
+Yes, you can get your smart home back up working somehow, but it will take several hours, and it will not be a complete restoration of all features and setups you used to have in operation before the crash.
 
 **A specific word of WARNING:**
-If you run a ZWave network like many openHAB users do, think what you need to do if the controller breaks and you need to
-replace it. A new controller has a different Home ID, so all of your devices will not talk to it unless you re-include all of them (and
-to physically access devices in quite a number of cases means you need to open your walls !!) And even if you have easy access,
-it can take many hours, even more so if it's dark and your ... no I'm NOT joking, and I'm not overdoing things.
-This is what happened to several people, and it can happen to you, too. We have seen people be so frustrated that they gave up
-on openHAB or smart home altogether because of this.
-For RaZberry/zwave.me USB stick, you can run the Z-Way software to backup and restore the ZWave network data including the
-controller. For the Aeon Gen5 stick, there's a Windows tool available for download.
-NOTE: you will face the same type of problem if you run a gateway unit to control commercial systems such as a HomeMatic CCU or Insteon
-controller.
-Remember Murphy's law: When your system fails and you need to restore your system for the first time, you'll notice your backup
-is broken. So dive into and ensure you have a working restore procedure and don't just believe it'll work BUT TEST IT, and
-repeat every now and then.
+If you run a ZWave network like many openHAB users do, think what you need to do if the controller breaks and you need to replace it.
+A new controller has a different Home ID, so all of your devices will not talk to it unless you re-include all of them (and to physically access devices in quite a number of cases means you need to open your walls!!).
+Even if you have easy access, it can take many hours, even more so if it's dark and your ... no I'm **NOT** joking, and I'm not overdoing things.
+This is what happened to several people, and it can happen to you, too.
+We have seen people be so frustrated that they gave up on openHAB or smart home altogether because of this.
+For RaZberry/zwave.me USB stick, you can run the Z-Way software to backup and restore the ZWave network data including the controller.
+For the Aeon Gen5 stick, there's a Windows tool available for download.
+
+**NOTE: you will face the same type of problem if you run a gateway unit to control commercial systems such as a HomeMatic CCU or Insteon controller.**
+
+Remember Murphy's law: When your system fails and you need to restore your system for the first time, you'll notice your backup is broken.
+So dive into and ensure you have a working restore procedure and don't just believe it'll work BUT TEST IT, and repeat every now and then.
 
 ### SD card issues
-The most common setup for a openHAB smart home server is to run a Raspberry Pi off its internal SD card, so we provide a backup
-concept for that one. But it will also work on most other SBCs (single board computers) and modified configurations (such as if
-you moved your OS or parts thereof).
-Pay special attention to SD card size: different models slightly differ in size. Any replacement gear must have *at least*
-the size of the original card so best is to get two identical cards right in the first place. If you don't, ensure at least
-you use the smaller one as your main and the larger one as the replacement card.
+
+The most common setup for a openHAB smart home server is to run a Raspberry Pi off its internal SD card, so we provide a backup concept for that one.
+But it will also work on most other SBCs (single board computers) and modified configurations (such as if you moved your OS or parts thereof).
+Pay special attention to SD card size: different models slightly differ in size.
+Any replacement gear must have _at least_ the size of the original card so best is to get two identical cards right in the first place.
+If you don't, ensure at least you use the smaller one as your main and the larger one as the replacement card.
 
 **Another word of WARNING:**
-To move your system off the internal SD card does NOT solve SD corruption problems or increase reliability in any other way.
-SD cards and USB sticks use the same technology. And SSDs and HDDs still can get corrupted as well, and they can crash, too.
-You may or may not want to use Internet / cloud services for various reasons (privacy, bandwidth, cost), so we provide
-you with one solution that is designed to run on local hardware only. We provide a config to use a directory as the backup
-destination. This can be a directory mounted from your NAS (if you have one), a USB-attached storage stick, hard drive, or other
-device. We also provide a config to store your most important data on Amazon Web Services if you are not afraid of that.
+Moving your system off the internal SD card does NOT solve SD corruption problems or increase reliability in any other way.
+SD cards and USB sticks use the same technology, and SSDs / HDDs still can get corrupted as well, and they can crash, too.
+You may or may not want to use Internet / cloud services for various reasons (privacy, bandwidth, cost), so we provide you with one solution that is designed to run on local hardware only.
+We provide a config to use a directory as the backup destination.
+This can be a directory mounted from your NAS (if you have one), a USB-attached storage stick, hard drive, or other device.
+We also provide a config to store your most important data on Amazon Web Services if you are not afraid of that.
 We believe this will cover most openHAB backup use cases.
-NOTE: don't use CIFS (Windows sharing). If you have a NAS, use NFS instead. It does not work with CIFS because of issues with symlinks,
-and it doesn't make sense to use a Windows protocol to share a disk from a UNIX server (all NAS) to a UNIX client (openHABian) at all.
-If you don't have a NAS, DON'T use your Windows box as the storage server. Attach a USB stick to your Pi instead for storage.
-There's many more possible configurations, the software is very flexible and you can tailor it to your own needs if those offers
-do not match your needs. You could even use it to backup all of your servers (if any) and desktop PCs, including Windows
-machines. Either way, it's not one-or-the-other, you can run multiple configs in parallel.
+NOTE: don't use CIFS (Windows sharing).
+If you have a NAS, use NFS instead.
+It does not work with CIFS because of issues with symlinks, and it doesn't make sense to use a Windows protocol to share a disk from a UNIX server (all NAS) to a UNIX client (openHABian) at all.
+If you don't have a NAS, DON'T use your Windows box as the storage server.
+Attach a USB stick to your Pi instead for storage.
+There's many more possible configurations, the software is very flexible and you can tailor it to your own needs if those offers do not match your needs.
+You could even use it to backup all of your servers (if any) and desktop PCs, including Windows machines.
+Either way, it's not one-or-the-other, you can run multiple configs in parallel.
 But in any case, you will need to have a clone SD card with your CURRENT config.
 
 Now all that being said, let's turn to what what you're here for: how to accomplish the software side of backup and restoration.
 
 ## Some Amanda background
+
 Best is to read up on and understand some of the basic Amanda concepts over at <http://www.amanda.org>.
 That's not a mandatory step but it will probably help you understand a couple of things better.
 The world of UNIX and backup IS complex and in the end, there's no way to fully hide that from a user.
-Here's a couple of those concepts, but this is not a comprehensive list. I cannot understand the system for you,
-that's something you have to accomplish on your own. Read and understand the Amanda docs.
+Here's a couple of those concepts, but this is not a comprehensive list.
+I cannot understand the system for you, that's something you have to accomplish on your own.
+Read and understand the Amanda docs.
 
-*   It's helpful to know that Amanda was originally built to use magnetic tape changer libraries as backup storage in professional
-data center installations. It can operate multiple tape drives in parallel, and the tapes used to be commonly stored in what's
-called a 'slot' inside the tape library cabinet.
-*   The default dumpcycle for an openHABian installation is 2 weeks. Amanda will run a 'level 0' dump (that means to backup EVERYTHING)
-once in a dumpcycle and will run 'level 1' dumps for the rest of the time (that means to only backup files that have CHANGED
-since the last level 0 dump was done, also called an 'incremental' backup).
-Amanda will combine level 0 of some devices with level 1 or 2 of others, aiming to have the more or less same amount of data
-to be backed up every day (every invocation, actually). No, you cannot have it do level 0 on weekends and level 1 else,
-[see FAQ](https://wiki.zmanda.com/index.php/FAQ:How_do_I_make_Amanda_do_full_backups_on_weekends_and_incrementals_during_the_week%3F).
-*   Note for *raw* devices to backup such as `/dev/mmcblk0` (which is the internal SD card reader of a RPi), nothing but a level 0
-dump will work because there is no efficient way  to determine what has been changed since the last full dump.
-So if you include `/dev/mmcblk0` in your disklist, it'll be backed up on EACH run. If you don't want that (as it'll likely consume
-the by far largest part of your backup run time and capacity) then remove it from the disklist. You can create a second Amanda
-configuration to only include that raw device and run it say just once every month. Essentially you need to create a copy of the
-/etc/amanda.conf/openhab-dir directory and contents, but a full explanation is out of scope for these docs.
-*   Typically, for a backup system to use this methodology, you need the amount of storage to be 2-3 times as large as the amount
-of data to be backed up. The number of tapes and their capacity (both of which are sort of artificially set when you store to a
-filesystem) determines how long your storage capacity will last until Amanda starts to overwrite old backups.
-By asking you to enter the total size of the storage area, the Amanda installation routine will compute the maximum amount of
-data that Amanda will store into each tape subdirectory as (storage size) divided by (number of tapes, 15 by default).
-The ability to backup to a directory was added later, but the 'slot', 'drive' and 'tape' concepts were kept. That's why here,
-as a deployment inside openHABian, we will have 'virtual' tapes and slots which are implemented as subdirectories (one for each
-'tape') and filesystem links (two by default config, drive0 and drive1) to point to a virtual tape.
-If you have the drive1 link point to the slot3 directory, it effectively means that tape 3 is currently inserted in drive 1).
-*   Amanda was built on top of UNIX and makes use of its user and rights system, so it is very useful and you are requested to
-familiarize yourself with that. As a general good UNIX practice, you shouldn’t use functional users such as “backup” (the OS
-uses functional users to execute tasks with specific access rights) for administration tasks. Use your personal user instead
-(that you have created that at the beginning of your openHABian installation or "openhabian" by default).
-Installation tasks including post-package-installation changes (edits) of the Amanda config files, require to use the `root`
-user. Any ordinary user (such as your personal one) can execute commands on behalf of root (and with root permission) by
-prepending "sudo " to the command. As yourself, prepend "sudo -u backup" to execute the following command as the "backup" user.
+*   It's helpful to know that Amanda was originally built to use magnetic tape changer libraries as backup storage in professional data center installations.
+    It can operate multiple tape drives in parallel, and the tapes used to be commonly stored in what's called a 'slot' inside the tape library cabinet.
+*   The default dumpcycle for an openHABian installation is 2 weeks.
+    Amanda will run a 'level 0' dump (that means to backup EVERYTHING) once in a dumpcycle and will run 'level 1' dumps for the rest of the time (that means to only backup files that have CHANGED since the last level 0 dump was done, also called an 'incremental' backup).
+    Amanda will combine level 0 of some devices with level 1 or 2 of others, aiming to have the more or less same amount of data to be backed up every day (every invocation, actually).
+    No, you cannot have it do level 0 on weekends and level 1 else, [see FAQ](https://wiki.zmanda.com/index.php/FAQ:How_do_I_make_Amanda_do_full_backups_on_weekends_and_incrementals_during_the_week%3F).
+*   Note for _raw_ devices to backup such as `/dev/mmcblk0` (which is the internal SD card reader of a RPi), nothing but a level 0 dump will work because there is no efficient way to determine what has been changed since the last full dump.
+    So if you include `/dev/mmcblk0` in your disklist, it'll be backed up on EACH run.
+    If you don't want that (as it'll likely consume the by far largest part of your backup run time and capacity) then remove it from the disklist.
+    You can create a second Amanda configuration to only include that raw device and run it say just once every month.
+    Essentially you need to create a copy of the /etc/amanda.conf/openhab-dir directory and contents, but a full explanation is out of scope for these docs.
+*   Typically, for a backup system to use this methodology, you need the amount of storage to be 2-3 times as large as the amount of data to be backed up.
+    The number of tapes and their capacity (both of which are sort of artificially set when you store to a filesystem) determines how long your storage capacity will last until Amanda starts to overwrite old backups.
+    By asking you to enter the total size of the storage area, the Amanda installation routine will compute the maximum amount of data that Amanda will store into each tape subdirectory as (storage size) divided by (number of tapes, 15 by default).
+    The ability to backup to a directory was added later, but the 'slot', 'drive' and 'tape' concepts were kept.
+    That's why here, as a deployment inside openHABian, we will have 'virtual' tapes and slots which are implemented as subdirectories (one for each 'tape') and filesystem links (two by default config, drive0 and drive1) to point to a virtual tape.
+    If you have the drive1 link point to the slot3 directory, it effectively means that tape 3 is currently inserted in drive 1).
+*   Amanda was built on top of UNIX and makes use of its user and rights system, so it is very useful and you should familiarize yourself with that.
+    As a general good UNIX practice, you shouldn’t use functional users such as “backup” (the OS uses functional users to execute tasks with specific access rights) for administration tasks.
+    Use your personal user instead (that you have created that at the beginning of your openHABian installation or `openhabian` by default).
+    Installation tasks including post-package-installation changes (edits) of the Amanda config files, require to use the `root` user.
+    Any ordinary user (such as your personal one) can execute commands on behalf of root (and with root permission) by prepending `sudo` to the command.
+    As yourself, prepend "sudo -u backup" to execute the following commands as the "backup" user.
 
 # Installation
-These notes were written for an interactive installation run. Note openHABian comes with the new ["auto backup" feature](https://github.com/openhab/openhabian/blob/master/docs/openhabian.md#auto-backup).
-It'll essentially mirror your internal SD card to another (bigger) card in an external card reader and uses the remaining space as your Amanda storage area. We highly recommend you to make use of this feature on initial openHABian installation, but you can also setup Amanda later on as well.
+
+These notes were written for an interactive installation run.
+Note openHABian comes with the new ["auto backup" feature](https://github.com/openhab/openhabian/blob/main/docs/openhabian.md#auto-backup).
+It'll essentially mirror your internal SD card to another (bigger) card in an external card reader and uses the remaining space as your Amanda storage area.
+We highly recommend you to make use of this feature on initial openHABian installation, but you can also setup Amanda later on as well.
 
 ## Storage preparation
+
 Now once you read up on all of this and feel you have understood this stuff, the next step will be to prepare your storage.
+
 ***
 HEADS UP: You need to provide your storage BEFORE you install Amanda.
 ***
 
 That is, you have to mount the USB stick or disk from your NAS to a directory that is LOCAL to your openHABian box.
-Specifically for Windows users: if you are not familiar with the UNIX filesystem concept and what it means 'to mount' storage,
-read up on it NOW. Various tutorial can be found on the net such as <https://linoxide.com/linux-how-to/how-to-mount-drive-in-linux> .
-Google is your friend, but make sure you ask specific questions such as “how to mount a NAS disk on a Raspberry Pi” to match your use case.
-So NOW, prepare your storage by creating a directory somewhere and by then mounting the USB device or disk you've previously
-exported (= shared, i.e. made available for mounting) on that directory. This is your mountpoint.
+Specifically for Windows users: if you are not familiar with the UNIX filesystem concept and what it means 'to mount' storage, read up on it NOW.
+Various tutorial can be found on the net such as <https://linoxide.com/linux-how-to/how-to-mount-drive-in-linux>.
+The internet is your friend, but make sure you ask search for specific things such as “how to mount a NAS disk on a Raspberry Pi” to match your use case.
+So NOW, prepare your storage by creating a directory somewhere and by then mounting the USB device or disk you've previously exported (= shared, i.e. made available for mounting) on that directory.
+This is your mountpoint.
 
-*For Windows fans: Let's be clear here. This only works if client AND server side are UNIX machines. And it only works to use NFS.
-If you want to use Windows sharing (CIFS), you can try to use the `nounix` mount option in /etc/fstab of your openHAB machine,
-but this is known to not work in various cases and to cause trouble. You are COMPLETELY on your own here. Using CIFS is NOT SUPPORTED.
-Let alone it also does not make sense as NFS can do the same but any Windows machine will not run 24x7 as a RPi or NAS will do.*
+*For Windows fans: Let's be clear here.
+This only works if client AND server side are UNIX machines.
+And it only works to use NFS.
+If you want to use Windows sharing (CIFS), you can try to use the `nounix` mount option in /etc/fstab of your openHAB machine, but this is known to not work in various cases and to cause trouble.
+You are COMPLETELY on your own here.
+Using CIFS is **NOT SUPPORTED**.
+Let alone it also does not make sense as NFS can do the same but any Windows machine will not run 24x7 as a RPi or NAS will do.
 
-Another specific thing to watch out for when configuring your export share on the NFS server is to add the `no_root_squash`
-option (that's the name on a generic Linux box, depending on your server OS or UI it might have a different name but it'll be
-available, too).
+Another specific thing to watch out for when configuring your export share on the NFS server is to add the `no_root_squash` option (that's the name on a generic Linux box, depending on your server OS or UI it might have a different name but it'll be available, too).
 Its function is to NOT map accesses of userID 0 (root) to some other UID as your server will do by default.
 
-Here's examples how to mount a NAS (to have the DNS name "nas" and IP address 192.168.1.100) and two partitions from an attached
-USB stick identified as `/dev/sda8` (Linux ext4) and `/dev/sda1` and Windows vfat(FAT-32) filesystems.
+Here's examples how to mount a NAS (to have the DNS name "nas" and IP address 192.168.1.100) and two partitions from an attached USB stick identified as `/dev/sda8` (Linux ext4) and `/dev/sda1` and Windows vfat(FAT-32) filesystems.
 
-HEADS UP: These are just EXAMPLES. Device and directory names will be different on your system.
-Do not deploy these commands unless you are fully aware what they will do to your system, using a command with a wrong device
-name can destroy your system.
+HEADS UP: These are just EXAMPLES.
+Device and directory names will be different on your system.
+Do not deploy these commands unless you are fully aware what they will do to your system, using a command with a wrong device name can destroy your system.
 
 ### NAS mount example
 
 ```
------ EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY -----
+----- EXAMPLE ONLY ----- Don't use unless you understand what these commands do! ----- EXAMPLE ONLY -----
+
 pi@pi:~ $ sudo bash
 root@pi:/home/pi# host nas
 nas.fritz.box has address 192.168.1.100
@@ -151,18 +151,17 @@ root@pi:/home/pi# df -k /server
 Filesystem                       1K-blocks       Used Available  Use% Mounted on
 192.168.1.100://share/freespace 2882740768 2502091488 380649280   87% /storage/server
 root@pi:/home/pi#
------ EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY -----
+
+----- EXAMPLE ONLY ----- Don't use unless you understand what these commands do! ----- EXAMPLE ONLY -----
 ```
 
 ### USB storage mount example
 
-Note that this is showing two alternative versions, for FAT16/VFAT filesystems (i.e. the original MS-DOS and the improved
-Windows filesystems that you usually use for USB sticks) and another version to use the ext4 native Linux filesystem. You can
-use ext4 on a stick or USB-attached hard drive.
+Note that this is showing two alternative versions, for FAT16/VFAT filesystems (i.e. the original MS-DOS and the improved Windows filesystems that you usually use for USB sticks) and another version to use the ext4 native Linux filesystem.
+You can use ext4 on a stick or USB-attached hard drive.
 Either way, you just need one or the other.
 
 ```
------ EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY -----
 root@pi:/home/pi# fdisk -l /dev/sda
 Disk /dev/sda: 14,8 GiB, 15836643328 bytes, 30930944 sectors
 Units: sectors of 1 * 512 = 512 bytes
@@ -215,66 +214,55 @@ Filesystem     1K-blocks    Used Available  Use% Mounted on
 /dev/sda8       13403236 8204144   4495196   65% /storage/usbstick-linux
 /dev/sda1       13403236 9018464   3680876   72% /storage/usbstick-msdos
 root@pi:/home/pi#
------ EXAMPLE ONLY ----- Don't use unless you understand what these commands do ! ----- EXAMPLE ONLY -----
 ```
 
 ## Software installation
 
 First, mount/prepare your storage (see examples).
-Next, double check that your `backup` user has write access to all of the storage area (preferrably, he `owns` the directory):
-*Create* a file there (`touch /path/to/storage/file`), check its ownership (`ls -l /path/to/storage/file`), then delete it
+Next, double check that your `backup` user has write access to all of the storage area (preferrably, he `owns` the directory): _Create_ a file there (`touch /path/to/storage/file`), check its ownership (`ls -l /path/to/storage/file`), then delete it
 (`rm /path/to/storage/file`).
-If that does not work as expected (to produce a file that is owned by the `backup` user), you need to change export options
-on your NAS/NFS server. See also [paragraph on `no_root_squash`](#storage-preparation) above.
+If that does not work as expected (to produce a file that is owned by the `backup` user), you need to change export options on your NAS/NFS server.
+See also [paragraph on `no_root_squash`](#storage-preparation) above.
 
 Now finally, install Amanda using the openHABian menu.
-When you start the Amanda installation from the openHABian menu, the install routine will create a directory/link structure in
-the directory you tell it. Your local user named "backup" will need to have write access there. Amanda install routine should do
-that for you, but it only CAN do it for you if you created/mounted it before you ran the installation.
+When you start the Amanda installation from the openHABian menu, the install routine will create a directory/link structure in the directory you tell it.
+Your local user named "backup" will need to have write access there.
+Amanda install routine should do that for you, but it only CAN do it for you if you created/mounted it before you ran the installation.
 
 Installation will ask you a couple of questions.
 *   "What's the directory to store backups into?"
-Here you need to enter the *local* directory of your openHABian box, also known as *the mount point*. This is where you have
-mounted your USB storage or NAS disk share (which in above example for the NAS is `/storage/server` and for the usb stick is
-either `/storage/usbstick-linux` or `/storage/usbstick-msdos`).
-*   "How much storage do you want to dedicate to your backup in megabytes ? Recommendation: 2-3 times the amount of data to be
-backed up. Enter a number to consist of figures only."
-Amanda will use at most this number of megabytes in total as its storage for backup.
-If you choose to include the raw device in the backup cycle (next question), that means you should enter 3 times the size of
-your SD disk NOW. If you choose not to include it (or selected the AWS S3 variant which omits raw SD backups per default), it's
-a lot less data and you need to estimate it by adding up the size of the config directories that are listed in the `disklist`
-file. If you don't have any idea and chose to NOT backup your SD card, enter 1024 (= 1 GByte). If you chose to backup it, the number
-should be larger than the SD capacity in megabytes plus 1024.
-You can change it in the Amanda config file at any later time (the entry below the line reading `define tapetype DIRECTORY {`).
-*   "Backup raw SD card ?" (not asked if you selected AWS S3 storage)
-Answer "yes" if you want to create raw disk backups of your SD card. This is only recommended if your SD card is 8GB or less in
-size, otherwise the backup can take too long. You can always add/remove this by editing `${confdir}/disklist` at a later time.
+    Here you need to enter the _local_ directory of your openHABian box, also known as _the mount point_.
+    This is where you have mounted your USB storage or NAS disk share (which in above example for the NAS is `/storage/server` and for the USB stick is either `/storage/usbstick-linux` or `/storage/usbstick-msdos`).
+*   "How much storage do you want to dedicate to your backup in megabytes?"
+    Amanda will use at most this number of megabytes in total as its storage for backup.
+    If you choose to include the raw device in the backup cycle (next question), that means you should enter 3 times the size of your SD disk NOW.
+    If you choose not to include it (or selected the AWS S3 variant which omits raw SD backups per default), it's a lot less data and you need to estimate it by adding up the size of the config directories that are listed in the `disklist` file.
+    If you don't have any idea and chose to NOT backup your SD card, enter 1024 (= 1 GByte).
+    If you chose to backup it, the number should be larger than the SD capacity in megabytes plus 1024.
+    You can change it in the Amanda config file at any later time (the entry below the line reading `define tapetype DIRECTORY {`).
+*   "Backup raw SD card?" (not asked if you selected AWS S3 storage)
+    Answer "yes" if you want to create raw disk backups of your SD card.
+    This is only recommended if your SD card is 8GB or less in size, otherwise the backup can take too long.
+    You can always add/remove this by editing `${confdir}/disklist` at a later time.
 
 All of your input will be used to create the initial Amanda config files, but you are free to change them later on.
-HEADS UP: if you re-run the install routine, it will OVERWRITE the config files at any time so if you make changes there,
-remember these changes and store them elsewhere, too.
+HEADS UP: if you re-run the install routine, it will OVERWRITE the config files at any time so if you make changes there, remember these changes and store them elsewhere, too.
 Once you're done installing openHABian and Amanda, proceed to the usage guide chapter below.
 
-Finally, another HEADS UP: The first thing you should do after your first backup run ended successfully is to create a clone of
-your active server SD card by restoring the backup to a blank SD card as shown below as an `amfetchdump` example for recovery of a
-raw device's contents. `/dev/mmcblk0` is the Pi's internal SD reader device, and from an Amanda perspective, this is a raw
-device to be backed up to have that same name.
-You will have two Amanda config directories (located in `/etc/amanda`) called `openhab-dir` and `openhab-AWS` if you choose to
-setup both of them.
-If any of your Amanda backup or recovery runs fail (particularly if you try to use the S3 backup), you should try getting it
-to work following the guides and knowledge base available on the web at <http://www.amanda.org/>.
+Finally, another HEADS UP: The first thing you should do after your first backup run ended successfully is to create a clone of your active server SD card by restoring the backup to a blank SD card as shown below as an `amfetchdump` example for recovery of a raw device's contents.
+`/dev/mmcblk0` is the RPi's internal SD reader device, and from an Amanda perspective, this is a raw device to be backed up to have that same name.
+You will have two Amanda config directories (located in `/etc/amanda`) called `openhab-dir` and `openhab-AWS` if you choose to setup both of them.
+If any of your Amanda backup or recovery runs fail (particularly if you try to use the S3 backup), you should try getting it to work following the guides and knowledge base available on the web at <http://www.amanda.org/>.
 There's online documentation including tutorials and FAQs at <http://wiki.zmanda.com/index.php/User_documentation>.
-In case you come across inherent problems or improvements, please let us (openHABian authors) know through a GitHub issue, but
-please don't expect us to guide you through Amanda, which is a rather complex system, and we're basically just users only, too.
+In case you come across inherent problems or improvements, please let us (openHABian authors) know through a GitHub issue, but please don't expect us to guide you through Amanda, which is a rather complex system, and we're basically just users only, too.
 
 
 # Operating Amanda - a (yes, very brief) usage guide
 
 The overall config is to be found in `/etc/amanda/openhab-<config>/amanda.conf`.
 You are free to change this file, but doing so is at your own risk.
-You can specify files, directories and raw devices (such as HDD partitions or SD cards) that you want to be backed up in
-`/etc/amanda/openhab-<config>/disklist`. You are free to add more lines here to have Amanda also take backup of other
-directories of yours.
+You can specify files, directories and raw devices (such as HDD partitions or SD cards) that you want to be backed up in `/etc/amanda/openhab-<config>/disklist`.
+You are free to add more lines here to have Amanda also take backup of other directories of yours.
 
 Note: the raw SD card backup was left out for the AWS S3 config, as that would require a lot of bandwidth and runtime.
 
@@ -283,12 +271,12 @@ openHABian setup routine will create systemd timers in `/etc/systemd/system/` to
 ## Backup
 
 Find below a terminal session log of a manually started backup run.
-It's showing the three most important commands to use. They all can be started as user *backup* only, interactively, via systemd.timer or cron,
-and you always need to specify the config to use. You can have multiple backup configs in parallel use.
+It's showing the three most important commands to use.
+They all can be started as user _backup_ only, interactively, via systemd.timer or cron, and you always need to specify the config to use.
+You can have multiple backup configs in parallel use.
 
-The `amcheck` command is meant to remind you to put in the right removeable storage medium such as a tape or SD card,
-but for the AWS and local/NAS-mounted directory based backup configs, we don't have removable media. So don't get confused,
-`amcheck` is not a required step.
+The `amcheck` command is meant to remind you to put in the right removeable storage medium such as a tape or SD card, but for the AWS and local/NAS-mounted directory based backup configs, we don't have removable media.
+So don't get confused, `amcheck` is not a required step.
 
 The `amdump` command will start the backup run itself.
 The result will be mailed to you (once your mail system was setup - see openHABian menu option 2C).
@@ -296,8 +284,8 @@ The result will be mailed to you (once your mail system was setup - see openHABi
 You can run `amreport [-l=logfile] <config>` at any time to see a report on the last backup run for that config.
 Use -l with a filename of /var/log/amanda/<config>/log* to get reports of past dumps.
 
-**Reminder:** you have to be logged in or use `sudo -u backup` to execute commands as the `backup` user. To accomplish that, you can also login as your ordinary user and
-use the `sudo` (execute commands with superuser privileges) and `su` (switch user) commands as shown below.
+**Reminder:** you have to be logged in or use `sudo -u backup` to execute commands as the `backup` user.
+To accomplish that, you can also login as your ordinary user and use the `sudo` (execute commands with superuser privileges) and `su` (switch user) commands as shown below.
 
 ```
 pi@pi:/etc/amanda/openhab-dir $ sudo su - backup
@@ -390,8 +378,8 @@ backup@pi:~$ amcheck openhab-dir
 
 ### Locating a backup
 
-Depending on the type of storage medium, you eventually may need to locate which volume a wanted backup is stored on.
-You can use the `amadmin` and eventually `amtape` commands to do this:
+Depending on the type of storage medium, you may need to locate which volume a wanted backup is stored on.
+You can use the `amadmin` and `amtape` commands to do this:
 
 ```
 [14:24:16] backup@openhabianpi:~$ amadmin openhab-dir find  openhabianpi /dev/mmcblk0 /var/lib/openhab
@@ -453,8 +441,7 @@ date                host         disk              lv storage     pool        ta
 ### Restoring a file
 
 To restore a file, you need to use the `amrecover` command as the `root` user.
-Note that since Amanda is designed to restore ANY file of the system, you are required to run `amrecover` as the root user to
-have the appropriate file access rights everywhere (neither the `backup` nor your personal user are allowed to write everywhere).
+Note that since Amanda is designed to restore ANY file of the system, you are required to run `amrecover` as the root user to have the appropriate file access rights everywhere (neither the `backup` nor your personal user are allowed to write everywhere).
 Remember in openHABian you can _execute_ commands as root using `sudo <command>`.
 
 `amrecover` sort of provides a shell-like interface to allow for navigating through the stored files.
@@ -524,9 +511,9 @@ Here's another terminal session log to show how a couple of files are restored i
 
 ### Restoring a partition
 
-To restore a raw disk partition, you need to use `amfetchdump` command. Unlike `amdump`, you have to run amfetchdump as user backup, though.
-Here’s another terminal session log to use `amfetchdump` to first retrieve the backup image from your backup storage to image called
-`openhabianpi-image` on `/server/temp/`
+To restore a raw disk partition, you need to use `amfetchdump` command.
+Unlike `amdump`, you have to run amfetchdump as user backup, though.
+Here’s another terminal session log to use `amfetchdump` to first retrieve the backup image from your backup storage to image called `openhabianpi-image` on `/server/temp/`.
 
 **Reminder:** you have to be logged in as the `backup` user.
 
@@ -537,9 +524,10 @@ backup@pi:/server/temp$ amfetchdump -p openhab-dir openhabianpi /dev/mmcblk0 201
   Press enter when ready
 ```
 
-Remember to specify the date. If you don't, Amanda will restore ALL available dumps. That likely is not what you want.
-When the partition(s) you specify to restore are stored across multiple (virtual) tapes, Amanda will eventually ask you to mount
- a specific volume (put a virtual tape into a virtual tape drive).
+Remember to specify the date.
+If you don't, Amanda will restore ALL available dumps.
+That likely is not what you want.
+When the partition(s) you specify to restore are stored across multiple (virtual) tapes, Amanda will eventually ask you to mount a specific volume (put a virtual tape into a virtual tape drive).
 Be prepared and have another terminal window open as the backup user.
 Use `amadmin` (see above) to find out where a specific backup is located.
 When in need, you can instruct Amanda to load a specific volume like this:
@@ -550,23 +538,22 @@ slot   1: time 20170322084708 label openhab-openhab-dir-001
 changed to slot 1
 ```
 
-Finally you can go back to the first terminal window and press Enter. Amanda will automatically pick up the other files if the backup
-consists of more than one file.
+Finally you can go back to the first terminal window and press <kbd>Enter</kbd>.
+Amanda will automatically pick up the other files if the backup consists of more than one file.
 
 ```
 amfetchdump: 4: restoring split dumpfile: date 20170322084708 host pi disk /dev/mmcblk0 part 1/UNKNOWN lev 0 comp N program APPLICATION
   927712 kb
 ```
 
-You can also provide amfetchdump with the date of the backup that you want to restore by adding the date parameter (format e.g. 20180327)
-like this:
+You can also provide amfetchdump with the date of the backup that you want to restore by adding the date parameter (format e.g. 20180327).
 
 ```
 backup@pi:/server/temp$ amfetchdump -p openhab-dir pi /dev/mmcblk0 > /server/temp/openhabianpi-image 20180327
 ```
 
-This line also shows how to restore this image file to a SD card from Linux. In this example, we have an external SD card writer with a
-(blank) SD card attached to /dev/sdd.
+This line also shows how to restore this image file to a SD card from Linux.
+In this example, we have an external SD card writer with a (blank) SD card attached to /dev/sdd.
 
 ```
 backup@pi:/server/temp$ dd bs=4M if=/server/temp/openhabianpi-image of=/dev/sdd
@@ -575,15 +562,18 @@ backup@pi:/server/temp$ dd bs=4M if=/server/temp/openhabianpi-image of=/dev/sdd
 You could also move that temporary recovered image file to your Windows PC that has a card writer, rename the file to have a .raw extension, and use Etcher or other tool in order to write the image to the card.
 
 
-### A final word on when things have gone badly wrong...
+### A final word on when things have gone badly...
 
-and your SD card to contain the Amanda database is broken: you don't have to give up.
+If your SD card that contains the Amanda database is broken: you don't have to give up.
 Whenever you use a directory as the storage area, openHABian Amanda by default creates a copy of its config and index files (to know what's stored where) in your storage directory once a day (see `/etc/systemd/system/amandaBackupDB.service`).
-So you can reinstall openHABian including Amanda from scratch and copy back those files. Eventually see `amadmin import` option.
+So you can reinstall openHABian including Amanda from scratch and copy back those files.
+See `amadmin import` option.
 Even if you fail to recover your index files, you can still access the files in your storage area.
-The `amindex` command can be used to regenerate the database. How to apply unfortunately is  out of scope for this document so please g**gle if needed.
+The `amindex` command can be used to regenerate the database.
+How to apply unfortunately is out of scope for this document so please use and internet search if needed.
 There's also a manual way: Amanda storage files are tar files of the destination directory or compressed raw copies of partitions, both have an additional 32KB header.
-If you just want to retrieve some files from a partition backup file, you can mount that file. See <https://major.io/2010/12/14/mounting-a-raw-partition-file-made-with-dd-or-dd_rescue-in-linux/>.
+If you just want to retrieve some files from a partition backup file, you can mount that file.
+See <https://major.io/2010/12/14/mounting-a-raw-partition-file-made-with-dd-or-dd_rescue-in-linux/>.
 Here's examples how to decode them:
 
 ```

--- a/docs/openhabian-exim.md
+++ b/docs/openhabian-exim.md
@@ -5,8 +5,8 @@ In case you enter anything wrong you can re-initiate the installation process fr
 
 ::: tip if you relay via mail.gmail.com or mail.gmx.net
 Both of these freemailers will only forward your mail when you authenticate with your Google/GMX username first.
-Additionally, GMX requires the "From:" address to be your GMX mail address. Google allows for arbitrary From: but will
-override any From: with your Gmail address.
+Additionally, GMX requires the "From:" address to be your GMX mail address.
+Google allows for arbitrary From: but will override any From: with your Gmail address.
 :::
 
 Here is what you will need to enter:

--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -1,7 +1,7 @@
 ---
 layout: documentation
 title: openHABian
-source: https://github.com/openhab/openhabian/blob/master/docs/openhabian.md
+source: https://github.com/openhab/openhabian/blob/main/docs/openhabian.md
 ---
 
 {% include base.html %}
@@ -9,40 +9,44 @@ source: https://github.com/openhab/openhabian/blob/master/docs/openhabian.md
 <!-- Attention authors: Do not edit directly. Please add your changes to the source repository -->
 
 ::: tip [TLDR](https://www.howtogeek.com/435266/what-does-tldr-mean-and-how-do-you-use-it/)
-Jump to [install instructions](#raspberry-pi-prepackaged-sd-card-image). Please read the _full_ docs before you ask for help.
+Jump to [install instructions](#raspberry-pi-prepackaged-sd-card-image).
+Please read the _full_ docs before you ask for help.
 :::
 
 # openHABian - Hassle-free openHAB Setup
+
 The Raspberry Pi is quite a famous platform for openHAB.
-However, setting up a fully working Linux system with all recommended packages and openHAB recommendations is a **boring task**, takes a lot of time and **Linux newcomers** are challenged in a number of ways although all they want is to run openHAB amd not some server.
+However, setting up a fully working Linux system with all recommended packages and openHAB recommendations is a **boring task**, takes a lot of time and **Linux newcomers** are challenged in a number of ways although all they want is to run openHAB and not some server.
 
 <p style="text-align: center; font-size: 1.2em; font-style: italic;"><q>A home automation enthusiast doesn't have to be a Linux enthusiast!</q></p>
 
 openHABian is a **self-configuring** Linux system setup to meet the needs of every openHAB user.
 It provides:
 
-*   complete **SD-card images pre-configured with openHAB** for the Raspberry Pi line of SBCs
+*   Complete **SD-card images pre-configured with openHAB** for the Raspberry Pi line of SBCs
 *   The openHABian configuration tool to set up and configure openHAB and many related things on any Debian based system
 
 #### Table of Contents
+
 {::options toc_levels="2..3"/}
 -   TOC
 {:toc}
 
 ## Features
-Out of the box, the openHABian image provides
+
+Out of the box, the openHABian image provides:
 
 -   Hassle-free setup without a display or keyboard, connected via Ethernet or [WiFi](#wifi-based-setup-notes)
--   the latest stable version of openHAB
+-   The latest stable version of openHAB
 -   Zulu Embedded OpenJDK Java 8, 11 or AdoptOpenJDK
 -   [openHABian Configuration Tool](#openhabian-configuration-tool) including updater functionality
--   web based openHAB Log Viewer (based on [frontail](https://github.com/mthenw/frontail))
+-   Web based openHAB Log Viewer (based on [frontail](https://github.com/mthenw/frontail))
 -   Samba file sharing [pre-configured to use shares](https://www.openhab.org/docs/installation/linux.html#mounting-locally)
 -   Useful Linux packages pre-installed, including `vim, mc, screen, htop, ...`
 -   Login information screen, powered by [FireMotD](https://github.com/OutsideIT/FireMotD)
 -   Customized Bash shell experience, settings and openHAB syntax highlighting for [vim](https://github.com/cyberkov/openhab-vim) and [nano](https://github.com/airix1/openhabnano)
 -   [Mosquitto](https://mosquitto.org) MQTT broker
--   the [InfluxDB](https://www.influxdata.com/) database to store home automation data and [Grafana](https://grafana.com/) to visualize it
+-   The [InfluxDB](https://www.influxdata.com/) database to store home automation data and [Grafana](https://grafana.com/) to visualize it
 -   FIND, the [Framework for Internal Navigation and Discovery](https://www.internalpositioning.com/)
 -   [Tailscale](https://tailscale.com/blog/how-tailscale-works/) VPN and [WireGuard](https://www.wireguard.com/) for remote VPN access
 
@@ -50,110 +54,91 @@ The included **openHABian Configuration Tool** [`openhabian-config`](#openhabian
 
 ![openHABian-config menu](images/openHABian-config.png)
 
--   Switch openHAB versions 2 vs 3 and select the latest *Release*, *Milestone* or *Snapshot* [*unstable/SNAPSHOT* build](https://www.openhab.org/docs/installation/linux.html#changing-versions) version
+-   Switch between openHAB versions 2 and 3 and select the latest _Release_, _Milestone_, and _SNAPSHOT_ [build versions](https://www.openhab.org/docs/installation/linux.html#changing-versions)
 -   Install and Setup a [reverse proxy](security.html##running-openhab-behind-a-reverse-proxy) with password authentication and/or HTTPS access (incl. [Let's Encrypt](https://letsencrypt.org) certificate) for self-controlled remote access
--   manually set up a WiFi connection
+-   Manually set up a WiFi connection
 -   Setup [Backup](#availability-and-backup) for your system
 -   Easily install and preconfigure [Optional Components](#optional-components) of your choice
--   configure Raspberry Pi specific functions
+-   Configure Raspberry Pi specific functions
     -   Prepare the serial port for the use with extension boards like RaZberry, Enocean Pi, ...
-    -   Use ZRAM to mitigate SD card wearout due to excessive writes
+    -   Use zram to mitigate SD wear due to excessive writes
     -   Move the system partition to an external USB stick or drive
-... and much more
+    -   ... and much more
 
 ## Hardware
 
 ### Hardware recommendation
-Let's put this first: our current recommendation is to get a RPi 4 with 2 or 4 GB,
-a 3 A power supply and a 16 GB SD card.
-Also get another 32 GB or larger SD card and a USB card reader to make use of the
-["auto backup" feature](docs/openhabian.md#Auto-Backup).
 
-::: warning ATTENTION
-Avoid getting the 8 GB model of RPi 4. 8 GB are a waste of money and it has issues,
-you must [disable ZRAM](https://github.com/openhab/openhabian/blob/master/docs/openhabian.md#disable-zram) or use the 64bit image (untested).
-:::
+Let's put this first: our current recommendation is to get a RPi 4 with 2 or 4 GB of RAM, a 3A power supply and a 16 GB SD card.
+Also get another 32 GB or larger SD card and a USB card reader to make use of the ["auto backup" feature](docs/openhabian.md#Auto-Backup).
 
 ### Hardware support
-As of openHABian version 1.6 and later, all Raspberry Pi models are supported as
-hardware. Anything x86 based may work or not. Anything else ARM based such as ODroids,
-OrangePis and the like may work or not. NAS servers such as QNAP and Synology
-boxes will not work. Support for PINEA64 was dropped in this current release.<br>
-We strongly recommend that users choose Raspberry Pi 2, 3 or 4 systems to have
-1 GB of RAM or more. RPi 1 and 0/0W only have a single CPU core and 512 MB.
-This can be sufficient to run a smallish openHAB setup, but it will
-not be enough to run a full-blown system with many bindings and memory consuming
-openHABian features/components such as ZRAM, InfluxDB or Grafana.
-We do not actively prohibit installation on any hardware, including unsupported
-systems, but we might skip or deny to install specific extensions such as those
-memory hungry applications named above.
 
-Supporting hardware means testing every single patch and every release. There
-are simply too many combinations of SBCs, peripherals and OS flavors that
-maintainers do not have available, or, even if they did, the time to spend on
-the testing efforts that is required to make openHABian a reliable system.
-Let's make sure you understand the implications of these statements: it means
-that to run on hardware other than RPi 2/3/4 or (bare metal i.e. not virtualized)
-x86 may work but this is **not** supported.
+As of openHABian version 1.6 and later, all Raspberry Pi models are supported as hardware.
+Anything x86 based may work or not.
+Anything else ARM based such as ODroids, OrangePis and the like may work or not.
+NAS servers such as QNAP and Synology boxes will not work.
+Support for PINEA64 was dropped in this current release.
+We strongly recommend that users choose Raspberry Pi 2, 3 or 4 systems that have 1 GB of RAM or more.
+RPi 1 and 0/0W only have a single CPU core and 512 MB of RAM.
+This can be sufficient to run a smallish openHAB setup, but it will not be enough to run a full-blown system with many bindings and memory consuming openHABian features/components such as zram, InfluxDB or Grafana.
+We do not actively prohibit installation on any hardware, including unsupported systems, but we might skip or deny to install specific extensions such as those memory hungry applications named above.
 
-It may work to install and run openHABian on unsupported hardware. If it does
-not, you are welcome to find out what's missing and contribute it back to
-the community with a Pull Request. It is sometimes simple things like a naming
-string. We'll be happy to include that in openHABian so you can use your box
-with openHABian unless there's a valid reason to change or remove it.
-However, that does not make your box a "supported" one as we don't have it
-available for our further development and testing. So there remains a risk that
-future openHABian releases will fail to work on your SBC because we changed a
-thing that broke support for your HW - unintentionally so however inevitable.
+Supporting hardware means testing every single patch and every release.
+There are simply too many combinations of SBCs, peripherals and OS flavors that maintainers do not have available, or, even if they did, the time to spend on the testing efforts that is required to make openHABian a reliable system.
+Let's make sure you understand the implications of these statements: it means that to run on hardware other than RPi 2/3/4 or (bare metal i.e. not virtualized) x86 Debian may work but this is **not** supported.
 
-For ARM hardware that we don't support, you can try any of the [fake hardware parameters](openhabian.md/#fake-hardware-mode)
-to 'simulate' RPi hardware and Raspi OS. If that still doesn't work for
-you, give [Ubuntu](https://ubuntu.com/download/iot) or [ARMbian](https://www.armbian.com/) a try.
+It may work to install and run openHABian on unsupported hardware.
+If it does not, you are welcome to find out what's missing and contribute it back to the community with a GitHub pull request.
+It is sometimes simple things like a naming string.
+We'll be happy to include that in openHABian so you can use your box with openHABian unless there's a valid reason to change or remove it.
+However, that does not make your box a "supported" one as we don't have it available for our further development and testing.
+So there remains a risk that future openHABian releases will fail to work on your SBC because we changed a thing that broke support for your HW - unintentionally, however inevitably.
 
-### OS support
-Going beyond what the RPi image provides, as a manually installed set of
-scripts, we support running openHABian on x86 hardware on generic Debian.
+For ARM hardware that we don't support, you can try any of the [fake hardware parameters](openhabian.md/#fake-hardware-mode) to 'simulate' RPi hardware and Raspi OS.
+If that still doesn't work for you, give [Ubuntu](https://ubuntu.com/download/iot) or [ARMbian](https://www.armbian.com/) a try.
+
+Going beyond what the RPi image provides, as a manually installed set of scripts, we support running openHABian on x86 hardware on generic Debian.
 On ARM, we only support Raspberry Pi OS.
 These are what we develop and test openHABian against.
-We do **not support Ubuntu** so no promises. We provide code "as-is", it may work or not.
-Several optional components such as WireGuard or Homegear are known to expose problems.
+We do **not** actively **support Ubuntu** so no promises but we provide code "as-is" that is known to run on there.
+Several optional components though, such as WireGuard or Homegear, are known to expose problems.
 
-We expect you to use the current stable distribution, 'buster' for Raspberry
-Pi OS (ARM) and Debian (x86).
-To install openHABian on anything older or newer may work or not. If you
-encounter issues, you may need to upgrade first or to live with the consequences
-of running an OS on the edge of software development.
+We expect you to use the current stable distribution: 'buster' for Raspberry Pi OS (ARM) and Debian (x86), with 'focal' for Ubuntu (x86).
+To install openHABian on anything older or newer may work or not.
+If you encounter issues, you may need to upgrade first or to live with the consequences of running an OS on the edge of software development.
 
-Either way, please note that you're on your own when it comes to configuring and
-installing the HW with the proper OS yourself.
+Either way, please note that you're on your own when it comes to configuring and installing the HW with the proper OS yourself.
 
-### 64 bit ?
+### 64 bit?
+
 RPi3 and 4 have a 64 bit processor and you may want to run openHAB in 64 bit.
-We provide a 64bit version of the image but it is unsupported so use it at your
-own risk. Please don't ask for support if it does not work for you.
+We provide a 64bit version of the image but it is unsupported so use it at your own risk.
+Please don't ask for support if it does not work for you.
 It's just provided as-is.
 Be aware that to run in 64 bit has a major drawback: increased memory usage.
 That is not a good idea on a heavily memory constrained platform like a RPi.
-Also remember openHABian makes use of Raspberry Pi OS which as per today still
-is a 32 bit OS.
+Also remember openHABian makes use of Raspberry Pi OS which as per today still is a 32 bit OS.
 We are closely observing development and will adapt openHABian once it will
-reliably work on 64 bit.<br/>
+reliably work on 64 bit.
 
 On x86 hardware, 64 bit is the standard.
 
 ## Raspberry Pi prepackaged SD card image
+
 **Flash, plug, wait, enjoy:**
 The provided image is based on the [Raspberry Pi OS Lite](https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit) (previously called Raspbian) standard system.
 openHABian is designed as a headless system, you will not need a display or a keyboard.
-On first boot, the system will set up openHAB, its tools and settings. Packages will be downloaded in their newest version and configured.
+On first boot, the system will set up openHAB, its tools and settings.
+Packages will be downloaded in their newest version and configured.
 The whole process will take a few minutes, then openHAB and all other tools needed to get started will be ready to use without further configuration steps.
 
 **Setup:**
 
--   [Download the latest "openHABian" SD card image file](https://github.com/openhab/openhabian/releases) (Note: the file is *xz* compressed)
--   Write the image to your SD card (e.g. with [Etcher](https://www.balena.io/etcher/) or official [Raspberry Pi Imager](https://www.raspberrypi.org/software/), both able to directly work with *xz* files
--   Insert the SD card into your Raspberry Pi, connect your Ethernet cable - [WiFi is also supported](#wifi-based-setup-notes) - and power on.
--   Wait approximately **15-45 minutes** for openHABian to do its magic. <br>You can watch the install progress from within your browser.
+-   [Download the latest "openHABian" SD card image file](https://github.com/openhab/openhabian/releases) (Note: the file is _xz_ compressed)
+-   Write the image to your SD card (e.g. with [Etcher](https://www.balena.io/etcher/) or official [Raspberry Pi Imager](https://www.raspberrypi.org/software/), both able to directly work with _xz_ files
+-   Insert the SD card into your Raspberry Pi, connect your Ethernet cable - [WiFi is also supported](#wifi-based-setup-notes) - and power on
+-   Wait approximately **15-45 minutes** for openHABian to do its magic, you can watch the install progress from within your browser.
 -   The system will be accessible by its IP or via the local DNS name `openhabian` (or whatever you changed 'hostname' in `openhabian.conf` to)
 -   Connect to the openHAB UI at [http://openhabian:8080](http://openhabian:8080)
 -   [Connect to the Samba network shares](https://www.openhab.org/docs/installation/linux.html#mounting-locally)
@@ -173,23 +158,24 @@ You will see the following welcome screen:
 
 <a id="manual-setup"></a>
 ### Other Linux Systems (add openHABian just like any other software)
+
 Going beyond what the RPi image provides, you can also openHABian on x86 hardware on top of any existing Debian installation.
-Please note that the unattended install is tailored to work for Raspberries. We cannot test HW/OS combos beyond RPis upfront so there is no promise for this work.
+Please note that the unattended install is tailored to work for Raspberries.
+We cannot test HW/OS combos beyond RPis upfront so there is no promise for this work.
 See the [Hardware and OS section](#hardware-and-os-support) for details on supported hardware and OSs before you proceed.
 Note that although the core parts of openHABian were reported to work on there, Ubuntu is not supported and untested.
 If you try and fail, please help and drop us a note on Github with debug log enabled, see [DEBUG guide](openhabian-DEBUG.md).
-***
 
 Start with a fresh installation of your operating system, login and run
 
-```shell
+``` bash
 # start shell as root user
 sudo bash
 ```
 
 then start installation
 
-```shell
+``` bash
 # install git - you can skip this if it's already installed
 apt-get update
 apt-get install git
@@ -199,29 +185,33 @@ git clone -b openHAB3 https://github.com/openhab/openhabian.git /opt/openhabian
 ln -s /opt/openhabian/openhabian-setup.sh /usr/local/bin/openhabian-config
 cp /opt/openhabian/openhabian.conf.dist /etc/openhabian.conf
 ```
+
 Edit `/etc/openhabian.conf` to match your needs, then finally use
 
-```shell
+``` bash
 openhabian-config unattended
 ```
+
 to install.
 
 #### Interactive install on generic x86 Linux
-We strongly recommend you to use the automated install but you actually *can* walk through the interactive tool.
+
+We strongly recommend you to use the automated install but you actually _can_ walk through the interactive tool.
 Start `openhabian-config`.
-Get the bare minimum you will *need* installed by selecting menu option 03.
+Get the bare minimum you will _need_ installed by selecting menu option 03.
 To install the recommended components that automated install will get in one go select menu options 33, 32, 31, 11, 12, 15, Zulu 11 OpenJDK 64-bit (in menu 4X), 13, 16, 14, 21, 38, 53, 52.
 We try to make install options independent of each other but there may be dependencies we are not aware of left so any other order may or may not work.
 
 ➜ Continue at the ["openHABian Configuration Tool"](#openhabian-configuration-tool) chapter below
 
 ## openHABian Configuration Tool
+
 The following instructions are developed for a Raspberry Pi but should be applicable to all hardware / all openHABian environments.
 Once connected to the command line console of your system, please execute the openHABian configuration tool by typing the following command:
 
 (Hint: sudo executes a command with elevated rights and will hence ask for your password: `openhabian`).
 
-```shell
+``` bash
 sudo openhabian-config
 ```
 
@@ -231,35 +221,44 @@ The configuration tool is the heart of openHABian.
 It is not only a menu with a set of options, it's also used in a special unattended mode to automate the setup run, either as part of the RPi image or in a manual install run.
 
 ⌨ - A quick note on menu navigation.
-Use the cursor keys to navigate, <kbd>Enter</kbd> to execute, <kbd>Space</kbd> to select and <kbd>Tab</kbd> to jump to the actions on the bottom of the screen. Press <kbd>Esc</kbd> twice to exit the configuration tool.
+Use the cursor keys to navigate, <kbd>Enter</kbd> to execute, <kbd>Space</kbd> to select and <kbd>Tab</kbd> to jump to the actions on the bottom of the screen.
+Press <kbd>Esc</kbd> twice to exit the configuration tool.
 
 ### Linux Hints
+
 Many helpful articles can be found on the internet, for example:
 
 -   "Learn the ways of Linux-fu, for free" interactively with exercises at [linuxjourney.com](https://linuxjourney.com).
 -   The official Raspberry Pi help articles over at [raspberrypi.org](https://www.raspberrypi.org/help)
 -   "Now what?", Tutorial on the Command line console at [LinuxCommand.org](http://linuxcommand.org/index.php)
 
-*The good news:* openHABian helps you to stay away from Linux - *The bad news:* not for long...
+_The good news:_ openHABian helps you to stay away from Linux - _The bad news:_ not for long...
 
 Regardless of if you want to copy some files or are on the search for a solution to a problem, sooner or later you'll have to know some Linux.
 Take a few minutes to study the above Tutorials and get to know the most basic commands and tools to be able to navigate on your Linux system, edit configurations, check the system state or look at log files.
 It's not complicated and something that doesn't hurt on one's résumé.
 
 ### First steps with openHAB
+
 After your first setup of openHABian is successful and you are able to access the openHAB dashboard, you should dig into the possibilites.
 Install [Bindings](https://www.openhab.org/addons/), discover your devices, and [configure your smart home](https://www.openhab.org/docs/configuration/).
 You might want to start defining [Items](https://www.openhab.org/docs/configuration/items.html), [Sitemap](https://www.openhab.org/docs/configuration/sitemaps.html) and [HABPanel](https://www.openhab.org/docs/configuration/habpanel.html) dashboard for your home, but these are just some first hints.
 Be sure to read up on the [Configuration](https://www.openhab.org/docs/configuration/) section of the documentation pages to learn more.
 
 ### Further configuration steps
+
 openHABian is supposed to provide a ready-to-use openHAB base system.
 There are a few things, however, we need you to decide and act on right now at the beginning:
 
--   **Delayed Rules loading** openHAB startup times can be annoyingly long. There's an optimization available that *delays* loading the rules. It quickly renames rules forth and back after 2 minutes, *effectively speeding up* openHAB startup. This is setup by default, you can disable this via \[menu option: 44\].
--   **Timezone:** The time zone of your openHABian system will be determined based on your internet connection. In some cases you might have to adjust that setting.
--   **Language:** The `locale` setting of the openHABian base system is set to "en_US.UTF-8". While this setting will not do any harm, you might prefer e.g. console errors in German or Spanish. Change the locale settings accordingly. Be aware, that error solving might be easier when using the English error messages as search phrases.
--   **Passwords:** Relying on default passwords is a security concern you should care about! The openHABian system is preconfigured with a few passwords you should change to ensure the security of your system. This is especially important if your system is accessible from outside your private subnet.
+-   **Timezone:** The time zone of your openHABian system will be determined based on your internet connection.
+    In some cases you might have to adjust that setting.
+-   **Language:** The `locale` setting of the openHABian base system is set to "en_US.UTF-8".
+    While this setting will not do any harm, you might prefer e.g. console errors in German or Spanish.
+    Change the locale settings accordingly.
+    Be aware, that error solving might be easier when using the English error messages as search phrases.
+-   **Passwords:** Relying on default passwords is a security concern you should care about!
+    The openHABian system is preconfigured with a few passwords you should change to ensure the security of your system.
+    This is especially important if your system is accessible from outside your private subnet.
 
 All of these settings can be changed via the openHABian configuration tool.
 
@@ -267,53 +266,74 @@ Here are the passwords in question with their respective default "username:passw
 They can be changed from openHABian menu.
 
 ### Passwords
+
 -   User password needed for SSH or sudo (e.g. "openhabian:openhabian")
 -   Samba share password (e.g. "openhabian:openhabian")
 -   openHAB remote console (e.g. "openhab:habopen")
 -   Amanda backup password (no default, applied when installing)
--   Nginx reverse proxy login (no default, applied when installing) *For manual configuration see [here](https://www.openhab.org/docs/installation/security.html#adding-or-removing-users).*
+-   Nginx reverse proxy login (no default, applied when installing) _For manual configuration see [here](https://www.openhab.org/docs/installation/security.html#adding-or-removing-users)._
 -   InfluxDB (No password set by default)
 -   Grafana visualization ("admin:admin")
 
 ## Availability and Backup
+
 openHAB is designed to reliably run 24 hours a day, seven days a week - and so should be your server.
-This is the right time to prepare your system for disasters such as getting hit by the SD card wearout/corruption problem which is quite common among users of single board computers such as Raspberry Pis. openHABian has a number of features built in to enhance resilience:
+This is the right time to prepare your system for disasters such as getting hit by the SD card wear-out/corruption problem which is quite common among users of single board computers such as Raspberry Pis. openHABian has a number of features built in to enhance resilience:
 
-1.  the ZRAM feature moves write intensive parts of openHABian into RAM to mitigate the risk of SD card corruption. See [community thread](https://community.openhab.org/t/zram-status/80996) for more up to date information.
-WARNING: power failure will result in some data to get lost (albeit the system should continue to run). Get an UPS.
-ZRAM is enabled by default for swap, logs and persistence data. You can toggle use in \[menu option 38\].
-2.  Move the root filesystem to USB-attached memory. WARNING: USB sticks are as susceptible to flash wearout as SD cards are, making ZRAM the better choice for a standard Pi to run off its internal SD card. But you can use this option to migrate your system to a safe medium such as an SSD or HDD. \[menu option 37\]
+1.  The zram feature moves write intensive parts of openHABian into RAM to mitigate the risk of SD card corruption. See [community thread](https://community.openhab.org/t/zram-status/80996) for more up to date information.
+    WARNING: power failure will result in some data to get lost (albeit the system should continue to run).
+    Get an UPS.
+    Zram is enabled by default for swap, logs and persistence data.
+    You can toggle use in \[menu option 38\].
+2.  Move the root filesystem to USB-attached memory.
+    WARNING: USB sticks are as susceptible to flash wear-out as SD cards are, making zram the better choice for a standard Pi to run off its internal SD card.
+    But you can use this option to migrate your system to a safe medium such as an SSD or HDD.
+    See \[menu option 37\].
 3.  Use the openHAB integrated [openhab-cli tool](https://community.openhab.org/t/recommended-way-to-backup-restore-oh2-configurations-and-things/7193/82) to interactively backup/restore your openHAB **config** \[menu option 50/51\].
-4.  Use [Amanda Network Backup](http://www.amanda.org/) for full system backups, documentation [here](https://github.com/openhab/openhabian/blob/master/docs/openhabian-amanda.md). \[menu option 52\]
+4.  Use [Amanda Network Backup](http://www.amanda.org/) for full system backups, documentation [here](https://github.com/openhab/openhabian/blob/main/docs/openhabian-amanda.md).
+    See \[menu option 52\].
 
-Standard openHABian install enables ZRAM by default (#1). Once you attach a *safe* external medium to your system (such as an SSD), you can disable ZRAM (#1) and move the system over using menu options 37 (#2).
-Finally, we strongly suggest you install Amanda (#4) right after you finish your setup. Amanda is to take care to backup the whole system to be able to quickly restore it when in need.
-This is not done by default because it requires a number of user inputs, but you should not skip it for your own safety !
+Standard openHABian install enables zram by default (#1).
+Once you attach a _safe_ external medium to your system (such as an SSD), you can disable zram (#1) and move the system over using menu options 37 (#2).
+Finally, we strongly suggest you install Amanda (#4) right after you finish your setup.
+Amanda is to take care to backup the whole system to be able to quickly restore it when in need.
+This is not done by default because it requires a number of user inputs, but you should not skip it for your own safety!
 
-`Delayed rules load` will be enabled by default in openHAB 2 but disabled in openHAB 3 (which has a new startlevel system).
-This function will rename the rules files so they get ignored by the starting openHAB instance, then after 2 minutes they're renamed back. You can toggle to use this feature in menu option 44.
+`Delayed rules load` will be enabled by default in openHAB 2 but disabled in openHAB 3 (which has a new start-level system).
+This function will rename the rules files so they get ignored by the starting openHAB instance, then after 2 minutes they're renamed back.
+You can toggle to use this feature in menu option 44.
 
 ## Setup notes
 
-### On openHAB3
+### On openHAB 3
+
 Starting with its general release, openHABian will install **openHAB 3** by default.
 There's some big changes also to openHABian such as to install Java 11 and to use changed file and directory names.
 Most directory names `... /openhab2/ ...` will become `... /openhab/ ...` (NOTE: not `openhab3`) plus there's changes in a number of places, often subtle ones like the name of Samba export shares to change.
 For openHABian users running openHAB 2.X, `openhabian-config` offers to migrate the openHABian environment and install openHAB3 for you.
-Menu option 42 will do the upgrade. Be aware that it isn't the universal answer to all your migration needs - there is ONLY an openHAB upgrade path. You cannot downgrade from OH3 to OH2.
+Menu option 42 will do the upgrade.
+Be aware that it isn't the universal answer to all your migration needs - there is ONLY an openHAB upgrade path.
+You cannot downgrade from openHAB 3 to openHAB 2.
 
 ::: warning No downgrades
-Take an openHAB config backup BEFORE you upgrade from openHAB v2 to v3. You should also take a system level backup !
+Take an openHAB config backup BEFORE you upgrade from openHAB v2 to v3. You should also take a system level backup!
 :::
-Menu option 42 can also do the downgrade and change the environment back to match openHAB 2 **BUT** it'll ONLY exchange the binary packages. There is no migration to change your configuration back to a OH2 compatible one. So it is essential that you take a backup before you upgrade. You will have to restore your setup from that backup after a downgrade using menu option 51 or by manually using `openhab-cli restore <archive file>`.
-Note option 42 will also not downgrade Java. openHAB 2 however is known to run with Zulu Java 11 as well.
+
+Menu option 42 can also do the downgrade and change the environment back to match openHAB 2 **BUT** it'll ONLY exchange the binary packages.
+There is no migration to change your configuration back to a openHAB 2 compatible one.
+So it is essential that you take a backup before you upgrade.
+You will have to restore your setup from that backup after a downgrade using menu option 51 or by manually using `openhab-cli restore <archive file>`.
+Note option 42 will also not downgrade Java.
+openHAB 2 however is known to run with Java 11 as well.
 
 ### `openhabian.conf`
-You can actually set a number of parameters _before_ you run an unattended installation. This applies to the RPi image on an SD card as well as to a manual installation.
+
+You can actually set a number of parameters _before_ you run an unattended installation.
+This applies to the RPi image on an SD card as well as to a manual installation.
 You can also try with a different set of parameters if your initial attempt fails:
 
 -   Flash the system image to your micro SD card as described, do not remove the SD card yet
--   Access the first SD card partition. It's a vfat/FAT-32 (Windows) filesystem so just use the file explorer of your client PC.
+-   Access the first SD card partition (it's a vfat/FAT-32 (Windows) filesystem so just use the file explorer of your client PC)
 -   Open the file `openhabian.conf` in a text editor
 -   Uncomment and complete the lines to contain the parameters you want to set
 -   Save, unmount/eject, remove and insert into the RPi and boot it
@@ -322,97 +342,103 @@ You can also try with a different set of parameters if your initial attempt fail
 Mind the comments for each configuration parameter. Browse the next documentation section for more explanations.
 
 #### Administration user
+
 Raspberry Pi OS images include a Linux user (`pi`) that you can use for openHAB administration.
 openHABian renames the user to what you specify in the `username` parameter and assigns the `userpw` password first, then it proceeds and makes various settings that are either useful (such as some aliases) or required to run openHAB.
 You can also make use of this if you don't use the image but unattended installation on non-RPi hardware, openHABian will then _create_ that user for you if it does not yet exist.
 
 #### admin key
-Make the `adminkeyurl` point to an URL to contain a public SSH key. This will be included with your administration
-user's `.ssh/authorized_keys` and the openHAB console so the admin user (yourself, usually) can login after installation.
+
+Make the `adminkeyurl` point to an URL to contain a public SSH key.
+This will be included with your administration user's `.ssh/authorized_keys` and the openHAB console so the admin user (yourself, usually) can login after installation.
 
 #### WiFi based setup notes
+
 If you own a RPi3, RPi3+, RPi4, a RPi0W or any other model with a compatible WiFi dongle you can set up and use openHABian via WiFi only.
 For the WiFi based setup to work, you'll need to make your SSID and password known to the system before the first boot.
 So in addition to the setup instructions given above, uncomment and complete the lines reading `wifi_ssid=""` and `wifi_psk=""` in `openhabian.conf`.
 
 #### WiFi Hotspot
+
 Whenever the WiFi interface wlan0 exists but does not have connectivity, openHABian will launch a **Hotspot**.
 When you use your mobile phone to scan for WiFi networks, you should be seeing a new network called `openHABian-<n>`.
 Connecting will work without a password. Once connected, open your browser and point it at `http://raspberrypi.local` or `http://comitup-<n>`.
-This may or may not work for your mobile browser as it requires Bonjour/ZeroConf abilities. If you cannot connect to this address, go to `http://10.41.0.1`.
-On that page you can select the SSID of the network you want to connect your system to. Provide the password and press the button.
+This may or may not work for your mobile browser as it requires Bonjour/ZeroConf abilities.
+If you cannot connect to this address, go to `http://10.41.0.1`.
+On that page you can select the SSID of the network you want to connect your system to.
+Provide the password and press the button.
 Note that as soon as you do, the wlan0 IP address changes so your mobile browser will not be able to provide you any feedback if that worked out.
 Try to ping the new system's hostname (default is `openhabian`) or check DHCP on your router if your openHABian system appeared there.
 For more information on this feature see [comitup-cli](https://davesteele.github.io/comitup/).
 You can use `sudo comitup-cli` inside openHABian to change networks and eventually remove network credentials.
 Note the hotspot may not only become available during installation: it will remain on standby and will show up again every time your `wlan0` interface is losing connectivity.
-The hotspot feature is known to work on RPi 0W, 3 and 4 but is known to often expose problems with WiFi USB adapters.
+The hotspot feature is known to work on RPi-0W, RPi-3, and RPi-4 but is known to often expose problems with WiFi USB adapters.
 
-#### Disable ZRAM
-ZRAM is activated by default on fresh installations on ARM hardware except on a 8GB RPi4 as that is known to be incompatible at the time of writing, leading to kernel crashes.
-If you want to disable ZRAM for a different reason, use `zraminstall=disable` in `openhabian.conf` to install without.
+#### Disable zram
+
+Zram is activated by default on fresh installations on ARM hardware.
+If you want to disable zram for some reason, use `zraminstall=disable` in `openhabian.conf` to install without.
 
 #### Debug mode
-See [Troubleshooting](#troubleshooting) section if you run into trouble installing. If you want to turn on debug mode,
-edit `openhabian.conf` and set the `debugmode=` parameter to either `off`, `on` or `maximum`.
+
+See [Troubleshooting](#troubleshooting) section if you run into trouble installing.
+If you want to turn on debug mode edit `openhabian.conf` and set the `debugmode=` parameter to either `off`, `on` or `maximum`.
 Mind you that if you intend to open an issue, we need you to provide the output of `debugmode=maximum` so if you're in interactive mode, set your terminal to record output.
 
 #### Auto-backup
+
 You might want to setup openHABian to automatically backup and mirror your internal SD card to an external unit.
-We suggest to use another SD card in an external card writer device so that in case your internal SD card fails,
-you can switch SD cards to get the system back up running fast.
-Note most "16GB" cards are not _exactly_ 16 GB and your new one mustn't have less bytes than the old one so
-openHABian enforces the second card to have at least twice the size of your internal card.
+We suggest to use another SD card in an external card writer device so that in case your internal SD card fails, you can switch SD cards to get the system back up running fast.
+Note most "16GB" cards are not _exactly_ 16 GB and your new one mustn't have less bytes than the old one so openHABian enforces the second card to have at least twice the size of your internal card.
 We make use of that extra space as storage for the backup system.
 
 To setup right at installation time:
 Define `backupdrive=/dev/sdX` (replace X with the proper character) to enable this functionality right during unattended installation.
-Eventually change `storagedir=/storage` to any other name.
+You may change `storagedir=/storage` to any other name.
 The first attached disk type device is usually called `/dev/sda`.
-openHABian will create partitions 1 and 2 to be mirrors of your internal card and will assign the remaining space
-to a storage partition.
+openHABian will create partitions 1 and 2 to be mirrors of your internal card and will assign the remaining space to a storage partition.
 Full mirroring will take place semiannually and for the 2nd partition (Linux root), changes will be synced once a week.
 See `systemctl list-timers`, timers are defined in `/etc/systemd/system/sd*.timer`.
 The unattended install routine will also setup Amanda to take daily backups and store them to that third partition.
 Use `storagecapacity=xxx` to override how much space to consume at most for Amanda backup storage (in MB).
-If you choose to skip this during system installation, you can still setup both, mirroring and Amanda, at
-any later time using the 5X menu options.
+If you choose to skip this during system installation, you can still setup both, mirroring and Amanda, at any later time using the 5X menu options.
 
 Menu 5X provides interactive access to the aforementioned functions:
-`53 Setup SD monitoring` prepares the partitions on an SD card and sets up timers to execute both, a full mirroring
-and complementary rsync 'diff' runs in a backup schedule.
+`53 Setup SD monitoring` prepares the partitions on an SD card and sets up timers to execute both, a full mirroring and complementary rsync 'diff' runs in a backup schedule.
 `54 Raw copy SD` is a one-time raw copy (mirror) run.
 `55 Sync SD` proagates (syncs) differences from your main SD card to your external card.
 
-Should you need to switch over to your backup card, get a another new SD card to match the size of the broken card and use menu option 54 to copy your active backup card back to the new one and switch cards back as soon as possible.
+Should you need to switch over to your backup card, get another new SD card that matches the size of the broken card and use menu option 54 to copy your active backup card back to the new one and switch cards back as soon as possible.
 
 #### Tailscale VPN network
-Tailscale is a management toolset to establish a WireGuard based VPN between multiple systems if you want
-to connect to openHAB(ian) instances outside your LAN over Internet.
+
+Tailscale is a management toolset to establish a WireGuard based VPN between multiple systems if you want to connect to openHAB(ian) instances outside your LAN over Internet.
 It'll take care to detect and open ports when you and your peers are located behind firewalls.
-[Download the client](https://tailscale.com/download) and eventually get the Solo service plan from Tailscale,
-that's free for private use. This free service will automatically be selected when you fire up your first VPN node.
-The Windows client has a link to the admin console where you can create pre-auth one-time keys. These you can put
-as the `preauthkey` into `openhabian.conf` to automatically deploy remote openHABian nodes (unattended install)
-and have them join the VPN.
+[Download the client](https://tailscale.com/download) and eventually get the Solo service plan from Tailscale, that's free for private use.
+This free service will automatically be selected when you fire up your first VPN node.
+The Windows client has a link to the admin console where you can create pre-auth one-time keys.
+These you can put as the `preauthkey` into `openhabian.conf` to automatically deploy remote openHABian nodes (unattended install) and have them join the VPN.
 
 #### IPv6 notes
+
 You might encounter problems when you make use of IPv6 on some networks and systems. openHABian installation may stop or hang forever.
-In that case *or if you are sure that you do not need IPv6 on your openHABian server*, you can disable IPv6.
+In that case _or if you are sure that you do not need IPv6 on your openHABian server_, you can disable IPv6.
 Follow the instructions in the previous section and insert a line into `openhabian.conf` reading `ipv6=disable`.
 
 #### Fake hardware mode
+
 If to install openHABian fails because you have a non-supported hardware or run an unsupported OS release, you can "fake" your hardware and OS to make openHABian behave as if you did own that HW/OS.
 In `openhabian.conf`, uncomment and complete the lines reading `hw=`, `hwarch=` and/or `osrelease=` with the hw and os versions you want to attempt installation with.
 
 ## Optional Components
+
 openHABian comes with a number of additional routines to quickly install and set up home automation related software.
 You'll find all of these in the [openHABian Configuration Tool](#openhabian-configuration-tool)
 
--   [Frontail](https://github.com/mthenw/frontail) - openHAB Log Viewer accessible from [http://openhab:9001](http://openhab:9001)
--   [InfluxDB and Grafana](https://community.openhab.org/t/influxdb-grafana-persistence-and-graphing/13761/1) - persistence and graphing available from [http://openhab:3000](http://openhab:3000)
+-   [Frontail](https://github.com/mthenw/frontail) - openHAB Log Viewer accessible from [http://openhabian:9001](http://openhabian:9001)
+-   [InfluxDB and Grafana](https://community.openhab.org/t/influxdb-grafana-persistence-and-graphing/13761/1) - persistence and graphing available from [http://openhabian:3000](http://openhabian:3000)
 -   [Eclipse Mosquitto](http://mosquitto.org) - Open Source MQTT v3.1/v3.1.1 Broker
--   [Node-RED](https://nodered.org) - "Flow-based programming for the Internet of Things". Access at [http://openhab:1880](http://openhab:1880).
+-   [Node-RED](https://nodered.org) - "Flow-based programming for the Internet of Things". Access at [http://openhabian:1880](http://openhabian:1880).
 -   [Homegear](https://www.homegear.eu/index.php/Main_Page) - Homematic control unit emulation
 -   [KNXd](http://michlstechblog.info/blog/raspberry-pi-eibknx-ip-gateway-and-router-with-knxd) - KNX daemon running at `224.0.23.12:3671/UDP`
 -   [OWServer](http://owfs.org/index.php?page=owserver_protocol) - 1wire control system
@@ -421,7 +447,8 @@ You'll find all of these in the [openHABian Configuration Tool](#openhabian-conf
 -   Tellstick core
 
 ## Troubleshooting
-If you're having problems to get openHABian to install properly, check out the [debug guide](openhabian-DEBUG.md). It's also available on your system as `/opt/openhabian/docs/openhabian-DEBUG.md`.
+
+If you're having problems with getting openHABian to install properly, check out the [debug guide](openhabian-DEBUG.md). It's also available on your system as `/opt/openhabian/docs/openhabian-DEBUG.md`.
 Do not hesitate to ask for help on the [openHABian community forum](https://community.openhab.org/) when the debug guide doesn't help.
 Remember to [mind the rules](https://community.openhab.org/t/how-to-ask-a-good-question-help-us-help-you/58396) please.
 
@@ -431,25 +458,27 @@ If you want to get involved, you found a bug, or just want to see what's planned
 
 <a id="changelog"></a>
 ### Where can I find a changelog for openHABian?
+
 Official announcements are co-located with the download links [here](https://github.com/openhab/openhabian/releases).
-If you want to stay in touch with all the latest code changes under the hood, see [commit history](https://github.com/openhab/openhabian/commits/master) for openHABian.
+If you want to stay in touch with all the latest code changes under the hood, see [commit history](https://github.com/openhab/openhabian/commits/main) for openHABian.
 You'll also see commits "fly by" when executing the "Update" function within the openHABian Configuration Tool.
 
 <a id="successful"></a>
 ### Did my Installation succeed? What to do in case of a problem?
+
 Don't panic ;-)
 openHABian setup will take 15 up to 45 minutes to complete all steps, depending on your device's performance and your internet connection.
 
-Watch the progress on the console or the web interface at https://\<your IP\>/ or <http://openhabian/> if that name has become available.
+Watch the progress on the console or the web interface at <https://yourIP/> or <http://openhabian/> if that name has become available.
 Double-check the IP address and name with your router while you wait.
-If there is absolutely no output for more than 10 minutes, your installation has failed in the first initialization phase. There probably is a problem
-with the way your router or local network are setup.
+If there is absolutely no output for more than 10 minutes, your installation has failed in the first initialization phase.
+There probably is a problem with the way your router or local network are setup.
 Read on in the [Troubleshooting](#troubleshooting) section or move on to the [DEBUG guide](openhabian-DEBUG.md).
 You can set `debugmode=on` (or even = `maximum`) right on first install, too, to get to see what openHABian is doing.
 
 After a few minutes of boot up time, you can [connect to the SSH console](https://www.raspberrypi.org/documentation/remote-access/ssh/windows.md) of your device.
 During the setup process you'll be redirected to the live progress report of the setup (you can Ctrl-C to get into the shell).
-The report can also be checked for errors at any time, see `/boot/first-boot.log`
+The report can also be checked for errors at any time, see `/boot/first-boot.log`.
 
 The progress of a successful installation will look like this:
 
@@ -458,6 +487,7 @@ The progress of a successful installation will look like this:
 Wait till the log tells you that the setup was "successful", then reconnect to the device.
 
 #### SSH Login Screen
+
 If the installation was **successful** you will see the normal login screen as shown in the first screenshot.
 If the installation was **not successful** you will see a warning and further instructions as shown in the second screenshot.
 
@@ -467,19 +497,24 @@ If the installation was **not successful** you will see a warning and further in
 </div>
 
 #### openHAB Dashboard
+
 After the installation of openHABian was successful, you should be able to access the openHAB dashboard:
 
--   Raspberry Pi image setup: [http://openhab:8080](http://openhab:8080)
+-   Raspberry Pi image setup: [http://openhabian:8080](http://openhabian:8080)
 -   In any case: [http://your-device-hostname:8080](http://your-device-hostname:8080) or [http://192.168.0.2:8080](http://192.168.0.2:8080) (replace name/IP with yours)
 
 #### What's next?
-If you are not able to access your system via the openHAB dashboard or SSH after more than one hour, chances are high that your hardware setup is the problem. Consult the [debug guide](openhabian-DEBUG.md) and move on from there.
+
+If you are not able to access your system via the openHAB dashboard or SSH after more than one hour, chances are high that your hardware setup is the problem.
+Consult the [debug guide](openhabian-DEBUG.md) and move on from there.
 
 <a id="switch-openhab-branch"></a>
-#### Can I switch openHAB 2 and 3 via openHABian branches ?
+#### Can I switch openHAB 2 and 3 via openHABian branches?
+
 openHABian installs the latest stable build of openHAB.
-The standard openHABian `openHAB3` and `main` branches will install the new openHAB version 3 and the old `stable` and `master` branches will install the old openHAB version 2.
-You can migrate between versions by selecting the corresponding 4X menu option. That should also result in an openHABian branch change.
+The standard openHABian `openHAB3` and `main` branches will install the new openHAB version 3 and the old `stable` branch will install the old openHAB version 2.
+You can migrate between versions by selecting the corresponding 4X menu option.
+That should also result in an openHABian branch change.
 If you want to choose from stable, snapshot or milestone releases, please do so via `openhabian-config` tool (also menu 4X).
 Note this will **not** result in any openHABian branch change.
 Switching from stable to newer development releases might introduce changes and incompatibilities, so please be sure to make a full openHAB backup first!
@@ -487,12 +522,14 @@ Check the Linux installation article for all needed details: [Linux: Changing Ve
 
 <a id="headache"></a>
 #### Where is the graphical user interface?
+
 I've just installed openHABian and now I'm confused.
-No fancy login screen, no windows, no mouse support. What did I get into?
+No fancy login screen, no windows, no mouse support.
+What did I get into?
 
 You are not the first one to get confused about the **intended use case of openHABian**.
 Maybe it helps to not think of the RPi as a PC as we know it.
-An RPi is not (well, not *necessarily*) to be used with a keyboard and display.
+An RPi is not (well, not _necessarily_) to be used with a keyboard and display.
 Its intended use case is to sit in a corner and provide a service reliably 24 hours a day, 7 days a week.
 You already own a **powerful PC or Mac** to work on.
 It would be a shame to have a powerful computer at your fingertips and then have to **restrict yourself** to a very limited graphical frontend on another device, wouldn't you agree?
@@ -505,8 +542,9 @@ However as you are willing to tinker with smart home technology, I'm sure you ar
 
 <a id="faq-other-platforms"></a>
 #### Can I use openHABian on ...?
-See the [README](https://github.com/openhab/openhabian/blob/master/README.md#hardware-and-os-support) for a list of supported HW and OS.
+
+See the [README](https://github.com/openhab/openhabian/blob/main/README.md#hardware-and-os-support) for a list of supported HW and OS.
 openHABian is developed for Debian based systems.
 If your operating system is based on these or if your hardware supports one, your chances are high openHABian can be used.
 Check out the [Manual Setup](#manual-setup) instructions for guidance and consult the [debug guide](openhabian-DEBUG.md) if you run into problems.
-Do not hesitate to ask for help on the [openHABian community forum](https://community.openhab.org/) !
+Do not hesitate to ask for help on the [openHABian community forum](https://community.openhab.org/)!

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -282,7 +282,7 @@ amanda_setup() {
   local backupPass
   local backupPass1
   local backupPass2
-  local queryText="You are about to install the Amanda backup solution.\\nDocumentation is available at '/opt/openhabian/docs/openhabian-amanda.md' or https://github.com/openhab/openhabian/blob/master/docs/openhabian-amanda.md\\nHave you read this document? If not, please do so now, as you will need to follow the instructions provided there in order to successfully complete installation of Amanda.\\n\\nProceeding will setup a backup mechanism to allow for saving your openHAB setup and modifications to either USB attached or Amazon cloud storage.\\nYou can add your own files/directories to be backed up, and you can store and create clones of your openHABian SD card to have an pre-prepared replacement in case of card failures.\\n\\nWARNING: running this setup will overwrite any previous Amanda backup configurations.\\n\\nWould you like to begin setup?"
+  local queryText="You are about to install the Amanda backup solution.\\nDocumentation is available at '/opt/openhabian/docs/openhabian-amanda.md' or https://github.com/openhab/openhabian/blob/main/docs/openhabian-amanda.md\\nHave you read this document? If not, please do so now, as you will need to follow the instructions provided there in order to successfully complete installation of Amanda.\\n\\nProceeding will setup a backup mechanism to allow for saving your openHAB setup and modifications to either USB attached or Amazon cloud storage.\\nYou can add your own files/directories to be backed up, and you can store and create clones of your openHABian SD card to have an pre-prepared replacement in case of card failures.\\n\\nWARNING: running this setup will overwrite any previous Amanda backup configurations.\\n\\nWould you like to begin setup?"
   local successText="Setup was successful.\\n\\nAmanda backup tool is now taking backups around 01:00. For further readings, start at http://wiki.zmanda.com/index.php/User_documentation."
 
   echo -n "$(timestamp) [openHABian] Beginning setup of the Amanda backup system... "
@@ -380,7 +380,7 @@ mirror_SD() {
       if [[ "$destSize" -lt "$srcSize" ]]; then
         echo "FAILED (cannot duplicate internal SD card ${src}, it is larger than external ${dest})"
         if [[ -z "$INTERACTIVE" ]]; then return 1; fi
-        repartitionText="One or more of the selected destination partition(s) are smaller than their equivalents on the internal SD card so you cannot simply replicate that. The physical size is sufficient though.\\n\\nDo you want the destination ${dest} to be overwritten to match the partitions of the internal SD card ?"
+        repartitionText="One or more of the selected destination partition(s) are smaller than their equivalents on the internal SD card so you cannot simply replicate that. The physical size is sufficient though.\\n\\nDo you want the destination ${dest} to be overwritten to match the partitions of the internal SD card?"
         if ! (whiptail --title "Repartition $dest" --yes-button "Repartition" --no-button "Cancel" --yesno "$repartitionText" 12 116); then echo "CANCELED"; return 0; fi
       fi
       sfdisk -d /dev/mmcblk0 | sfdisk --force "$dest"

--- a/functions/ext-storage.bash
+++ b/functions/ext-storage.bash
@@ -11,14 +11,14 @@ move_root2usb() {
     return 0
   fi
   if [[ -f /etc/ztab ]]; then
-    echo "$(timestamp) [openHABian] Move root to USB must not be used while using ZRAM! Canceling move root to USB!"
-    whiptail --title "Incompatible selection detected!" --msgbox "Move root to USB must not be used together with ZRAM.\\n\\nIf you want to mitigate SD card corruption, don't use this but stay with ZRAM, it is the proper choice.\\n\\nIf you want to move for other reasons, uninstall ZRAM first then return here." 13 80
+    echo "$(timestamp) [openHABian] Move root to USB must not be used while using zram! Canceling move root to USB!"
+    whiptail --title "Incompatible selection detected!" --msgbox "Move root to USB must not be used together with zram.\\n\\nIf you want to mitigate SD card corruption, don't use this but stay with zram, it is the proper choice.\\n\\nIf you want to move for other reasons, uninstall zram first then return here." 13 80
     return 0
   fi
 
   local newRootDev="/dev/sda"
   local newRootPart="/dev/sda1"
-  local introText="DANGEROUS OPERATION, USE WITH PRECAUTION!\\n\\nThis will move your system root from your SD card to a USB device like an SSD or a USB stick.\\nATTENTION: this is NOT the recommended method to reduce wearout and failure of the SD card. If that is your intention, stop here and go for ZRAM (menu option 38).\\n\\nIf you still want to proceed,\\n1.) Ensure your RPi model can boot from a device other than the internal SD card reader.\\n2.) Make a backup of your SD card\\n3.) Remove all USB mass storage devices from your Pi\\n4.) Insert the USB device to be used for the new system root.\\n\\nTHIS DEVICE WILL BE COMPLETELY DELETED!\\n\\nDo you want to continue at your own risk?"
+  local introText="DANGEROUS OPERATION, USE WITH PRECAUTION!\\n\\nThis will move your system root from your SD card to a USB device like an SSD or a USB stick.\\nATTENTION: this is NOT the recommended method to reduce wearout and failure of the SD card. If that is your intention, stop here and go for zram (menu option 38).\\n\\nIf you still want to proceed,\\n1.) Ensure your RPi model can boot from a device other than the internal SD card reader.\\n2.) Make a backup of your SD card\\n3.) Remove all USB mass storage devices from your Pi\\n4.) Insert the USB device to be used for the new system root.\\n\\nTHIS DEVICE WILL BE COMPLETELY DELETED!\\n\\nDo you want to continue at your own risk?"
   local rootOnSD
   local rootPart
   local srcSize

--- a/functions/find.bash
+++ b/functions/find.bash
@@ -88,7 +88,7 @@ find3_setup() {
   if cond_redirect python3 -m pip install -r requirements.txt; then echo "OK"; else echo "FAILED (pip)"; return 1; fi
 
   if [[ -f /etc/ztab ]] && ! grep -qs "/find3.bind" /etc/ztab; then
-    echo -n "$(timestamp) [openHABian] Adding FIND3 to ZRAM... "
+    echo -n "$(timestamp) [openHABian] Adding FIND3 to zram... "
     if ! cond_redirect mv /etc/ztab "${TMPDIR:-/tmp}"; then echo "FAILED (move old configuration)"; return 1; fi
     if ! (echo "dir	lz4	100M		350M		/opt/find3/server/main		/find3.bind" > /etc/ztab); then echo "FAILED (temporary configuration creation)"; return 1; fi
     if ! cond_redirect zram-config "start"; then echo "FAILED (start temporary configuration)"; return 1; fi

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -506,7 +506,7 @@ is_wifi_connected() {
   if echo "q" | comitup-cli | grep -q 'State: CONNECTED'; then return 0; else return 1; fi
 }
 
-## Add dependency on ZRAM up: install/uninstall dependencies in zram-config.service
+## Add dependency on zram up: install/uninstall dependencies in zram-config.service
 ## Argument 1 is "install" or "remove"
 ## all remaining arguments are service names that zram must be available for to start
 ##

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -136,8 +136,8 @@ show_main_menu() {
     "36 | WiFi setup"             "Configure wireless network connection" \
     "   | Disable WiFi"           "Disable wireless network connection" \
     "37 | Move root to USB"       "Move the system root from the SD card to a USB device (SSD or stick)" \
-    "38 | Use ZRAM"               "Use compressed RAM/disk sync for active directories to avoid SD card corruption" \
-    "   | Uninstall ZRAM"         "Don't use compressed memory (back to standard Raspberry Pi OS filesystem layout)" \
+    "38 | Use zram"               "Use compressed RAM/disk sync for active directories to avoid SD card corruption" \
+    "   | Uninstall zram"         "Don't use compressed memory (back to standard Raspberry Pi OS filesystem layout)" \
     "39 | Setup Exim Mail Relay"  "Install Exim4 to relay mails via public email provider" \
     "3A | Setup Tailscale VPN"    "Establish or join a WireGuard based VPN using the Tailscale service" \
     "   | Remove Tailscale VPN"   "Remove the Tailscale VPN service" \
@@ -158,7 +158,7 @@ show_main_menu() {
       *Disable\ WiFi) configure_wifi disable ;;
       37\ *) move_root2usb ;;
       38\ *) init_zram_mounts "install" ;;
-      *Uninstall\ ZRAM) init_zram_mounts "uninstall" ;;
+      *Uninstall\ zram) init_zram_mounts "uninstall" ;;
       39\ *) exim_setup ;;
       3A\ *) if install_tailscale install; then setup_tailscale; fi;;
       *Remove\ Tailscale*) install_tailscale remove;;
@@ -227,5 +227,5 @@ show_main_menu() {
   fi
 
   # shellcheck disable=SC2154,SC2181
-  if [ $? -ne 0 ]; then whiptail --msgbox "There was an error or interruption during the execution of:\\n  \"$choice\"\\n\\nPlease try again. If the error persists, please read /opt/openhabian/docs/openhabian-DEBUG.md or https://github.com/openhab/openhabian/blob/master/docs/openhabian-DEBUG.md how to proceed." 14 80; return 0; fi
+  if [ $? -ne 0 ]; then whiptail --msgbox "There was an error or interruption during the execution of:\\n  \"$choice\"\\n\\nPlease try again. If the error persists, please read /opt/openhabian/docs/openhabian-DEBUG.md or https://github.com/openhab/openhabian/blob/main/docs/openhabian-DEBUG.md how to proceed." 14 80; return 0; fi
 }

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## Generate systemd dependencies for ZRAM, Frontail and others to start together with OH
+## Generate systemd dependencies for zram, Frontail and others to start together with OH
 ## This is done using /etc/systemd/system/openhab.service.d/override.conf
 ##
 ##    create_systemd_dependencies()

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -252,7 +252,7 @@ openhabian_update() {
 ##    migrate_installation()
 ##
 migrate_installation() {
-  local failText="is already installed on your system !\\n\\nCanceling migration, returning to menu."
+  local failText="is already installed on your system!\\n\\nCanceling migration, returning to menu."
   local frontailService="/etc/systemd/system/frontail.service"
   local homegearService="/etc/systemd/system/homegear.service"
   local zramService="/etc/systemd/system/zram-config.service"
@@ -296,7 +296,7 @@ migrate_installation() {
 
   javaVersion="$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')"
   # shellcheck disable=SC2154
-  [[ "$zraminstall" != "disable" ]] && [[ -s /etc/ztab ]] && if cond_redirect zram-config "stop"; then echo "OK"; else echo "FAILED (stop ZRAM)"; return 1; fi
+  [[ "$zraminstall" != "disable" ]] && [[ -s /etc/ztab ]] && if cond_redirect zram-config "stop"; then echo "OK"; else echo "FAILED (stop zram)"; return 1; fi
   backup_openhab_config
 
   if [[ -z "$javaVersion" ]] || [[ "${javaVersion}" -lt "11" ]]; then
@@ -349,13 +349,13 @@ migrate_installation() {
   echo "OK"
 
   if [[ -s /etc/ztab ]]; then
-    echo -n "$(timestamp) [openHABian] Migrating ZRAM config... "
+    echo -n "$(timestamp) [openHABian] Migrating zram config... "
     sed -i "s|/${from}|/${to}|g" "$ztab"
     sed -i "s|${from}|${to}|g" "$zramService"
   fi
 
   # shellcheck disable=SC2154
-  [[ "$zraminstall" != "disable" ]] && if cond_redirect systemctl restart zram-config.service; then echo "OK"; else echo "FAILED (restart ZRAM)"; return 1; fi
+  [[ "$zraminstall" != "disable" ]] && if cond_redirect systemctl restart zram-config.service; then echo "OK"; else echo "FAILED (restart zram)"; return 1; fi
 }
 
 ## Check for default system password and if found issue a warning and suggest

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -252,7 +252,7 @@ create_mount() {
 ##
 srv_bind_mounts() {
   if [[ -f /etc/ztab ]] && [[ $(systemctl is-active zram-config.service) == "active" ]]; then
-    echo -n "$(timestamp) [openHABian] Stopping ZRAM service... "
+    echo -n "$(timestamp) [openHABian] Stopping zram service... "
     if cond_redirect zram-config "stop"; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
@@ -269,7 +269,7 @@ srv_bind_mounts() {
   if cond_redirect create_mount "/usr/share/openhab/addons" "addons"; then echo "OK"; else echo "FAILED (addons)"; return 1; fi
 
   if [[ -f /etc/ztab ]]; then
-    echo -n "$(timestamp) [openHABian] Restarting ZRAM service... "
+    echo -n "$(timestamp) [openHABian] Restarting zram service... "
     if cond_redirect systemctl restart zram-config.service; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 }
@@ -312,7 +312,7 @@ permissions_corrections() {
   if [[ -f /etc/mosquitto/mosquitto.conf ]]; then
     if ! cond_redirect fix_permissions /etc/mosquitto/passwd "mosquitto:${username:-openhabian}" 640 750; then echo "FAILED (mosquitto passwd permissions)"; retval=1; fi
     if ! cond_redirect fix_permissions /var/log/mosquitto "mosquitto:${username:-openhabian}" 644 755; then echo "FAILED (mosquitto log permissions)"; retval=1; fi
-    if ! cond_redirect fix_permissions /opt/zram/log.bind/mosquitto "mosquitto:${username:-openhabian}" 644 755; then echo "FAILED (mosquitto log permissions on ZRAM)"; retval=1; fi
+    if ! cond_redirect fix_permissions /opt/zram/log.bind/mosquitto "mosquitto:${username:-openhabian}" 644 755; then echo "FAILED (mosquitto log permissions on zram)"; retval=1; fi
   fi
   if ! cond_redirect setfacl --recursive --remove-all "${openhabFolders[@]}"; then echo "FAILED (reset file access lists)"; retval=1; fi
   # not sure if still needed. Let's see if removing this causes any user issues
@@ -321,12 +321,12 @@ permissions_corrections() {
 
   if cond_redirect fix_permissions /var/log/unattended-upgrades root:root 644 755; then echo "OK"; else echo "FAILED (unattended upgrades logdir)"; retval=1; fi
   if cond_redirect fix_permissions /var/log/samba root:root 640 750; then echo "OK"; else echo "FAILED (samba logdir)"; retval=1; fi
-  if cond_redirect fix_permissions /opt/zram/log.bind/samba root:root 640 750; then echo "OK"; else echo "FAILED (samba logdir on ZRAM)"; retval=1; fi
+  if cond_redirect fix_permissions /opt/zram/log.bind/samba root:root 640 750; then echo "OK"; else echo "FAILED (samba logdir on zram)"; retval=1; fi
 
   if cond_redirect fix_permissions /opt/zram/persistence.bind "openhab:${username:-openhabian}" 664 775; then echo "OK"; else echo "FAILED (persistence)"; retval=1; fi
 
   if cond_redirect fix_permissions /var/log/openhab "openhab:${username:-openhabian}" 664 775; then echo "OK"; else echo "FAILED (openhab log)"; retval=1; fi
-  if cond_redirect fix_permissions /opt/zram/log.bind/openhab "openhab:${username:-openhabian}" 664 775; then echo "OK"; else echo "FAILED (openhab log on ZRAM)"; retval=1; fi
+  if cond_redirect fix_permissions /opt/zram/log.bind/openhab "openhab:${username:-openhabian}" 664 775; then echo "OK"; else echo "FAILED (openhab log on zram)"; retval=1; fi
 
   if [[ -d /etc/homegear ]]; then
     echo -n "$(timestamp) [openHABian] Applying additional file permissions recommendations for Homegear... "
@@ -394,7 +394,7 @@ misc_system_settings() {
 }
 
 ## Change system swap size dependent on free space on '/swap' on SD
-## ('/var/swap' per default) only used after ZRAM swap is full if ZRAM is enabled.
+## ('/var/swap' per default) only used after zram swap is full if zram is enabled.
 ##
 ##    change_swapsize()
 ##

--- a/functions/vpn.bash
+++ b/functions/vpn.bash
@@ -11,7 +11,7 @@ install_wireguard() {
   local textInstallation
 
   configdir="/etc/wireguard"
-  textReady="In order to access your system from the Internet using Wireguard, you need to setup a couple of prerequisites. Do so now if you have not already done so.\\nYou need to have a (dynamically adapting) DNS name point to your router. Get it from any of the free providers such as DuckDNS or selfhost.de.\\nYou also need to forward an UDP port from the router to your system to allow for establishing the VPN (default 51900/UDP).\\nYou need to have this information available and your router should be setup to forward the VPN port. Are you ready to proceed ?"
+  textReady="In order to access your system from the Internet using Wireguard, you need to setup a couple of prerequisites. Do so now if you have not already done so.\\nYou need to have a (dynamically adapting) DNS name point to your router. Get it from any of the free providers such as DuckDNS or selfhost.de.\\nYou also need to forward an UDP port from the router to your system to allow for establishing the VPN (default 51900/UDP).\\nYou need to have this information available and your router should be setup to forward the VPN port. Are you ready to proceed?"
   textInstallation="We will now install Wireguard VPN on your system. That'll take some time.\\n\\nMake use of this waiting time to install the client side part.\\nYou need to install the Wireguard client from either http://www.wireguard.com/install to your local PC or from PlayStore/AppStore to your mobile device.\\nopenHABian will display a QR code at the end of this installation to let you easily transfer the configuration."
 
   if [[ $1 == "remove" ]]; then
@@ -156,10 +156,10 @@ setup_wireguard() {
 
   # iface=eth0 or wlan0
   if [[ -n "$INTERACTIVE" ]]; then
-    if ! iface=$(whiptail --title "VPN interface" --inputbox "Which interface do you want to setup the VPN on ?" 10 60 "$iface" 3>&1 1>&2 2>&3); then return 1; fi
-    if ! defaultNetwork=$(whiptail --title "VPN network" --inputbox "What's the IP network to be assigned to the VPN ?\\nSpecify the first 3 octets." 10 60 "$defaultNetwork" 3>&1 1>&2 2>&3); then return 1; fi
-    if ! dynDNS=$(whiptail --title "dynamic domain name" --inputbox "Which dynamic DNS name is your router running found as from the Internet ?" 10 60 3>&1 1>&2 2>&3); then return 1; fi
-    if ! port=$(whiptail --title "VPN port" --inputbox "Which port do you want to expose for establishing the VPN ?" 10 60 "$port" 3>&1 1>&2 2>&3); then return 1; fi
+    if ! iface=$(whiptail --title "VPN interface" --inputbox "Which interface do you want to setup the VPN on?" 10 60 "$iface" 3>&1 1>&2 2>&3); then return 1; fi
+    if ! defaultNetwork=$(whiptail --title "VPN network" --inputbox "What's the IP network to be assigned to the VPN?\\nSpecify the first 3 octets." 10 60 "$defaultNetwork" 3>&1 1>&2 2>&3); then return 1; fi
+    if ! dynDNS=$(whiptail --title "dynamic domain name" --inputbox "Which dynamic DNS name is your router running found as from the Internet?" 10 60 3>&1 1>&2 2>&3); then return 1; fi
+    if ! port=$(whiptail --title "VPN port" --inputbox "Which port do you want to expose for establishing the VPN?" 10 60 "$port" 3>&1 1>&2 2>&3); then return 1; fi
   fi
   create_wireguard_config "$iface" "$port" "$defaultNetwork" "$dynDNS"
   if [[ -n "$INTERACTIVE" ]]; then

--- a/functions/zram.bash
+++ b/functions/zram.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## Install code needed to compile ZRAM tools at installation time this
+## Install code needed to compile zram tools at installation time this
 ## can be called standalone from build.bash or during install from init_zram_mounts().
 ## The argument is the destination directory.
 ##
@@ -9,7 +9,7 @@
 install_zram_code() {
   local zramGit="https://github.com/ecdye/zram-config"
 
-  echo -n "$(timestamp) [openHABian] Installing ZRAM code... "
+  echo -n "$(timestamp) [openHABian] Installing zram code... "
   if ! cond_redirect mkdir -p "$1"; then echo "FAILED (create directory)"; return 1; fi
 
   if [[ -d "${1}/zram-config" ]]; then
@@ -19,7 +19,7 @@ install_zram_code() {
   fi
 }
 
-## Setup ZRAM for openHAB specific usage
+## Setup zram for openHAB specific usage
 ## Valid arguments: "install" or "uninstall"
 ##
 ##    init_zram_mounts(String option)
@@ -29,22 +29,22 @@ init_zram_mounts() {
 
   local disklistFileAWS="/etc/amanda/openhab-aws/disklist"
   local disklistFileDir="/etc/amanda/openhab-dir/disklist"
-  local introText="You are about to activate the ZRAM feature.\\nBe aware you do this at your own risk of data loss.\\nPlease check out the \"ZRAM status\" thread at https://community.openhab.org/t/zram-status/80996 before proceeding."
-  local lowMemText="Your system has less than 1 GB of RAM. It is definitely NOT recommended to run ZRAM (AND openHAB) on your box. If you proceed now you will do so at your own risk!"
+  local introText="You are about to activate the zram feature.\\nBe aware you do this at your own risk of data loss.\\nPlease check out the \"zram status\" thread at https://community.openhab.org/t/zram-status/80996 before proceeding."
+  local lowMemText="Your system has less than 1 GB of RAM. It is definitely NOT recommended to run zram (AND openHAB) on your box. If you proceed now you will do so at your own risk!"
   local zramInstallLocation="/opt/zram"
 
   if [[ $1 == "install" ]] && ! [[ -f /etc/ztab ]]; then
     if [[ -n $INTERACTIVE ]]; then
-      # display warn disclaimer and point to ZRAM status thread on forum
-      if ! (whiptail --title "Install ZRAM" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 10 80); then echo "CANCELED"; return 0; fi
-      # double check if there's enough RAM to run ZRAM
+      # display warn disclaimer and point to zram status thread on forum
+      if ! (whiptail --title "Install zram" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 10 80); then echo "CANCELED"; return 0; fi
+      # double check if there's enough RAM to run zram
       if has_lowmem; then
         if ! (whiptail --title "WARNING, continue?" --yes-button "REALLY Continue" --no-button "Cancel" --yesno --defaultno "$lowMemText" 10 80); then echo "CANCELED"; return 0; fi
       fi
     fi
 
     if ! dpkg -s 'make' 'libattr1-dev' &> /dev/null; then
-      echo -n "$(timestamp) [openHABian] Installing ZRAM required packages (make, libattr1-dev)... "
+      echo -n "$(timestamp) [openHABian] Installing zram required packages (make, libattr1-dev)... "
       if cond_redirect apt-get install --yes make libattr1-dev; then echo "OK"; else echo "FAILED"; return 1; fi
     fi
 
@@ -55,33 +55,33 @@ init_zram_mounts() {
     if ! cond_redirect mkdir -p /usr/local/lib/zram-config/; then echo "FAILED (create directory)"; return 1; fi
     if cond_redirect install -m 755 "$zramInstallLocation"/zram-config/overlayfs-tools/overlay /usr/local/lib/zram-config/overlay; then echo "OK"; else echo "FAILED (install overlayfs)"; return 1; fi
 
-    echo -n "$(timestamp) [openHABian] Setting up ZRAM... "
+    echo -n "$(timestamp) [openHABian] Setting up zram... "
     if ! cond_redirect install -m 755 "$zramInstallLocation"/zram-config/zram-config /usr/local/sbin; then echo "FAILED (zram-config)"; return 1; fi
     if ! cond_redirect install -m 644 "${BASEDIR:-/opt/openhabian}"/includes/ztab /etc/ztab; then echo "FAILED (ztab)"; return 1; fi
     if ! cond_redirect mkdir -p /usr/local/share/zram-config/log; then echo "FAILED (create directory)"; return 1; fi
     if cond_redirect install -m 644 "$zramInstallLocation"/zram-config/zram-config.logrotate /etc/logrotate.d/zram-config; then echo "OK"; else echo "FAILED (logrotate)"; return 1; fi
 
     if [[ -f /etc/systemd/system/find3server.service ]]; then
-      echo -n "$(timestamp) [openHABian] Adding FIND3 to ZRAM... "
+      echo -n "$(timestamp) [openHABian] Adding FIND3 to zram... "
       if cond_redirect sed -i '/^.*persistence.bind$/a dir	lz4	100M		350M		/opt/find3/server/main		/find3.bind' /etc/ztab; then echo "OK"; else echo "FAILED (sed)"; return 1; fi
     fi
     if ! openhab_is_installed; then
-      echo -n "$(timestamp) [openHABian] Removing openHAB persistence from ZRAM... "
+      echo -n "$(timestamp) [openHABian] Removing openHAB persistence from zram... "
       if cond_redirect sed -i '/persistence.bind/d' /etc/ztab; then echo "OK"; else echo "FAILED (sed)"; return 1; fi
     else
       if [[ -f $disklistFileDir ]]; then
-        echo -n "$(timestamp) [openHABian] Adding ZRAM to Amanda local backup... "
+        echo -n "$(timestamp) [openHABian] Adding zram to Amanda local backup... "
         if ! cond_redirect sed -i '/zram/d' "$disklistFileDir"; then echo "FAILED (old config)"; return 1; fi
         if (echo "${HOSTNAME}  /opt/zram/persistence.bind    comp-user-tar" >> "$disklistFileDir"); then echo "OK"; else echo "FAILED (new config)"; return 1; fi
       fi
       if [[ -f $disklistFileAWS ]]; then
-        echo -n "$(timestamp) [openHABian] Adding ZRAM to Amanda AWS backup... "
+        echo -n "$(timestamp) [openHABian] Adding zram to Amanda AWS backup... "
         if ! cond_redirect sed -i '/zram/d' "$disklistFileAWS"; then echo "FAILED (old config)"; return 1; fi
         if (echo "${HOSTNAME}  /opt/zram/persistence.bind    comp-user-tar" >> "$disklistFileAWS"); then echo "OK"; else echo "FAILED (new config)"; return 1; fi
       fi
     fi
 
-    echo -n "$(timestamp) [openHABian] Setting up ZRAM service... "
+    echo -n "$(timestamp) [openHABian] Setting up zram service... "
     if ! cond_redirect install -m 644 "$zramInstallLocation"/zram-config/zram-config.service /etc/systemd/system/zram-config.service; then echo "FAILED (install service)"; return 1; fi
     if ! cond_redirect systemctl -q daemon-reload &> /dev/null; then echo "FAILED (daemon-reload)"; return 1; fi
 
@@ -90,7 +90,7 @@ init_zram_mounts() {
     fi
     if cond_redirect systemctl enable --now zram-config.service; then echo "OK"; else echo "FAILED (enable service)"; return 1; fi
   elif [[ $1 == "uninstall" ]]; then
-    echo -n "$(timestamp) [openHABian] Removing ZRAM service... "
+    echo -n "$(timestamp) [openHABian] Removing zram service... "
     if ! cond_redirect zram-config "stop"; then echo "FAILED (stop zram)"; return 1; fi
     if ! cond_redirect systemctl disable zram-config.service; then echo "FAILED (disable service)"; return 1; fi
     if ! cond_redirect rm -f /etc/systemd/system/zram-config.service; then echo "FAILED (remove service)"; return 1; fi
@@ -99,7 +99,7 @@ init_zram_mounts() {
     fi
     if cond_redirect systemctl -q daemon-reload &> /dev/null; then echo "OK"; else echo "FAILED (daemon-reload)"; return 1; fi
 
-    echo -n "$(timestamp) [openHABian] Removing ZRAM... "
+    echo -n "$(timestamp) [openHABian] Removing zram... "
     if ! cond_redirect rm -f /usr/local/sbin/zram-config; then echo "FAILED (zram-config)"; return 1; fi
     if ! cond_redirect rm -f /etc/ztab; then echo "FAILED (ztab)"; return 1; fi
     if ! cond_redirect rm -rf /usr/local/share/zram-config; then echo "FAILED (zram-config share)"; return 1; fi
@@ -107,32 +107,32 @@ init_zram_mounts() {
     if cond_redirect rm -f /etc/logrotate.d/zram-config; then echo "OK"; else echo "FAILED (logrotate)"; return 1; fi
 
     if [[ -f "$disklistFileDir" ]]; then
-      echo -n "$(timestamp) [openHABian] Removing ZRAM from Amanda local backup... "
+      echo -n "$(timestamp) [openHABian] Removing zram from Amanda local backup... "
       if cond_redirect sed -i -e '/zram/d' "$disklistFileDir"; then echo "OK"; else echo "FAILED (old config)"; return 1; fi
     fi
     if [[ -f "$disklistFileAWS" ]]; then
-      echo -n "$(timestamp) [openHABian] Removing ZRAM from Amanda AWS backup... "
+      echo -n "$(timestamp) [openHABian] Removing zram from Amanda AWS backup... "
       if cond_redirect sed -i -e '/zram/d' "$disklistFileAWS"; then echo "OK"; else echo "FAILED (old config)"; return 1; fi
     fi
   else
-    echo "$(timestamp) [openHABian] Refusing to install ZRAM as it is already installed, please uninstall and then try again... EXITING"
+    echo "$(timestamp) [openHABian] Refusing to install zram as it is already installed, please uninstall and then try again... EXITING"
     return 1
   fi
 }
 
 zram_setup() {
   if [[ -n "$UNATTENDED" ]] && [[ "${zraminstall:-enable}" == "disable" ]]; then
-    echo -n "$(timestamp) [openHABian] Skipping ZRAM install as requested."
+    echo -n "$(timestamp) [openHABian] Skipping zram install as requested."
     return 1
   fi
   if is_arm; then
     if ! has_lowmem && ! is_pione && ! is_cmone && ! is_pizero && ! is_pizerow; then
-      echo -n "$(timestamp) [openHABian] Installing ZRAM... "
+      echo -n "$(timestamp) [openHABian] Installing zram... "
       if cond_redirect init_zram_mounts "install"; then echo "OK"; else echo "FAILED"; return 1; fi
     else
-      echo "$(timestamp) [openHABian] Skipping ZRAM install on ARM hardware without enough memory."
+      echo "$(timestamp) [openHABian] Skipping zram install on ARM hardware without enough memory."
     fi
   else
-    echo "$(timestamp) [openHABian] Skipping ZRAM install on non-ARM hardware."
+    echo "$(timestamp) [openHABian] Skipping zram install on non-ARM hardware."
   fi
 }

--- a/functions/zram.bats
+++ b/functions/zram.bats
@@ -73,7 +73,7 @@ check_zram_removal() {
 @test "installation-zram" {
   if ! is_arm; then skip "Not executing zram test because not on native ARM architecture hardware."; fi
 
-  echo -e "# ${COL_CYAN}$(timestamp) [openHABian] ZRAM test installation starting...${COL_DEF}" >&3
+  echo -e "# ${COL_CYAN}$(timestamp) [openHABian] Zram test installation starting...${COL_DEF}" >&3
   run init_zram_mounts "install" 3>&-
   if [ "$status" -ne 0 ]; then echo "$output" >&3; fi
   [ "$status" -eq 0 ]

--- a/includes/ztab
+++ b/includes/ztab
@@ -13,16 +13,16 @@
 # than the compression algorithm is capable of as it will waste memory because
 # there is a ~0.1% memory overhead when empty
 #
-# swap_priority will set ZRAM over alternative swap devices.
+# swap_priority will set zram over alternative swap devices.
 #
 # page-cluster 0 means tuning to singular pages rather than the default 3 which
 # caches 8 for HDD tuning, which can lower latency.
 #
-# swappiness 80 because the improved performance of ZRAM allows more usage
+# swappiness 80 because the improved performance of zram allows more usage
 # without any adverse affects from the default of 60. It can be raised up to 100
 # but that will increase process queue on intense loads such as boot time.
 #
-# target_dir is the directory you wish to hold in ZRAM, and the original will be
+# target_dir is the directory you wish to hold in zram, and the original will be
 # moved to a bind mount 'bind_dir' and is synchronized on start, stop, and write
 # commands.
 #
@@ -30,13 +30,13 @@
 # sync purposes. Usually in '/opt' or '/var', name optional.
 #
 # oldlog_dir will enable log-rotation to an off device directory while retaining
-# only live logs in ZRAM. Usually in '/opt' or '/var', name optional.
+# only live logs in zram. Usually in '/opt' or '/var', name optional.
 #
-# If you need multiple ZRAM swaps or ZRAM directories, just create another entry
+# If you need multiple zram swaps or zram directories, just create another entry
 # in this file.
-# To do this safely, first stop ZRAM using 'zram-config "stop"',
+# To do this safely, first stop zram using 'zram-config "stop"',
 # then edit this file.
-# Once finished, restart ZRAM using 'systemctl restart zram-config.service'.
+# Once finished, restart zram using 'systemctl restart zram-config.service'.
 
 # swap	alg		mem_limit	disk_size	swap_priority	page-cluster	swappiness
 swap	lzo-rle		200M		600M		75		0		80

--- a/openhabian.conf.dist
+++ b/openhabian.conf.dist
@@ -66,7 +66,7 @@ java_opt=Zulu11-32
 # Valid arguments: "light", "dark"
 frontailtheme=light
 
-# install ZRAM per default, set to "disable" to skip installation
+# install zram per default, set to "disable" to skip installation
 zraminstall=enable
 
 # start comitup hotspot if internet is not reachable


### PR DESCRIPTION
Additionally, switch from 80 character line length limit as it is not
necessary. Instead, follow the guideline of one sentence per line for
documentation. This allows for easy reading of git diffs when
documentation changes are made.

A few text inconsistencies were also fixed throughout the code.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>