### PR TITLE
check for hold package state in apt as well

### DIFF
--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -589,7 +589,7 @@ openhab_is_running() {
 ##    openhab2_is_installed()
 ##
 openhab2_is_installed() {
-  if [[ $(dpkg -s 'openhab2' 2> /dev/null | grep Status | cut -d' ' -f2) == "install" ]]; then return 0; else return 1; fi
+  if [[ $(dpkg -s 'openhab2' 2> /dev/null | grep Status | cut -d' ' -f2) =~ ^(install|hold)$ ]]; then return 0; else return 1; fi
 }
 ## Function to check if openHAB 3 is installed on the current system. Returns
 ## 0 / true if openHAB is installed and 1 / false if not.
@@ -597,7 +597,7 @@ openhab2_is_installed() {
 ##    openhab3_is_installed()
 ##
 openhab3_is_installed() {
-  if [[ $(dpkg -s 'openhab' 2> /dev/null | grep Status | cut -d' ' -f2) == "install" ]]; then return 0; else return 1; fi
+  if [[ $(dpkg -s 'openhab' 2> /dev/null | grep Status | cut -d' ' -f2) =~ ^(install|hold)$ ]]; then return 0; else return 1; fi
 }
 ## Function to check if openHAB is installed on the current system. Returns
 ## 0 / true if openHAB is installed and 1 / false if not.


### PR DESCRIPTION
This was annoying me that my MOTD kept giving errors about not finding
/var/lib/openhab2/etc/version.properties, when I realized it's because
I have the package on hold (I'm on a snapshot, and don't want it
accidentally updated).

Signed-off-by: Cody Cutrer <cody@cutrer.us>