### PR TITLE
Migrate openHABian to OH3 on menu 03

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@ Hit tab to unselect buttons and scroll through the text using UP/DOWN or
 PGUP/PGDN. All announcements are stored in `/opt/openhabian/docs/CHANGELOG.md`
 for you to lookup.
 
+## Install openHAB function changed ## July 23, 2021
+Menu option 03 "Install or upgrade to openHAB release 3" was changed to now
+actually do what most users have been expecting it to: it now also upgrades
+the environment to work with openHAB3 and installs openHAB3 "stable" version.
+Previously, you had to additionally use menu option 42 to migrate the
+environment.
+
 ## Telldus Core service removed ## May 20, 2021
 The Telldus Core service has now been removed from openHABian, and will no
 longer receive active support from the openHABian developers. Existing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Install openHAB function changed ## July 23, 2021
+Menu option 03 "Install or upgrade to openHAB release 3" was changed to now
+actually do what most users have been expecting it to: it now also upgrades
+the environment to work with openHAB3 and installs openHAB3 "stable" version.
+Previously, you had to additionally use menu option 42 to migrate the
+environment.
+
 ## Telldus Core service removed ## May 20, 2021
 The Telldus Core service has now been removed from openHABian, and will no
 longer receive active support from the openHABian developers. Existing

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -63,7 +63,7 @@ show_main_menu() {
 
   elif [[ "$choice" == "03"* ]]; then
     wait_for_apt_to_finish_update
-    openhab_setup openHAB3 "stable"
+    migrate_installation "openHAB3"
 
   elif [[ "$choice" == "10"* ]]; then
     choice2=$(whiptail --title "openHABian Configuration Tool — $(get_git_revision)" --menu "Apply Improvements" 13 116 6 --cancel-button Back --ok-button Execute \


### PR DESCRIPTION
dunno why this slipped before
See e.g. https://community.openhab.org/t/openhab-3-1-successful-but-openhabian-putty-always-starts-in-2-5-12-1/124518/11

Signed-off-by: Markus Storm <markus.storm@gmx.net>