### PR TITLE
add Zulu JDK 21 installation on 64bit

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -7,7 +7,7 @@ set -e
 ####################################################################
 
 usage() {
-  echo -e "Usage: $(basename "$0") <platform> [oldstable]"
+  echo -e "Usage: $(basename "$0") <platform> [oldstable|latest]"
   echo -e "\\nCurrently supported platforms: rpi, rpi64"
 }
 

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -219,6 +219,7 @@ show_main_menu() {
     "   | OpenJDK 11"                     "Install and activate OpenJDK 11 as Java provider" \
     "   | Zulu 11 OpenJDK 32-bit"         "Install Zulu 11 32-bit OpenJDK as Java provider" \
     "   | Zulu 11 OpenJDK 64-bit"         "Install Zulu 11 64-bit OpenJDK as Java provider" \
+    "   | Zulu 21 OpenJDK 64-bit"         "Install Zulu 21 64-bit OpenJDK (EXPERIMENTAL)" \
     "46 | Install openhab-js"             "JS Scripting: Upgrade to latest version of openHAB JavaScript library (advanced)" \
     "   | Uninstall openhab-js"           "JS Scripting: Switch back to included version of openHAB JavaScript library" \
     "47 | Install openhab_rules_tools"    "JS Scripting: Manually install openhab_rules_tools (auto-installed)" \
@@ -239,6 +240,7 @@ show_main_menu() {
       *OpenJDK\ 17) update_config_java "17" && java_install "17";;
       *Zulu\ 11\ OpenJDK\ 32-bit) update_config_java "Zulu11-32" && java_install_or_update "Zulu11-32";;
       *Zulu\ 11\ OpenJDK\ 64-bit) update_config_java "Zulu11-64" && java_install_or_update "Zulu11-64";;
+      *Zulu\ 21\ OpenJDK\ 64-bit) update_config_java "Zulu21-64" && java_install_or_update "Zulu21-64";;
       46\ *) jsscripting_npm_install "openhab";;
       *Uninstall\ openhab-js) jsscripting_npm_install "openhab" "uninstall";;
       47\ *) jsscripting_npm_install "openhab_rules_tools";;


### PR DESCRIPTION
Requires a native 64 bit image, running a 64 bit kernel with 32-bit OS is not sufficient.

I have been working to make OH compile an run with Java21 openhab/openhab-distro#1590. Not all of the required PRs have been merged, so we are not yet there.
This PR allows to install Java21 on x64/aarch64 systems.

Running the snapshot distro without modification is not yet possible, still waiting for the PR openhab/openhab-distro#1640
 to be merged.