### PR TITLE
Fix service script on Openhabian (and every other *nix)

### DIFF
--- a/includes/openhab-override.conf
+++ b/includes/openhab-override.conf
@@ -3,4 +3,4 @@ Wants=frontail.service homegear.service
 Before=frontail.service homegear.service
 
 [Service]
-ExecStartPre=+/usr/bin/rm -f /var/lock/LCK..ttyAMA0 /var/lock/LCK..ttyACM0
+ExecStartPre=+/bin/rm -f /var/lock/LCK..ttyAMA0 /var/lock/LCK..ttyACM0


### PR DESCRIPTION
rm(1) resides in /bin, not /usr/bin