### PR TITLE
[Z2M] Support zigbee network adapters

### DIFF
--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -122,7 +122,7 @@ show_main_menu() {
     "27 | knxd"                   "KNX specific, the KNX router/gateway daemon knxd" \
     "28 | 1wire"                  "1wire specific, owserver and related packages" \
     "29 | deCONZ"                 "deCONZ / Phoscon companion app for Conbee/Raspbee controller" \
-    "2A | Zigbee2MQTT"            "Install or Update Zigbee2MQTT" \
+    "2A | Zigbee2MQTT"            "Install or Update Zigbee2MQTT (usb or ethernet controller)" \
     "   | Remove Zigbee2MQTT"     "Remove Zigbee2MQTT from this system" \
     "2B | FIND 3"                 "Framework for Internal Navigation and Discovery" \
     "   | Monitor Mode"           "Patch firmware to enable monitor mode (ALPHA/DANGEROUS)" \

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -122,7 +122,7 @@ show_main_menu() {
     "27 | knxd"                   "KNX specific, the KNX router/gateway daemon knxd" \
     "28 | 1wire"                  "1wire specific, owserver and related packages" \
     "29 | deCONZ"                 "deCONZ / Phoscon companion app for Conbee/Raspbee controller" \
-    "2A | Zigbee2MQTT"            "Install or Update Zigbee2MQTT (usb or ethernet controller)" \
+    "2A | Zigbee2MQTT"            "Install or Update Zigbee2MQTT" \
     "   | Remove Zigbee2MQTT"     "Remove Zigbee2MQTT from this system" \
     "2B | FIND 3"                 "Framework for Internal Navigation and Discovery" \
     "   | Monitor Mode"           "Patch firmware to enable monitor mode (ALPHA/DANGEROUS)" \

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -317,6 +317,7 @@ zigbee2mqtt_setup() {
   if [[ -n $INTERACTIVE ]]; then
     if ! (whiptail --title "Zigbee2MQTT installation" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 14 80); then echo "CANCELED"; return 0; fi
     if [[ $my_adapters == "" ]] ; then
+      # No usb dongle found. ask user to specify network dongle ip
       if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
       by_path_or_id="tcp:/"
     else

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -235,7 +235,7 @@ zigbee2mqtt_setup() {
   local installText="Zigbee2MQTT is installed from the official repository.\\n\\nPlease wait about 4 minutes... "
   local uninstallText="Zigbee2MQTT is completely removed from the system."
   local adapterText="Please select your zigbee adapter:"
-  local adapterNetw="\\nNo USB dongle was found. If you use a network adapter please specify its ip:port."
+  local adapterNetw="\\nPlease specify the ip:port of the zigbee coordinator."
   local mqttUserText="\\nPlease enter your MQTT-User (default = openhabian):"
   local mqttPWText="\\nIf your MQTT-server requires a password, please enter it here:"
   local my_adapters
@@ -316,12 +316,17 @@ zigbee2mqtt_setup() {
   # ask for user input parameters
   if [[ -n $INTERACTIVE ]]; then
     if ! (whiptail --title "Zigbee2MQTT installation" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 14 80); then echo "CANCELED"; return 0; fi
-    if [[ $my_adapters == "" ]] ; then
-      # No usb dongle found. ask user to specify network dongle ip
+    # shellcheck disable=SC2086
+    if ! zigmode=$(whiptail --title "Zigbee2MQTT installation" --menu "Choose mode:" 14 100 2 --cancel-button "Cancel" --ok-button "Continue" \
+    "usb"  "The zigbee coordinator is directly connected to this computer." \
+    "network"  "The zigbee coordinator is connected to the LAN and has an IP address." \
+    3>&1 1>&2 2>&3); then echo "CANCELED"; return 0; fi
+    # shellcheck disable=SC2086
+
+    if [[ $zigmode == "network" ]] ; then
       if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
       by_path_or_id="tcp:/"
     else
-      # shellcheck disable=SC2086
       if ! selectedAdapter=$(whiptail --noitem --title "Zigbee2MQTT installation" --radiolist "$adapterText" 14 100 4 $my_adapters 3>&1 1>&2 2>&3); then return 0; fi
     fi
     if ! mqttUser=$(whiptail --title "MQTT User" --inputbox "$mqttUserText" 10 80 "$mqttDefaultUser" 3>&1 1>&2 2>&3); then return 0; fi

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -356,7 +356,7 @@ zigbee2mqtt_setup() {
   if ! cond_redirect sudo -u "${username:-openhabian}" npm ci ; then echo "FAILED (npm ci)"; return 1; fi
 
   if ! cond_redirect install -o "${username:-openhabian}" -g openhab -m 644 "${BASEDIR:-/opt/openhabian}/includes/zigbee2mqtt/configuration.yaml" /opt/zigbee2mqtt/data/; then echo "FAILED (install configuration.yaml)"; return 1; fi
-  sed -i -e "s|%adapter|$by_path_or_id/$selectedAdapter|g" /opt/zigbee2mqtt/data/configuration.yaml
+  sed -i -e "s|%adapter%|$by_path_or_id/$selectedAdapter|g" /opt/zigbee2mqtt/data/configuration.yaml
   sed -i -e "s|%user%|$mqttUser|g" /opt/zigbee2mqtt/data/configuration.yaml
   sed -i -e "s|%password%|$mqttPW|g" /opt/zigbee2mqtt/data/configuration.yaml 
   

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -233,7 +233,7 @@ zigbee2mqtt_setup() {
   local z2mInstalledText="A configuration for Zigbee2MQTT is already existing.\\n\\nWould you like to update Zigbee2MQTT to the latest version with this configuration?"
   local introText="A MQTT-server is required for Zigbee2mqtt. If you haven't installed one yet, please select <cancel> and come back after installing one (e.g. Mosquitto).\\n\\nZigbee2MQTT will be installed from the official repository.\\n\\nDuration is about 4 minutes... "
   local installText="Zigbee2MQTT is installed from the official repository.\\n\\nPlease wait about 4 minutes... "
-  local uninstallText="Zigbee2MQTT is completely removed from the system."
+  local uninstallText="Zigbee2MQTT will be completely removed from the system."
   local adapterText="Please select your zigbee adapter:"
   local adapterNetw="\\nPlease specify the ip:port of the zigbee coordinator."
   local mqttUserText="\\nPlease enter your MQTT-User (default = openhabian):"

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -311,19 +311,18 @@ zigbee2mqtt_setup() {
     done < <( ls /dev/serial/by-path )
   fi
 
-  if [[ $my_adapters == "" ]] ; then
-    if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
-    by_path_or_id="tcp:/"
-  else
-    if ! selectedAdapter=$(whiptail --noitem --title "Zigbee2MQTT installation" --radiolist "$adapterText" 14 100 4 $my_adapters 3>&1 1>&2 2>&3); then return 0; fi
-  fi
-
   unset IFS
   
   # ask for user input parameters
   if [[ -n $INTERACTIVE ]]; then
     if ! (whiptail --title "Zigbee2MQTT installation" --yes-button "Continue" --no-button "Cancel" --yesno "$introText" 14 80); then echo "CANCELED"; return 0; fi
-    # shellcheck disable=SC2086
+    if [[ $my_adapters == "" ]] ; then
+      if ! selectedAdapter=$(whiptail --title "Zigbee Network Coordinator" --inputbox "$adapterNetw" 10 80 "xxx.xxx.xxx.xxx:port" 3>&1 1>&2 2>&3); then return 0; fi
+      by_path_or_id="tcp:/"
+    else
+      # shellcheck disable=SC2086
+      if ! selectedAdapter=$(whiptail --noitem --title "Zigbee2MQTT installation" --radiolist "$adapterText" 14 100 4 $my_adapters 3>&1 1>&2 2>&3); then return 0; fi
+    fi
     if ! mqttUser=$(whiptail --title "MQTT User" --inputbox "$mqttUserText" 10 80 "$mqttDefaultUser" 3>&1 1>&2 2>&3); then return 0; fi
     if ! mqttPW=$(whiptail --title "MQTT password" --passwordbox "$mqttPWText" 10 80 3>&1 1>&2 2>&3); then return 0; fi
     if ! (whiptail --title "Zigbee2MQTT installation" --infobox "$installText" 14 80); then echo "CANCELED"; return 0; fi

--- a/functions/nodejs-apps.bash
+++ b/functions/nodejs-apps.bash
@@ -235,7 +235,7 @@ zigbee2mqtt_setup() {
   local installText="Zigbee2MQTT is installed from the official repository.\\n\\nPlease wait about 4 minutes... "
   local uninstallText="Zigbee2MQTT is completely removed from the system."
   local adapterText="Please select your zigbee adapter:"
-  local adapterNetw="No USB dongle was found. If you use a network adapter please specify its ip:port."
+  local adapterNetw="\\nNo USB dongle was found. If you use a network adapter please specify its ip:port."
   local mqttUserText="\\nPlease enter your MQTT-User (default = openhabian):"
   local mqttPWText="\\nIf your MQTT-server requires a password, please enter it here:"
   local my_adapters

--- a/includes/zigbee2mqtt/configuration.yaml
+++ b/includes/zigbee2mqtt/configuration.yaml
@@ -8,7 +8,7 @@ mqtt:
   user: "%user%"
   password: "%password%"
 serial:
-  port: "%adapter"
+  port: "%adapter%"
 advanced:
   network_key: GENERATE
   pan_id: GENERATE 

--- a/includes/zigbee2mqtt/configuration.yaml
+++ b/includes/zigbee2mqtt/configuration.yaml
@@ -8,7 +8,7 @@ mqtt:
   user: "%user%"
   password: "%password%"
 serial:
-  port: "/dev/serial/%adapter"
+  port: "%adapter"
 advanced:
   network_key: GENERATE
   pan_id: GENERATE 


### PR DESCRIPTION
Adds network coordinator support to zigbee2mqtt install. Fixes https://github.com/openhab/openhabian/issues/1868

Test methodology:

1) Install Mosquitto
2) Plug zigbee usb dongle in usb2 port
3) Install Z2M: user is prompted to choose either usb or network installation. Choose usb
4) Verify configuration.yaml and connect to openhabian:8081 to confirm that Z2M is running
5) Uninstall Z2M
6) Install Z2M: user is prompted to choose either usb or network installation. Choose network
7) Verify configuration.yaml and connect to openhabian:8081 to confirm that Z2M is running

Signed-off-by: Hugo Castelo Branco [hugo.castelobranco@gmail.com](mailto:hugo.castelobranco@gmail.com) according to Developer's Certificate of Origin 1.1