### PR TITLE
Fix typo in smb.conf

### DIFF
--- a/includes/smb.conf
+++ b/includes/smb.conf
@@ -84,7 +84,7 @@
 # domain controller", "classic backup domain controller", "active
 # directory domain controller".
 #
-# Most people will want "standalone sever" or "member server".
+# Most people will want "standalone server" or "member server".
 # Running as "active directory domain controller" will require first
 # running "samba-tool domain provision" to wipe databases and create a
 # new domain.


### PR DESCRIPTION
Just a typo.