### PR TITLE
pkill java after restart to eventually break out of startup loop

### DIFF
--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -132,8 +132,8 @@ openhab_setup() {
   dashboard_add_tile "openhabiandocs"
 
   # see https://github.com/openhab/openhab-core/issues/1937
-  echo -n "$(timestamp) [openHABian] Restarting openHAB service to play it safe... "
-  if cond_redirect systemctl restart ${ohPkgName}.service; then echo "OK"; else echo "FAILED (restart service)"; return 1; fi
+  echo -n "$(timestamp) [openHABian] Restarting openHAB service the hard way to play it safe... "
+  pkill -9 java
 
   if [[ -n $INTERACTIVE ]]; then
     unset DEBIAN_FRONTEND

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -133,6 +133,8 @@ openhab_setup() {
 
   # see https://github.com/openhab/openhab-core/issues/1937
   echo -n "$(timestamp) [openHABian] Restarting openHAB service the hard way to play it safe... "
+  if cond_redirect systemctl restart ${ohPkgName}.service; then echo "OK"; else echo "FAILED (restart service)"; return 1; fi
+  sleep 60
   pkill -9 java
 
   if [[ -n $INTERACTIVE ]]; then


### PR DESCRIPTION
Fixes: #1870 

not 100% sure it's ok to remove the restart command, but the effect should be the same (except for the speedup, of course)