### PR TITLE
Update frontail-theme.css

### DIFF
--- a/includes/frontail-theme.css
+++ b/includes/frontail-theme.css
@@ -1,4 +1,4 @@
-@import url('//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css');
+@import url('bootstrap.min.css');
 
 body {
   padding-top: 7em;


### PR DESCRIPTION
website looks bad if openhab is offline (internet-outtage etc.). I have no idea why having this css available locally is a bad idea :)
I used the github-change-option, so I cannot add the bootstra.min.css file to the repo myself.