### PR TITLE
Add automatic release drafting

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2.4.0
+         with:
+           repository: ${{ github.event.pull_request.head.repo.full_name }}
+           ref: ${{ github.event.pull_request.head.ref }}
+       - name: Setup environment
+         id: setup
+         run: |
+           sudo -E bash -c set
+           sudo apt-get update
+           sudo apt-get install --yes libarchive-zip-perl dos2unix systemd-container qemu-user-static qemu-utils
+           echo "::set-output name=image32::$(basename "$(curl "https://downloads.raspberrypi.org/raspios_lite_armhf_latest" -s -L -I  -o /dev/null -w '%{url_effective}')")"
+           echo "::set-output name=image64::$(basename "$(curl "https://downloads.raspberrypi.org/raspios_lite_arm64_latest" -s -L -I  -o /dev/null -w '%{url_effective}')")"
+       - name: Cache Raspberry Pi OS image32
+         uses: actions/cache@v2.1.6
+         with:
+           path: ${{ steps.setup.outputs.image32 }}
+           key: ${{ steps.setup.outputs.image32 }}
+       - name: Cache Raspberry Pi OS image64
+         uses: actions/cache@v2.1.6
+         with:
+           path: ${{ steps.setup.outputs.image64 }}
+           key: ${{ steps.setup.outputs.image64 }}
+       - name: Build openHABian 32bit image
+         id: build32
+         run: |
+           sudo -E ./tests/ci-setup.bash github .pi-raspios32
+           sed -i -e "s|^userpw=.*$|userpw=\"${{secrets.USERPW}}\"|g" build-image/openhabian.pi-raspios32.conf
+           sed -i -e "s|ap_password:.*$|ap_password: ${{secrets.HOTSPOTPW}}|g" includes/comitup.conf
+           sudo -E ./build.bash rpi
+           echo "::set-output name=file::$(ls openhabian-pi-raspios32*.img.xz)"
+       - name: Build openHABian 64bit image
+         id: build64
+         run: |
+           sudo -E ./tests/ci-setup.bash github .pi-raspios64beta
+           sed -i -e "s|^userpw=.*$|userpw=\"${{secrets.USERPW}}\"|g" build-image/openhabian.pi-raspios64beta.conf
+           sed -i -e "s|ap_password:.*$|ap_password: ${{secrets.HOTSPOTPW}}|g" includes/comitup.conf
+           sudo -E ./build.bash rpi64
+           echo "::set-output name=file::$(ls openhabian-pi-raspios64beta*.img.xz)"
+       - name: Create release template
+         uses: "marvinpinto/action-automatic-releases@v1.2.1"
+         with:
+           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+           title: "openHABian $GITHUB_REF"
+           prerelease: false
+           draft: true
+           files: |
+             ${{ steps.build32.outputs.file }}
+             ${{ steps.build64.outputs.file }}

--- a/build-image/offline-install-modifications.bash
+++ b/build-image/offline-install-modifications.bash
@@ -12,19 +12,19 @@ add_keys "https://davesteele.github.io/key-366150CE.pub.txt" "comitup"
 echo "deb [signed-by=/usr/share/keyrings/comitup.gpg] http://davesteele.github.io/comitup/repo comitup main" > /etc/apt/sources.list.d/comitup.list
 apt-get --quiet update
 apt-get --quiet upgrade --yes
-apt-get --quiet install --download-only --yes libattr1-dev libc6 libstdc++6 \
-  zlib1g make openhab openhab-addons samba amanda-common amanda-server \
-  amanda-client exim4 dnsutils mailutils gdisk screen vim nano mc vfu \
-  bash-completion coreutils htop curl wget multitail git util-linux bzip2 zip \
-  unzip xz-utils software-properties-common man-db whiptail acl usbutils dirmngr \
-  arping apt-transport-https bc sysstat jq moreutils avahi-daemon python3 \
-  python3-pip python3-wheel python3-setuptools avahi-autoipd fontconfig \
-  comitup dns-root-data dnsmasq-base javascript-common libcairo2 \
-  libgudev-1.0-0 libjs-jquery libmbim-glib4 libmbim-proxy libmm-glib0 \
-  libndp0 libnm0 libpixman-1-0 libqmi-glib5 libqmi-proxy libteamdctl0 \
-  libxcb-render0 libxcb-shm0 libxrender1 modemmanager  network-manager \
-  python3-blinker python3-cairo python3-click python3-colorama \
-  python3-flask python3-itsdangerous python3-jinja2 python3-markupsafe \
+apt-get --quiet install --download-only --yes libc6 libstdc++6 zlib1g make \
+  openhab openhab-addons samba amanda-common amanda-server amanda-client exim4 \
+  dnsutils mailutils gdisk screen vim nano mc vfu bash-completion coreutils \
+  htop curl wget multitail git util-linux bzip2 zip unzip xz-utils \
+  software-properties-common man-db whiptail acl usbutils dirmngr arping \
+  apt-transport-https bc sysstat jq moreutils avahi-daemon python3 python3-pip \
+  python3-wheel python3-setuptools avahi-autoipd fontconfig comitup \
+  dns-root-data dnsmasq-base javascript-common libcairo2 libgudev-1.0-0 \
+  libjs-jquery libmbim-glib4 libmbim-proxy libmm-glib0 libndp0 libnm0 \
+  libpixman-1-0 libqmi-glib5 libqmi-proxy libteamdctl0 libxcb-render0 \
+  libxcb-shm0 libxrender1 modemmanager network-manager python3-blinker \
+  python3-cairo python3-click python3-colorama python3-flask \
+  python3-itsdangerous python3-jinja2 python3-markupsafe \
   python3-networkmanager python3-pyinotify python3-simplejson python3-werkzeug
 source /opt/openhabian/functions/nodejs-apps.bash
 nodejs_setup

--- a/build.bash
+++ b/build.bash
@@ -197,7 +197,7 @@ offline_install_modifications() {
   local loopPrefix
 
   if running_on_github; then
-    echo_process "Cacheing packages for offline install..."
+    echo_process "Caching packages for offline install..."
     loopPrefix="$(kpartx -asv "$imageFile" | grep -oE "loop([0-9]+)" | head -n 1)"
     mount -o rw -t ext4 "/dev/mapper/${loopPrefix}p2" "$mountFolder"
     mount -o rw -t vfat "/dev/mapper/${loopPrefix}p1" "${mountFolder}/boot"


### PR DESCRIPTION
This primarily solves the issue of having to download and reupload the
image files for releases.

When used, this will let the maintainers simply push a tag in the format
of 'vx.x.x' and the action will run and generate a release draft with
the proper image files alreay attached. All the maintainer needs to do
is wait for it to generate and while waiting make some nice and pretty
release notes to go along with it.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>