### PR TITLE
Java 21 for 32-bit: Add BellSoft Liberica JDK 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Choose yours based on your hardware and primary use case. Please be aware that y
 Use the 64 bit image versions but please be aware that 64 bit always has one major drawback: increased memory usage. That is not a good idea on heavily memory constrained platforms like Raspberries. If you want to go with 64 bit, ensure your RPi has a minimum of 2 GB, 4 will put you on the safe side.
 You can use the 32 bit version for older or non official addons that will not work on 64 bit yet.
 Note there's a known issue on 32 bit, JS rules are reported to be annoyingly slow on first startup and in some Blockly use cases.
-If you consider using the (newer but still experimental) Java version 21, choose 64 bit. Java 21 is not available for 32 bit systems.
+If you consider using the (newer but still experimental) Java version 21, better choose 64 bit.
 
 On x86 hardware, it's all 64 bit but that in turn once more increases memory usage. A NUC to run on should have no less than 8 GB.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Choose yours based on your hardware and primary use case. Please be aware that y
 Use the 64 bit image versions but please be aware that 64 bit always has one major drawback: increased memory usage. That is not a good idea on heavily memory constrained platforms like Raspberries. If you want to go with 64 bit, ensure your RPi has a minimum of 2 GB, 4 will put you on the safe side.
 You can use the 32 bit version for older or non official addons that will not work on 64 bit yet.
 Note there's a known issue on 32 bit, JS rules are reported to be annoyingly slow on first startup and in some Blockly use cases.
-If you consider using the (newer but still experimental) Java version 21, better choose 64 bit.
+If you consider using the (newer but still experimental) Java version 21, if possible choose 64 bit.
 
 On x86 hardware, it's all 64 bit but that in turn once more increases memory usage. A NUC to run on should have no less than 8 GB.
 

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -110,7 +110,8 @@ liberica_install_apt() {
   elif dpkg -s $pkgname &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Reconfiguring BellSoft Liberica JDK... "
     if cond_redirect dpkg-reconfigure $pkgname; then echo "OK"; else echo "FAILED"; return 1; fi
-    update-alternatives --set java $(ls -d /usr/lib/jvm/bellsoft-java21-lite-* |head -n1)/bin/java
+    # shellcheck disable=SC2012
+    update-alternatives --set java "$(ls -d /usr/lib/jvm/bellsoft-java21-lite-* |head -n1)"/bin/java
   fi
 }
 

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -54,27 +54,13 @@ openjdk_install_apt() {
   if ! dpkg -s "openjdk-${1}-jre-headless" &> /dev/null; then # Check if already is installed
     openjdk_fetch_apt "$1"
     echo -n "$(timestamp) [openHABian] Installing OpenJDK ${1}... "
-
-    if openhab_is_running; then
-      cond_redirect systemctl stop openhab.service
-    fi
-
     cond_redirect java_alternatives_reset
     if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" "openjdk-${1}-jre-headless"; then echo "OK"; else echo "FAILED"; return 1; fi
-
-    if openhab_is_installed; then
-      cond_redirect systemctl restart openhab.service
-    fi
-
   elif dpkg -s "openjdk-${1}-jre-headless" &> /dev/null; then
     echo -n "$(timestamp) [openHABian] Reconfiguring OpenJDK ${1}... "
     cond_redirect java_alternatives_reset
     if cond_redirect dpkg-reconfigure "openjdk-${1}-jre-headless"; then echo "OK"; else echo "FAILED"; return 1; fi
     update-alternatives --set java /usr/lib/jvm/java-"${1}"-openjdk-armhf/bin/java
-
-    if openhab_is_installed; then
-      cond_redirect systemctl restart openhab.service
-    fi
   fi
 }
 
@@ -111,7 +97,7 @@ liberica_install_apt() {
     echo -n "$(timestamp) [openHABian] Reconfiguring BellSoft Liberica JDK... "
     if cond_redirect dpkg-reconfigure $pkgname; then echo "OK"; else echo "FAILED"; return 1; fi
     # shellcheck disable=SC2012
-    update-alternatives --set java "$(ls -d /usr/lib/jvm/bellsoft-java21-lite-* |head -n1)"/bin/java
+    update-alternatives --set java "$(ls -d /usr/lib/jvm/bellsoft-java21-lite-* | head -n1)"/bin/java
   fi
 }
 

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -216,7 +216,8 @@ show_main_menu() {
     "   | OpenJDK 11"                     "Install and activate OpenJDK 11 as Java provider" \
     "   | Zulu 11 OpenJDK 32-bit"         "Install Zulu 11 32-bit OpenJDK as Java provider" \
     "   | Zulu 11 OpenJDK 64-bit"         "Install Zulu 11 64-bit OpenJDK as Java provider" \
-    "   | Zulu 21 OpenJDK 64-bit"         "Install Zulu 21 64-bit OpenJDK (EXPERIMENTAL)" \
+    "   | Zulu 21 OpenJDK 64-bit"         "Install Zulu 21 64-bit OpenJDK as Java provider" \
+    "   | BellSoft Liberica JDK 21"       "Install BellSoft Liberica JDK 21, supports 32bit RPi (EXPERIMENTAL)" \
     "47 | Install openhab-js"             "JS Scripting: Upgrade to latest version of openHAB JavaScript library (advanced)" \
     "   | Uninstall openhab-js"           "JS Scripting: Switch back to included version of openHAB JavaScript library" \
     "48 | Install openhab_rules_tools"    "JS Scripting: Manually install openhab_rules_tools (auto-installed)" \
@@ -239,6 +240,7 @@ show_main_menu() {
       *Zulu\ 11\ OpenJDK\ 32-bit) update_config_java "Zulu11-32" && java_install_or_update "Zulu11-32";;
       *Zulu\ 11\ OpenJDK\ 64-bit) update_config_java "Zulu11-64" && java_install_or_update "Zulu11-64";;
       *Zulu\ 21\ OpenJDK\ 64-bit) update_config_java "Zulu21-64" && java_install_or_update "Zulu21-64";;
+      *BellSoft\ Liberica\ JDK\ 21) update_config_java "BellSoft21" && java_install_or_update "BellSoft21";;
       47\ *) jsscripting_npm_install "openhab";;
       *Uninstall\ openhab-js) jsscripting_npm_install "openhab" "uninstall";;
       48\ *) jsscripting_npm_install "openhab_rules_tools";;


### PR DESCRIPTION
Java 21 until now required a native 64 bit installation, as we did not have a provider for JDKs for 32-bit systems.
I found a provider for a JDK, which also runs on 32-bit systems.

This removes a big blocker for introducing Java 21 on more systems, as we can still support 32-bit hardware and the JDK can be installed on existing installations without much effort.

I have no experience with the BellSoft Liberica JDK until now. Maybe someone else knows these JDKs and can give some input.

On my test system (RPi 4, 32-bit) OH seems to start up fine.