### PR TITLE
Fix locale setting with openhabian.conf not working

### DIFF
--- a/functions/system.bash
+++ b/functions/system.bash
@@ -150,6 +150,7 @@ locale_setting() {
   if [[ -n $INTERACTIVE ]]; then
     echo -n "$(timestamp) [openHABian] Setting locale based on user choice... "
     if ! dpkg-reconfigure locales; then echo "FAILED (reconfigure locales)"; return 1; fi
+    if ! syslocale="$(grep "^[[:space:]]*LANG=" /etc/default/locale | sed 's|LANG=||g')"; then echo "FAILED"; return 1; fi
   else
     echo -n "$(timestamp) [openHABian] Setting locale based on openhabian.conf... "
     # shellcheck disable=SC2154,SC2086
@@ -161,10 +162,10 @@ locale_setting() {
       done
       if ! cond_redirect locale-gen; then echo "FAILED (locale-gen)"; return 1; fi
     fi
-    if ! cond_redirect dpkg-reconfigure --frontend=noninteractive locales; then echo "FAILED (reconfigure locales)"; return 1; fi
+    # shellcheck disable=SC2154
+    syslocale=$system_default_locale
   fi
 
-  if ! syslocale="$(grep "^[[:space:]]*LANG=" /etc/default/locale | sed 's|LANG=||g')"; then echo "FAILED"; return 1; fi
   if cond_redirect update-locale LANG="${syslocale:-en_US.UTF-8}" LC_ALL="${syslocale:-en_US.UTF-8}" LC_CTYPE="${syslocale:-en_US.UTF-8}" LANGUAGE="${syslocale:-en_US.UTF-8}"; then echo "OK (reboot required)"; else echo "FAILED"; return 1; fi
 
   if [[ -n $INTERACTIVE ]]; then

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -163,10 +163,10 @@ locale_setting() {
       if ! cond_redirect locale-gen; then echo "FAILED (locale-gen)"; return 1; fi
     fi
     # shellcheck disable=SC2154
-    syslocale=$system_default_locale
+    syslocale=${system_default_locale:-en_US.UTF-8}
   fi
 
-  if cond_redirect update-locale LANG="${syslocale:-en_US.UTF-8}" LC_ALL="${syslocale:-en_US.UTF-8}" LC_CTYPE="${syslocale:-en_US.UTF-8}" LANGUAGE="${syslocale:-en_US.UTF-8}"; then echo "OK (reboot required)"; else echo "FAILED"; return 1; fi
+  if cond_redirect update-locale LANG="${syslocale}" LC_ALL="${syslocale}" LC_CTYPE="${syslocale}" LANGUAGE="${syslocale}"; then echo "OK (reboot required)"; else echo "FAILED"; return 1; fi
 
   if [[ -n $INTERACTIVE ]]; then
     whiptail --title "Change locale" --msgbox "For the locale change to take effect, please reboot your system now." 7 80


### PR DESCRIPTION
Fixes #1721.

@mstormi Am I right with the following assumption?
Removed `dpkg-reconfigure --frontend=noninteractive locales` because it's only generating the locales, which is already done with `locale-gen`.

I tested the locale setup using `openhabian.conf` and the `openhabian-config` tool a few times, seems to work this time.
Maybe you could also test.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>