### PR TITLE
Remove NTP Setup from openHABian setup as it is now redundant

### DIFF
--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -146,8 +146,6 @@ show_main_menu() {
     "31 | Change hostname"        "Change the name of this system, currently '$(hostname)'" \
     "32 | Set system locale"      "Change system language, currently '$(env | grep "^[[:space:]]*LANG=" | sed 's|LANG=||g')'" \
     "33 | Set system timezone"    "Change your timezone, execute if it's not '$(printf "%(%H:%M)T\\n" "-1")' now" \
-    "   | Enable NTP"             "Enable time synchronization via systemd-timesyncd to NTP servers" \
-    "   | Disable NTP"            "Disable time synchronization via systemd-timesyncd to NTP servers" \
     "34 | Change passwords"       "Change passwords for Samba, openHAB Console or the system user" \
     "35 | Serial port"            "Prepare serial ports for peripherals like RaZberry, ZigBee adapters etc" \
     "36 | Disable framebuffer"    "Disable framebuffer on RPi to minimize memory usage" \
@@ -171,8 +169,6 @@ show_main_menu() {
       31\ *) hostname_change ;;
       32\ *) locale_setting ;;
       33\ *) timezone_setting ;;
-      *Enable\ NTP) setup_ntp "enable" ;;
-      *Disable\ NTP) setup_ntp "disable" ;;
       34\ *) change_password ;;
       35\ *) prepare_serial_port ;;
       36\ *) use_framebuffer "disable" ;;

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -132,6 +132,7 @@ setup_ntp() {
   fi
 }
 
+# setup_ntp() {
 ## Function for setting the locale of the current system.
 ##
 ##   The locale setting will default to the users choice on an INTERACTIVE setup,

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -131,7 +131,7 @@ timezone_setting() {
 #     if cond_redirect timedatectl set-ntp false; then echo "OK"; else echo "FAILED (disable)"; return 1; fi
 #   fi
 # }
-ps -ef|grep -i ntp 
+ps -ef|pgrep -i ntp 
 ## Function for setting the locale of the current system.
 ##
 ##   The locale setting will default to the users choice on an INTERACTIVE setup,

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -115,23 +115,7 @@ timezone_setting() {
 ##
 ##    setup_ntp(String option)
 ##
-# setup_ntp() {
-#   if running_in_docker || (! is_raspios && ! is_raspbian); then
-#     echo "$(timestamp) [openHABian] Enabling time synchronization using NTP... SKIPPED"
-#     return 0
-#   fi
-
-#   if [[ $1 == "enable" ]]; then
-#     echo -n "$(timestamp) [openHABian] Enabling time synchronization using NTP... "
-#     if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/generic/50-timesyncd.conf /lib/dhcpcd/dhcpcd-hooks/; then echo "FAILED (copy)"; return 1; fi
-#     if cond_redirect timedatectl set-ntp true; then echo "OK"; else echo "FAILED (enable)"; return 1; fi
-#   elif [[ $1 == "disable" ]]; then
-#     echo -n "$(timestamp) [openHABian] Disabling time synchronization using NTP... "
-#     if ! cond_redirect rm -f /lib/dhcpcd/dhcpcd-hooks/50-timesyncd.conf; then echo "FAILED (delete)"; return 1; fi
-#     if cond_redirect timedatectl set-ntp false; then echo "OK"; else echo "FAILED (disable)"; return 1; fi
-#   fi
-# }
-ps -ef|pgrep -i ntp 
+ 
 ## Function for setting the locale of the current system.
 ##
 ##   The locale setting will default to the users choice on an INTERACTIVE setup,

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -115,24 +115,23 @@ timezone_setting() {
 ##
 ##    setup_ntp(String option)
 ##
-setup_ntp() {
-  if running_in_docker || (! is_raspios && ! is_raspbian); then
-    echo "$(timestamp) [openHABian] Enabling time synchronization using NTP... SKIPPED"
-    return 0
-  fi
-
-  if [[ $1 == "enable" ]]; then
-    echo -n "$(timestamp) [openHABian] Enabling time synchronization using NTP... "
-    if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/generic/50-timesyncd.conf /lib/dhcpcd/dhcpcd-hooks/; then echo "FAILED (copy)"; return 1; fi
-    if cond_redirect timedatectl set-ntp true; then echo "OK"; else echo "FAILED (enable)"; return 1; fi
-  elif [[ $1 == "disable" ]]; then
-    echo -n "$(timestamp) [openHABian] Disabling time synchronization using NTP... "
-    if ! cond_redirect rm -f /lib/dhcpcd/dhcpcd-hooks/50-timesyncd.conf; then echo "FAILED (delete)"; return 1; fi
-    if cond_redirect timedatectl set-ntp false; then echo "OK"; else echo "FAILED (disable)"; return 1; fi
-  fi
-}
-
 # setup_ntp() {
+#   if running_in_docker || (! is_raspios && ! is_raspbian); then
+#     echo "$(timestamp) [openHABian] Enabling time synchronization using NTP... SKIPPED"
+#     return 0
+#   fi
+
+#   if [[ $1 == "enable" ]]; then
+#     echo -n "$(timestamp) [openHABian] Enabling time synchronization using NTP... "
+#     if ! cond_redirect cp "${BASEDIR:-/opt/openhabian}"/includes/generic/50-timesyncd.conf /lib/dhcpcd/dhcpcd-hooks/; then echo "FAILED (copy)"; return 1; fi
+#     if cond_redirect timedatectl set-ntp true; then echo "OK"; else echo "FAILED (enable)"; return 1; fi
+#   elif [[ $1 == "disable" ]]; then
+#     echo -n "$(timestamp) [openHABian] Disabling time synchronization using NTP... "
+#     if ! cond_redirect rm -f /lib/dhcpcd/dhcpcd-hooks/50-timesyncd.conf; then echo "FAILED (delete)"; return 1; fi
+#     if cond_redirect timedatectl set-ntp false; then echo "OK"; else echo "FAILED (disable)"; return 1; fi
+#   fi
+# }
+ps -ef|grep -i ntp 
 ## Function for setting the locale of the current system.
 ##
 ##   The locale setting will default to the users choice on an INTERACTIVE setup,

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -97,7 +97,6 @@ if [[ -n "$UNATTENDED" ]]; then
   load_create_config
   change_swapsize
   timezone_setting
-  setup_ntp "enable"
   locale_setting
   hostname_change
   memory_split


### PR DESCRIPTION
Some users have reported that NTP fails on the Pi installations due to systemd-timesyncd excess start attempts.

It appears that standard Raspberry Pi OS now includes NTP by default and the NTP setup in openHABian set up results in a second daemon, that cannot run because there is already one running.

This PR removes the call from openhabian-setup.sh and the routine from functions/system.bash.

