### PR TITLE
nodejs-apps.bash: bug-fix in zigbee2mqtt install routine

### DIFF
--- a/includes/zigbee2mqtt/configuration.yaml
+++ b/includes/zigbee2mqtt/configuration.yaml
@@ -8,7 +8,7 @@ mqtt:
   user: "%user%"
   password: "%password%"
 serial:
-  port: "/dev/serial/by-id/%adapterName"
+  port: "/dev/serial/%adapter"
 advanced:
   network_key: GENERATE
   pan_id: GENERATE 


### PR DESCRIPTION
- bug-fix: wrong path if using by-path directory
- use -p option when creating directories for zigbee2mqtt to avoid unnecessary abort of installation
Signed-off-by: Carsten Mogge <carsten.mogge@gmail.com>