### PR TITLE
Fix switching between different OH releases

### DIFF
--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -82,7 +82,7 @@ show_main_menu() {
       fi
     fi
     repo=$(apt-cache madison openhab | head -n 1 | awk '{ print $6 }' |cut -d'/' -f1)
-    openhab_setup "openHAB" "${repo:-release}"
+    openhab_setup "${repo:-release}"
 
   elif [[ "$choice" == "04"* ]]; then
     import_openhab_config
@@ -231,9 +231,9 @@ show_main_menu() {
     version="$( (openhab4_is_installed && echo "openHAB") || (openhab3_is_installed && echo "openHAB3"))"
     # shellcheck disable=SC2154
     case "$choice2" in
-      41\ *) openhab_setup "$version" "release";;
-      *openHAB\ Milestone) openhab_setup "$version" "milestone";;
-      *openHAB\ Snapshot) openhab_setup "$version" "snapshot";;
+      41\ *) openhab_setup "release";;
+      *openHAB\ Milestone) openhab_setup "milestone";;
+      *openHAB\ Snapshot) openhab_setup "snapshot";;
       42\ *) openhab_shell_interfaces;;
       43\ *) openhab_clean_cache;;
       44\ *) nginx_setup;;

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -42,7 +42,7 @@ delayed_rules() {
 ## Function to install / upgrade / downgrade the installed openHAB version
 ## Valid argument 1: "release", "milestone" or "testing", or "snapshot" or "unstable"
 ##
-##    openhab_setup(String version, String release, String packageversion)
+##    openhab_setup(String release)
 ##
 openhab_setup() {
   local introText


### PR DESCRIPTION
Remove additional argument to openhab_setup which was missed in #1926.

It seems that since #1926 was applied, the OH release could no longer be changed.
When I tried to install snapshot today, I got an empty dialogue box, after hitting "ok" also empty package sources file, and still the old OH version installed.

Hope this PR catches all remaining locations.