### PR TITLE
Update openhabian.bash to support yescrypt which is default hash with…

### DIFF
--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -382,13 +382,15 @@ system_check_default_password() {
   if ! is_pi; then return 0; fi
 
   local algo
+  local param
   local defaultPassword
   local defaultUser
   local generatedPassword
   local introText
   local originalPassword
   local salt
-
+  local fields
+  
   if is_pi && id -u pi &> /dev/null; then
     defaultUser="pi"
     defaultPassword="raspberry"
@@ -397,12 +399,25 @@ system_check_default_password() {
     defaultPassword="openhabian"
   fi
   originalPassword="$(grep -w "$defaultUser" /etc/shadow | cut -d: -f2)"
-  algo="$(echo "$originalPassword" | cut -d'$' -f2)"
-  introText="The default password was detected on your system! That is a serious security concern. Bad guys or malicious programs in your subnet are able to gain root access!\\n\\nPlease set a strong password by typing the command 'passwd ${defaultUser}'!"
-  salt="$(echo "$originalPassword" | cut -d'$' -f3)"
-  export algo defaultPassword salt
-  generatedPassword="$(perl -le 'print crypt("$ENV{defaultPassword}","\$$ENV{algo}\$$ENV{salt}\$")')"
+  fields=$(echo $originalPassword|awk -F'$' '{print NF}')
+  case $fields in
+    5)
+      algo="$(echo "$originalPassword" | cut -d'$' -f2)"
+      param="$(echo "$originalPassword" | cut -d'$' -f3)"
+      salt="$(echo "$originalPassword" | cut -d'$' -f4)"
+      export algo defaultPassword param salt fields
+      generatedPassword="$(perl -le 'print crypt("$ENV{defaultPassword}","\$$ENV{algo}\$$ENV{param}\$$ENV{salt}\$")')"
+      ;;
+    *)
+      algo="$(echo "$originalPassword" | cut -d'$' -f2)"
+      salt="$(echo "$originalPassword" | cut -d'$' -f3)"
+      export algo defaultPassword salt fields
+      generatedPassword="$(perl -le 'print crypt("$ENV{defaultPassword}","\$$ENV{algo}\$$ENV{salt}\$")')"
+      ;;
+  esac  
 
+  introText="The default password was detected on your system! That is a serious security concern. Bad guys or malicious programs in your subnet are able to gain root access!\\n\\nPlease set a strong password by typing the command 'passwd ${defaultUser}'!"
+        
   echo -n "$(timestamp) [openHABian] Checking for default openHABian username:password combination... "
   if ! [[ $(id -u "$defaultUser") ]]; then echo "OK (unknown user)"; return 0; fi
   if [[ $generatedPassword == "$originalPassword" ]]; then
@@ -414,6 +429,7 @@ system_check_default_password() {
     echo "OK"
   fi
 }
+
 
 ## Enable / Disable IPv6 according to the users configured option in '$configFile'
 ## Valid arguments: "enable" or "disable"

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -399,7 +399,7 @@ system_check_default_password() {
     defaultPassword="openhabian"
   fi
   originalPassword="$(grep -w "$defaultUser" /etc/shadow | cut -d: -f2)"
-  fields=$(echo $originalPassword|awk -F'$' '{print NF}')
+  fields=$(echo "$originalPassword" | awk -F'$' '{print NF}')
   case $fields in
     5)
       algo="$(echo "$originalPassword" | cut -d'$' -f2)"


### PR DESCRIPTION
… bookworm

To support default password detection when OS is bookworm yescrypt hash needs to be supported. Modified code detects if yescrypt is used.