### PR TITLE
Support zigbee network adapters

### DIFF
--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -317,6 +317,7 @@ zigbee2mqtt_setup() {
   if [[ -n $INTERACTIVE ]]; then
     if ! (whiptail --title "Zigbee2MQTT installation" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 14 80); then echo "CANCELED"; return 0; fi
     if [[ $my_adapters == "" ]] ; then
+      # No usb dongle found. ask user to specify network dongle ip
       if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
       by_path_or_id="tcp:/"
     else

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -311,19 +311,18 @@ zigbee2mqtt_setup() {
     done < <( ls /dev/serial/by-path )
   fi
 
-  if [[ $my_adapters == "" ]] ; then
-    if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
-    by_path_or_id="tcp:/"
-  else
-    if ! selectedAdapter=$(whiptail --noitem --title "Zigbee2MQTT installation" --radiolist "$adapterText" 14 100 4 $my_adapters 3>&1 1>&2 2>&3); then return 0; fi
-  fi
-
   unset IFS
   
   # ask for user input parameters
   if [[ -n $INTERACTIVE ]]; then
     if ! (whiptail --title "Zigbee2MQTT installation" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 14 80); then echo "CANCELED"; return 0; fi
-    # shellcheck disable=SC2086
+    if [[ $my_adapters == "" ]] ; then
+      if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
+      by_path_or_id="tcp:/"
+    else
+      # shellcheck disable=SC2086
+      if ! selectedAdapter=$(whiptail --noitem --title "Zigbee2MQTT installation" --radiolist "$adapterText" 14 100 4 $my_adapters 3>&1 1>&2 2>&3); then return 0; fi
+    fi
     if ! mqttUser=$(whiptail --title "MQTT User" --inputbox "$mqttUserText" 10 80 "$mqttDefaultUser" 3>&1 1>&2 2>&3); then return 0; fi
     if ! mqttPW=$(whiptail --title "MQTT password" --passwordbox "$mqttPWText" 10 80 3>&1 1>&2 2>&3); then return 0; fi
     if ! (whiptail --title "Zigbee2MQTT installation" --infobox "$installText" 14 80); then echo "CANCELED"; return 0; fi

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -235,7 +235,7 @@ zigbee2mqtt_setup() {
   local installText="Zigbee2MQTT is installed from the official repository.\\n\\nPlease wait about 4 minutes... "
   local uninstallText="Zigbee2MQTT is completely removed from the system."
   local adapterText="Please select your zigbee adapter:"
-  local adapterNetw="No USB dongle was found. If you use a network adapter please specify its ip:port."
+  local adapterNetw="\\nNo USB dongle was found. If you use a network adapter please specify its ip:port."
   local mqttUserText="\\nPlease enter your MQTT-User (default = openhabian):"
   local mqttPWText="\\nIf your MQTT-server requires a password, please enter it here:"
   local my_adapters

--- a/includes/zigbee2mqtt/configuration.yaml
+++ b/includes/zigbee2mqtt/configuration.yaml
@@ -8,7 +8,7 @@ mqtt:
   user: "%user%"
   password: "%password%"
 serial:
-  port: "/dev/serial/%adapter"
+  port: "%adapter"
 advanced:
   network_key: GENERATE
   pan_id: GENERATE 


### PR DESCRIPTION
Adds network coordinator support to zigbee2mqtt install

Test methodology:

1) Install Mosquitto
2) Plug zigbee usb dongle in usb2 port
3) Install Z2M: dongle is detected and user is prompted to confirm (no change to the existing action)
4) Verify `configuration.yaml` and connect to `openhabian:8081` to confirm that Z2M is running
5) Unplug zigbee usb dongle and uninstall Z2M
6) Install Z2M: no dongle is detected. User is prompted to specify ip:port address of the coordinator (or `cancel`)
7) Verify `configuration.yaml` and connect to `openhabian:8081` to confirm that Z2M is running

Signed-off-by: Hugo Castelo Branco <hugo.castelobranco@gmail.com> according to Developer's Certificate of Origin 1.1