### PR TITLE
Update NodeJS installed check & armv6l NodeJS install

### DIFF
--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -640,7 +640,7 @@ grafana_is_installed() {
 ##    node_is_installed
 ##
 node_is_installed() {
-  if [[ -x $(command -v npm) ]] && [[ $(node --version) == "v14"* ]]; then return 0; fi
+  if [[ -x $(command -v npm) ]] && [[ $(node --version) == "v16"* ]]; then return 0; fi
   return 1
 }
 

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -9,7 +9,7 @@ nodejs_setup() {
   if node_is_installed && ! is_armv6l; then return 0; fi
 
   local keyName="nodejs"
-  local link="https://unofficial-builds.nodejs.org/download/release/v14.18.2/node-v14.18.2-linux-armv6l.tar.xz"
+  local link="https://unofficial-builds.nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-armv6l.tar.xz"
   local myDistro
   local temp
 


### PR DESCRIPTION
Fixes #1722.

## Changes

Updates the `node_is_installed` check from v14 to v16.
Install NodeJS v16 instead of v14 on `armv6l`.

## Testing

Should not require much testing, as openHABian is on NodeJS v16 since mid of June this year.
Futhermore, as described in #1722, all dependencies should run on NodeJS v16.

@mstormi 
The installation of v16 on `armv6l` is something I can‘t test due to the lack of such hardware.
WDYT?