### PR TITLE
Forward Docker base CI image from buster to bullseye

### DIFF
--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -196,10 +196,10 @@ influxdb_install() {
   else
     myOS="$(lsb_release -si)"
   fi
-  #myRelease="$(lsb_release -sc)"
-  #if [[ "$myRelease" == "n/a" ]]; then
-  myRelease=${osrelease:-buster}        # no InfluxDB bullseye repo available
-  #fi
+  myRelease="$(lsb_release -sc)"
+  if [[ "$myRelease" == "n/a" ]]; then
+    myRelease=${osrelease:-buster}
+  fi
 
   if ! dpkg -s 'influxdb' &> /dev/null; then
     if ! add_keys "https://repos.influxdata.com/influxdb.key"; then return 1; fi
@@ -253,7 +253,11 @@ grafana_install(){
   if ! dpkg -s 'grafana' &> /dev/null; then
     if ! add_keys "https://packages.grafana.com/gpg.key"; then return 1; fi
 
-    echo "deb https://packages.grafana.com/oss/deb stable main" > /etc/apt/sources.list.d/grafana.list
+    if is_bullseye; then
+      echo "deb https://packages.grafana.com/oss/deb beta main" > /etc/apt/sources.list.d/grafana.list
+    else
+      echo "deb https://packages.grafana.com/oss/deb stable main" > /etc/apt/sources.list.d/grafana.list
+    fi
 
     echo -n "$(timestamp) [openHABian] Installing Grafana... "
     if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -196,10 +196,10 @@ influxdb_install() {
   else
     myOS="$(lsb_release -si)"
   fi
-  myRelease="$(lsb_release -sc)"
-  if [[ "$myRelease" == "n/a" ]]; then
-    myRelease=${osrelease:-buster}
-  fi
+  #myRelease="$(lsb_release -sc)"
+  #if [[ "$myRelease" == "n/a" ]]; then
+  myRelease=${osrelease:-buster}        # no InfluxDB bullseye repo available
+  #fi
 
   if ! dpkg -s 'influxdb' &> /dev/null; then
     if ! add_keys "https://repos.influxdata.com/influxdb.key"; then return 1; fi

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -197,14 +197,15 @@ influxdb_install() {
     myOS="$(lsb_release -si)"
   fi
   myRelease="$(lsb_release -sc)"
-  #if [[ "$myRelease" == "n/a" ]]; then
+  if is_bullseye || [[ "$myRelease" == "n/a" ]]; then
     myRelease=${osrelease:-buster}
-  #fi
+  fi
 
   if ! dpkg -s 'influxdb' &> /dev/null; then
     if ! add_keys "https://repos.influxdata.com/influxdb.key"; then return 1; fi
 
-    echo "deb https://repos.influxdata.com/${myOS,,} ${myRelease,,} stable" > /etc/apt/sources.list.d/influxdb.list
+    #echo "deb https://repos.influxdata.com/${myOS,,} ${myRelease,,} stable" > /etc/apt/sources.list.d/influxdb.list
+    echo "deb https://repos.influxdata.com/debian ${myRelease} stable" > /etc/apt/sources.list.d/influxdb.list
 
     echo -n "$(timestamp) [openHABian] Installing InfluxDB... "
     if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -191,6 +191,7 @@ influxdb_install() {
   address="http://localhost:8086"
   adminUsername="$1"
   adminPassword="$2"
+  # shellcheck disable=SC2034
   if is_pi; then
     myOS="Debian"
   else

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -3,7 +3,7 @@
 ## Function to install and configure InfluxDB and Grafana, and integrate them with openHAB.
 ## This function can only be invoked in INTERACTIVE with userinterface.
 ##
-##    influxdb_grafana_setup()
+##    ebetanfluxdb_grafana_setup()
 ##
 influxdb_grafana_setup() {
   if [[ -z $INTERACTIVE ]]; then
@@ -197,9 +197,9 @@ influxdb_install() {
     myOS="$(lsb_release -si)"
   fi
   myRelease="$(lsb_release -sc)"
-  if [[ "$myRelease" == "n/a" ]]; then
+  #if [[ "$myRelease" == "n/a" ]]; then
     myRelease=${osrelease:-buster}
-  fi
+  #fi
 
   if ! dpkg -s 'influxdb' &> /dev/null; then
     if ! add_keys "https://repos.influxdata.com/influxdb.key"; then return 1; fi

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -193,7 +193,7 @@ influxdb_install() {
   adminPassword="$2"
   # shellcheck disable=SC2034
   if is_pi; then
-    myOS="Debian"
+    myOS="debian"
   else
     myOS="$(lsb_release -si)"
   fi
@@ -205,8 +205,7 @@ influxdb_install() {
   if ! dpkg -s 'influxdb' &> /dev/null; then
     if ! add_keys "https://repos.influxdata.com/influxdb.key"; then return 1; fi
 
-    #echo "deb https://repos.influxdata.com/${myOS,,} ${myRelease,,} stable" > /etc/apt/sources.list.d/influxdb.list
-    echo "deb https://repos.influxdata.com/debian ${myRelease} stable" > /etc/apt/sources.list.d/influxdb.list
+    echo "deb https://repos.influxdata.com/${myOS,,} ${myRelease,,} stable" > /etc/apt/sources.list.d/influxdb.list
 
     echo -n "$(timestamp) [openHABian] Installing InfluxDB... "
     if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
@@ -245,7 +244,7 @@ influxdb_install() {
 
 ## Install local Grafana installation
 ##
-##    influxdb_install(String admin_password)
+##    grafana_install(String admin_password)
 ##
 grafana_install(){
   local adminPassword

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -210,7 +210,11 @@ homegear_setup() {
 
   if ! add_keys "https://apt.homegear.eu/Release.key"; then return 1; fi
 
-  echo "deb https://apt.homegear.eu/${myOS}/ ${myRelease}/" > /etc/apt/sources.list.d/homegear.list
+  if is_bullseye; then
+    echo "deb https://aptnightly.homegear.eu/${myOS} ${myRelease}/" > /etc/apt/sources.list.d/homegear.list
+  else
+    echo "deb https://apt.homegear.eu/${myOS}/ ${myRelease}/" > /etc/apt/sources.list.d/homegear.list
+  fi
 
   echo -n "$(timestamp) [openHABian] Installing Homegear... "
   if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi

--- a/tests/Dockerfile.amd64-installation
+++ b/tests/Dockerfile.amd64-installation
@@ -1,4 +1,4 @@
-FROM balenalib/amd64-debian:buster-build
+FROM balenalib/amd64-debian:bullseye-build
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 ENV DOCKER=1

--- a/tests/Dockerfile.rpi2-installation
+++ b/tests/Dockerfile.rpi2-installation
@@ -1,5 +1,5 @@
 # Assumes at least ARMv71 but not ARMv8 (aarch64) yet
-FROM balenalib/raspberry-pi2-debian:bullseye-build
+FROM balenalib/raspberry-pi2-debian:buster-build
 
 RUN [ "cross-build-start" ]
 

--- a/tests/Dockerfile.rpi2-installation
+++ b/tests/Dockerfile.rpi2-installation
@@ -1,5 +1,5 @@
 # Assumes at least ARMv71 but not ARMv8 (aarch64) yet
-FROM balenalib/raspberry-pi2-debian:buster-build
+FROM balenalib/raspberry-pi2-debian:bullseye-build
 
 RUN [ "cross-build-start" ]
 

--- a/tests/Dockerfile.rpi3-64-installation
+++ b/tests/Dockerfile.rpi3-64-installation
@@ -1,5 +1,5 @@
 # Note RPi3 base (first RPi to have aarch64 available) WITH 64bit OS
-FROM balenalib/raspberrypi3-64-debian:buster-build
+FROM balenalib/raspberrypi3-64-debian:bullseye-build
 
 RUN [ "cross-build-start" ]
 

--- a/tests/Dockerfile.rpi3-installation
+++ b/tests/Dockerfile.rpi3-installation
@@ -1,5 +1,5 @@
 # Note RPi3 base (first RPi to have aarch64 available) WITH 32bit OS
-FROM balenalib/raspberrypi3-debian:buster-build
+FROM balenalib/raspberrypi3-debian:bullseye-build
 
 RUN [ "cross-build-start" ]
 

--- a/tests/Dockerfile.rpi4-BATS
+++ b/tests/Dockerfile.rpi4-BATS
@@ -1,5 +1,5 @@
 # Note RPi4 base WITH 64bit OS
-FROM balenalib/raspberrypi4-64-debian:buster-build
+FROM balenalib/raspberrypi4-64-debian:bullseye-build
 
 RUN [ "cross-build-start" ]
 


### PR DESCRIPTION
Mostly LGTM

Only thing I noticed is https://github.com/mstormi/openhabian/runs/3190479326?check_suite_focus=true#step:8:1389

```
W: Skipping acquire of configured file 'ui/binary-armhf/Packages' as repository 'http://archive.raspberrypi.org/debian bullseye InRelease' doesn't have the component 'ui' (component misspelt in sources.list?)
```

Signed-off-by: Markus Storm <markus.storm@gmx.net>