### PR TITLE
[WIP]Add update docs action

### DIFF
--- a/.github/workflows/docs-update-action.yml
+++ b/.github/workflows/docs-update-action.yml
@@ -1,0 +1,17 @@
+name: Doc update on release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  triggerWorkflowDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
+          repository: openhab/openhab-docs
+          event-type: update-openhabian-docs-event


### PR DESCRIPTION
This will add an action, which triggers an openhab docs repo action on an openHABian release.
(Or on a manual dispatch of this action via the Github Page.)

Depends on: openhab/openhab-docs#1690

## Goal

Transfer latest openHABian documentation to the openhab docs website, when a new release has been published.

## Prerequisites

- [x] Doc files have to be in a `docs` folder
- [x] Articles that should be transferred have to be prefixed with `openhabian-`
- [x] Images that should be transferred have to be in a `docs/images` folder
- [x] Images that should be transferred have to be prefixed with `openHABian-`
- [ ] This repository needs a secret named `DOCS_REPO_ACCESS_TOKEN` with `public_repo` access to the openhab-docs repository

## Workflow

This action will trigger a `repository_dispatch` event in the openhab-docs repository, when everything is set up correct.
This event will start an action in the openhab-docs repository that fetches the latest openHABian docs contents and copy them into the stable-release openHAB documentation.


@kaikreuzer can we steup a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the openhab-bot account for this?
The PAT then needs to be stored as a Secret in this repo, with the name written above.
This is needed to trigger events across different repositories.