### PR TITLE
Updated InfluxDB Key URL

### DIFF
--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -200,7 +200,7 @@ influxdb_install() {
   fi
 
   if ! influxdb_is_installed; then
-    if ! add_keys "https://repos.influxdata.com/influxdb.key" "$keyName"; then return 1; fi
+    if ! add_keys "https://repos.influxdata.com/influxdata-archive_compat.key" "$keyName"; then return 1; fi
 
     echo "deb [signed-by=/usr/share/keyrings/${keyName}.gpg] https://repos.influxdata.com/${myOS,,} ${myRelease,,} stable" > /etc/apt/sources.list.d/influxdb.list
 


### PR DESCRIPTION
InluxDB updated their GPG key and provides it under a new URL.
It is already changed in `main` branch but, is not backported to `OpenHAB3` branch.

See also Issue #1753 and commit [e2000f2](https://github.com/openhab/openhabian/commit/e2000f2185bd61716c2f53546455deea8fbd654f)

With this Pull Request the install influx+grafana.bash script will work for all users still on `Release` branch