### PR TITLE
Fix TIP box presentation

### DIFF
--- a/docs/openhabian-DEBUG.md
+++ b/docs/openhabian-DEBUG.md
@@ -8,7 +8,8 @@ source: https://github.com/openhab/openhabian/blob/main/docs/openhabian-DEBUG.md
 
 This document is meant to give a guiding hand to users when their openHABian install fails either on initial image installation or later on when running menu options that install or configure optional components.
 
-::: tip [TLDR](https://www.howtogeek.com/435266/what-does-tldr-mean-and-how-do-you-use-it/)
+::: tip
+[TLDR](https://www.howtogeek.com/435266/what-does-tldr-mean-and-how-do-you-use-it/)
 Set `debugmode=maximum`in `/etc/openhabian.conf` and see `/boot/first-boot.log` for image installation else record the terminal output.
 :::
 


### PR DESCRIPTION
The missing newline probably makes the rendering fail for the link on the website.
GitHub seems to work, because it does not know anything about the tip syntax.

Fixes openhab/openhab-docs#1760