### PR TITLE
Make Amanda backup mounted subdirectories properly

### DIFF
--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -210,9 +210,6 @@ create_amanda_config() {
   if [[ -d /var/lib/openhab ]]; then
     echo "${HOSTNAME}  /var/lib/openhab              ${dumpType}" >> "$configDir"/disklist
   fi
-  if [[ -d /opt/zram/persistence.bind ]]; then
-    echo "${HOSTNAME}  /var/lib/openhab/persistence  ${dumpType}" >> "$configDir"/disklist
-  fi
   if [[ -d /var/lib/homegear ]]; then
     echo "${HOSTNAME}  /var/lib/homegear             ${dumpType}" >> "$configDir"/disklist
   fi

--- a/includes/amanda.conf-template
+++ b/includes/amanda.conf-template
@@ -32,10 +32,11 @@ define application-tool app_amraw {
 define application-tool app_amgtar {
     plugin "amgtar"
 
-    property        "NORMAL" ": socket ignored$"
-    property append "NORMAL" "file changed as we read it$"
-    property append "NORMAL" ": directory is on a different filesystem; not dumped$"
-    property append "NORMAL" ": File removed before we read it$"
+    property        "ONE-FILE-SYSTEM" "NO"
+    property        "NORMAL"          ": socket ignored$"
+    property append "NORMAL"          "file changed as we read it$"
+    property append "NORMAL"          ": directory is on a different filesystem; not dumped$"
+    property append "NORMAL"          ": File removed before we read it$"
 }
 
 define dumptype global {


### PR DESCRIPTION
Because the amgtar app is set by default to not cross filesystem
boundaries, when zram was enabled it would no longer properly backup the
/var/lib/openhab/persistence directory. By overriding the default option
and allowing the amgtar app to cross filesystem boundaries, we can
simplify the backup process.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>