### PR TITLE
Update nodejs-apps.bash

### DIFF
--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -294,6 +294,14 @@ zigbee2mqtt_setup() {
     my_adapters="$my_adapters $line $loopSel "
     loopSel=0
   done < <( ls /dev/serial/by-id )
+
+  if [[ $my_adapters == "" ]] ; then
+    while IFS= read -r line; do
+      my_adapters="$my_adapters $line $loopSel "
+      loopSel=0
+    done < <( ls /dev/serial/by-path )
+  fi
+
   unset IFS
   
   # ask for user input parameters


### PR DESCRIPTION
provide a workaround for the debian bug with missing /dev/serial/by-id. In this case /dev/serial/by-path is scanned
Signed-off-by: Carsten Mogge <carsten.mogge@gmail.com>