### PR TITLE
Adding esphome dashboard install and uninstall feature

### DIFF
--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -160,7 +160,7 @@ show_main_menu() {
       *Remove\ EVCC*) install_evcc "remove";;
       *Setup\ EVCC*) setup_evcc;;
       2E\ *) install_esphomedashboard "install";;
-      *Remove\ ESPHome dashboard*) install_esphomedashboard "remove";;
+      *Remove\ ESPHome\ dashboard*) install_esphomedashboard "remove";;
       "") return 0 ;;
       *) whiptail --msgbox "An unsupported option was selected (probably a programming error):\\n  \"$choice2\"" 8 80 ;;
     esac

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -132,6 +132,9 @@ show_main_menu() {
     "2D | Install EVCC"           "Deploy Electric Vehicle Charge Controller" \
     "   | Remove EVCC"            "Uninstall EVCC" \
     "   | Setup EVCC"             "Setup EVCC from command line (German only)" \
+    "2E | Install ESPHome dashboard"           "Deploy ESPHome dashboard" \
+    "   | Remove ESPHome dashboard"            "Uninstall ESPHome dashboard" \
+
     3>&1 1>&2 2>&3)
     RET=$?
     if [ $RET -eq 1 ] || [ $RET -eq 255 ]; then return 0; fi
@@ -157,6 +160,9 @@ show_main_menu() {
       2D\ *) install_evcc "install";;
       *Remove\ EVCC*) install_evcc "remove";;
       *Setup\ EVCC*) setup_evcc;;
+      2E\ *) install_esphomedashboard "install";;
+      *Remove\ ESPHome dashboard*) install_esphomedashboard "remove";;
+      *Setup\ ESPHome dashboard*) setup_evcc;;
       "") return 0 ;;
       *) whiptail --msgbox "An unsupported option was selected (probably a programming error):\\n  \"$choice2\"" 8 80 ;;
     esac

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -134,7 +134,6 @@ show_main_menu() {
     "   | Setup EVCC"             "Setup EVCC from command line (German only)" \
     "2E | Install ESPHome dashboard"           "Deploy ESPHome dashboard" \
     "   | Remove ESPHome dashboard"            "Uninstall ESPHome dashboard" \
-
     3>&1 1>&2 2>&3)
     RET=$?
     if [ $RET -eq 1 ] || [ $RET -eq 255 ]; then return 0; fi
@@ -162,7 +161,6 @@ show_main_menu() {
       *Setup\ EVCC*) setup_evcc;;
       2E\ *) install_esphomedashboard "install";;
       *Remove\ ESPHome dashboard*) install_esphomedashboard "remove";;
-      *Setup\ ESPHome dashboard*) setup_evcc;;
       "") return 0 ;;
       *) whiptail --msgbox "An unsupported option was selected (probably a programming error):\\n  \"$choice2\"" 8 80 ;;
     esac

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -803,7 +803,7 @@ setup_evcc() {
 ## The function must be invoked UNATTENDED.
 ## Valid arguments: "install" or "remove"
 ##
-##   install_esphomedashboard(String action)
+##  install_esphomedashboard(String action)
 ##
 ##
 install_esphomedashboard() {

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -901,7 +901,7 @@ install_esphomedashboard() {
     # Set up a virtual environment and install ESPHome
     echo "$(timestamp) [openHABian] Setting up a virtual environment in $ESPHOME_DIR..."
     cd "$ESPHOME_DIR" || return
-    if ! sudo -u "$USER" python3 -m venv venv; then
+    if ! sudo -u "$USER" python3 -m venv "$ESPHOME_DIR/venv"; then
       echo "$(timestamp) [openHABian] Error: Failed to create a Python virtual environment."
       return
     fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -812,7 +812,7 @@ install_esphomedashboard() {
   local removeText="This will remove ESPhome dashboard"
 
   ESPHOME_DIR="/opt/esphomedashboard"
-  SERVICE_TEMPLATE="../includes/esphome-dashboard.service.template" # Update with the actual path
+  SERVICE_TEMPLATE="${BASEDIR:-/opt/openhabian}/includes/esphome-dashboard.service.template" # Update with the actual path
 
   if [[ $1 == "remove" ]]; then
     if [[ -n $INTERACTIVE ]]; then
@@ -821,29 +821,26 @@ install_esphomedashboard() {
     echo "$(timestamp) [openHABian] Starting ESPHome Dashboard uninstallation..."
 
     # Stop the ESPHome Dashboard service
-    echo "$(timestamp) [openHABian] Stopping the ESPHome Dashboard service..."
-    if ! systemctl stop esphome-dashboard.service; then
-      echo "$(timestamp) [openHABian] Error: Failed to stop ESPHome Dashboard service."
-      return
-    fi
+    echo -n "$(timestamp) [openHABian] Stopping the ESPHome Dashboard service... "
+    if ! cond_redirect systemctl stop esphome-dashboard.service; then echo "FAILED (stop service)"; return 1; fi
 
     # Disable the ESPHome Dashboard service
     echo "$(timestamp) [openHABian] Disabling the ESPHome Dashboard service..."
-    if ! systemctl disable esphome-dashboard.service; then
+    if ! cond_redirect systemctl disable esphome-dashboard.service; then
       echo "$(timestamp) [openHABian] Error: Failed to disable ESPHome Dashboard service."
       return
     fi
 
     # Remove the ESPHome Dashboard service file
     echo "$(timestamp) [openHABian] Removing the ESPHome Dashboard systemd service file..."
-    if ! rm -f /etc/systemd/system/esphome-dashboard.service; then
+    if ! cond_redirect rm -f /etc/systemd/system/esphome-dashboard.service; then
       echo "$(timestamp) [openHABian] Error: Failed to remove systemd service file."
       return
     fi
 
     # Reload systemd daemon
     echo "$(timestamp) [openHABian] Reloading systemd daemon..."
-    if ! systemctl daemon-reload; then
+    if ! cond_redirect systemctl daemon-reload; then
       echo "$(timestamp) [openHABian] Error: Failed to reload systemd daemon."
       return
     fi
@@ -865,15 +862,10 @@ install_esphomedashboard() {
     fi
     echo "$(timestamp) [openHABian] Starting ESPHome Dashboard setup..."
 
-    # Ensure the script is run with sudo
-    if [ "$EUID" -ne 0 ]; then 
-      echo "$(timestamp) [openHABian] Please run this script as root or with sudo."
-      return
-    fi
 
     # Install Python 3 and pip
     echo "$(timestamp) [openHABian] Installing Python 3 and pip..."
-    if ! apt install -y python3-venv; then
+    if ! cond_redirect apt install -y python3-venv; then
       echo "$(timestamp) [openHABian] Error: Failed to install Python 3 and pip."
       return
     fi
@@ -893,7 +885,6 @@ install_esphomedashboard() {
 
     # Set up a virtual environment and install ESPHome
     echo "$(timestamp) [openHABian] Setting up a virtual environment in $ESPHOME_DIR..."
-    cd "$ESPHOME_DIR" || return
     if ! sudo -u "$USER" python3 -m venv "$ESPHOME_DIR/venv"; then
       echo "$(timestamp) [openHABian] Error: Failed to create a Python virtual environment."
       return
@@ -906,22 +897,22 @@ install_esphomedashboard() {
     fi
 
     # Copy the systemd service file
-    echo "$(timestamp) [openHABian] Copying systemd service file..."
-    if ! cp "$SERVICE_TEMPLATE" /etc/systemd/system/esphome-dashboard.service; then
-      echo "$(timestamp) [openHABian] Error: Failed to copy systemd service file."
-      return
+    echo "$(timestamp) [openHABian] Installing systemd service file..."
+    if ! cond_redirect install -m 755 "$SERVICE_TEMPLATE" /etc/systemd/system/esphome-dashboard.service; then
+        echo "$(timestamp) [openHABian] Error: Failed to install systemd service file."
+        return
     fi
 
     # Reload systemd and enable/start the service
     echo "$(timestamp) [openHABian] Reloading systemd daemon and starting the ESPHome Dashboard service..."
-    if ! systemctl daemon-reload; then
+    if ! cond_redirect systemctl daemon-reload; then
       echo "$(timestamp) [openHABian] Error: Failed to reload systemd daemon."
       return
     fi
 
     # Enable and start the ESPHome Dashboard service
     echo "$(timestamp) [openHABian] Enabling and starting the ESPHome Dashboard service..."
-    if ! systemctl enable --now esphome-dashboard.service; then
+    if ! cond_redirect systemctl enable --now esphome-dashboard.service; then
       echo "$(timestamp) [openHABian] Error: Failed to enable and start ESPHome Dashboard service."
       return
     fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -866,7 +866,7 @@ install_esphomedashboard() {
     echo "$(timestamp) [openHABian] Starting ESPHome Dashboard setup..."
 
     # Ensure the script is run with sudo
-    if [ "$EUID" -ne 0 ]; then
+    if [ "$EUID" -ne 0 ]; then 
       echo "$(timestamp) [openHABian] Please run this script as root or with sudo."
       return
     fi
@@ -926,13 +926,10 @@ install_esphomedashboard() {
       return
     fi
 
-    if ! systemctl enable esphome-dashboard.service; then
-      echo "$(timestamp) [openHABian] Error: Failed to enable ESPHome Dashboard service."
-      return
-    fi
-
-    if ! systemctl start esphome-dashboard.service; then
-      echo "$(timestamp) [openHABian] Error: Failed to start ESPHome Dashboard service."
+    # Enable and start the ESPHome Dashboard service
+    echo "$(timestamp) [openHABian] Enabling and starting the ESPHome Dashboard service..."
+    if ! systemctl enable --now esphome-dashboard.service; then
+      echo "$(timestamp) [openHABian] Error: Failed to enable and start ESPHome Dashboard service."
       return
     fi
 

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -798,3 +798,160 @@ setup_evcc() {
   echo -n "$(timestamp) [openHABian] Created EVCC config, restarting ... "
   if cond_redirect systemctl restart evcc.service; then echo "OK"; else echo "FAILED"; fi
 }
+
+## Function for (un)installing ESPhome dashboard
+## The function must be invoked UNATTENDED.
+## Valid arguments: "install" or "remove"
+##
+##   install_esphomedashboard(String action)
+##
+##
+install_esphomedashboard() {
+  local port=6052
+  local installText="This will install ESPhome dashboard\\nUse the web interface on port $port to access ESPhome dashboard web interface."
+  local removeText="This will remove ESPhome dashboard"
+  
+  if [[ $1 == "remove" ]]; then
+    if [[ -n $INTERACTIVE ]]; then
+      whiptail --title "ESPhome dashboard removal" --msgbox "$removeText" 7 80
+    fi
+    echo -n "$(timestamp) [openHABian] Starting ESPHome Dashboard uninstallation..."
+
+    # Function to check the success of the last executed command
+    check_success() {
+        if [ $? -ne 0 ]; then
+            echo -n "$(timestamp) [openHABian] Error: $1"
+            exit 1
+        fi
+    }
+
+    # Ensure the script is run with sudo
+    if [ "$EUID" -ne 0 ]; then
+        echo -n "$(timestamp) [openHABian] Please run this script as root or with sudo."
+        exit 1
+    fi
+
+    # Stop the ESPHome Dashboard service
+    echo -n "$(timestamp) [openHABian] Stopping the ESPHome Dashboard service..."
+    systemctl stop esphome-dashboard.service
+    check_success "Failed to stop ESPHome Dashboard service."
+
+    # Disable the ESPHome Dashboard service
+    echo -n "$(timestamp) [openHABian] Disabling the ESPHome Dashboard service..."
+    systemctl disable esphome-dashboard.service
+    check_success "Failed to disable ESPHome Dashboard service."
+
+    # Remove the ESPHome Dashboard service file
+    echo -n "$(timestamp) [openHABian] Removing the ESPHome Dashboard systemd service file..."
+    rm -f /etc/systemd/system/esphome-dashboard.service
+    check_success "Failed to remove systemd service file."
+
+    # Reload systemd daemon
+    echo -n "$(timestamp) [openHABian] Reloading systemd daemon..."
+    systemctl daemon-reload
+    check_success "Failed to reload systemd daemon."
+
+    # Remove the ESPHome installation directory
+    ESPHOME_DIR="/opt/esphomedashboard"
+    echo -n "$(timestamp) [openHABian] Removing ESPHome directory at $ESPHOME_DIR..."
+    rm -rf "$ESPHOME_DIR"
+    check_success "Failed to remove $ESPHOME_DIR."
+
+    # Final cleanup 
+    echo -n "$(timestamp) [openHABian] Uninstallation complete!"
+    echo -n "$(timestamp) [openHABian] ESPHome Dashboard has been completely removed from the system."
+    return;
+  fi
+
+  if [[ $1 != "install" ]]; then 
+    if [[ -n $INTERACTIVE ]]; then
+      whiptail --title "ESPhome dashboard installation" --msgbox "$installText" 8 80
+    fi
+    echo -n "$(timestamp) [openHABian] Starting ESPHome Dashboard setup..."
+
+    # Function to check the success of the last executed command
+    check_success() {
+        if [ $? -ne 0 ]; then
+            echo -n "$(timestamp) [openHABian] Error: $1"
+            exit 1
+        fi
+    }
+
+    # Ensure the script is run with sudo
+    if [ "$EUID" -ne 0 ]; then
+        echo -n "$(timestamp) [openHABian] Please run this script as root or with sudo."
+        exit 1
+    fi
+
+    # Update system packages
+    echo -n "$(timestamp) [openHABian] Updating system packages..."
+    apt update && apt upgrade -y
+    check_success "Failed to update system packages."
+
+    # Install Python 3 and pip
+    echo -n "$(timestamp) [openHABian] Installing Python 3 and pip..."
+    apt install -y python3 python3-pip python3-venv
+    check_success "Failed to install Python 3 and pip."
+
+    # Create the /opt/esphomedashboard directory and set permissions
+    ESPHOME_DIR="/opt/esphomedashboard"
+    echo -n "$(timestamp) [openHABian] Creating directory at $ESPHOME_DIR..."
+    mkdir -p "$ESPHOME_DIR/config"
+    check_success "Failed to create $ESPHOME_DIR and its config directory."
+   
+    # Set ownership to the current non-root user
+    USER=$(logname)
+    chown -R "$USER:$USER" "$ESPHOME_DIR"
+    check_success "Failed to set ownership of $ESPHOME_DIR to $USER."
+
+    # Switch to the ESPHome directory and set up a virtual environment
+    echo -n "$(timestamp) [openHABian] Setting up a virtual environment in $ESPHOME_DIR..."
+    cd "$ESPHOME_DIR" || exit
+    sudo -u "$USER" python3 -m venv venv
+    check_success "Failed to create a Python virtual environment."
+
+    # Activate the virtual environment and install ESPHome
+    echo -n "$(timestamp) [openHABian] Activating the virtual environment and installing ESPHome..."
+    sudo -u "$USER" bash -c "source venv/bin/activate && pip install esphome"
+    check_success "Failed to install ESPHome."
+    
+    # Create the ESPHome Dashboard systemd service
+    echo -n "$(timestamp) [openHABian] Creating a systemd service for ESPHome Dashboard..."
+    cat > /etc/systemd/system/esphome-dashboard.service <<EOF
+    [Unit]
+    Description=ESPHome Dashboard
+    After=network.target
+
+    [Service]
+    WorkingDirectory=$ESPHOME_DIR
+    ExecStart=$ESPHOME_DIR/venv/bin/esphome dashboard $ESPHOME_DIR/config --port 6052
+    Restart=always
+    User=$USER
+
+    [Install]
+    WantedBy=multi-user.target
+EOF
+    check_success "Failed to create the ESPHome Dashboard systemd service file."
+
+    # Reload systemd and enable the service
+    echo -n "$(timestamp) [openHABian] Reloading systemd daemon and enabling the ESPHome Dashboard service..."
+    systemctl daemon-reload
+    check_success "Failed to reload systemd daemon."
+
+    systemctl enable esphome-dashboard.service
+    check_success "Failed to enable ESPHome Dashboard service."
+ 
+    # Start the ESPHome Dashboard service
+    echo -n "$(timestamp) [openHABian] Starting the ESPHome Dashboard service..."
+    systemctl start esphome-dashboard.service
+    check_success "Failed to start ESPHome Dashboard service."
+
+    # Final message
+    echo -n "$(timestamp) [openHABian] ESPHome Dashboard setup complete!"
+    echo -n "$(timestamp) [openHABian] Access your ESPHome Dashboard at http://<your-ip>:6052"
+    return ;
+  fi
+ 
+}
+
+

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -871,16 +871,9 @@ install_esphomedashboard() {
       return
     fi
 
-    # Update system packages
-    echo "$(timestamp) [openHABian] Updating system packages..."
-    if ! apt update && apt upgrade -y; then
-      echo "$(timestamp) [openHABian] Error: Failed to update system packages."
-      return
-    fi
-
     # Install Python 3 and pip
     echo "$(timestamp) [openHABian] Installing Python 3 and pip..."
-    if ! apt install -y python3 python3-pip python3-venv; then
+    if ! apt install -y python3-venv; then
       echo "$(timestamp) [openHABian] Error: Failed to install Python 3 and pip."
       return
     fi

--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -859,7 +859,7 @@ install_esphomedashboard() {
     return
   fi
 
-  if [[ $1 != "install" ]]; then 
+  if [[ $1 == "install" ]]; then 
     if [[ -n $INTERACTIVE ]]; then
       whiptail --title "ESPhome dashboard installation" --msgbox "$installText" 8 80
     fi

--- a/includes/esphome-dashboard.service.template
+++ b/includes/esphome-dashboard.service.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=ESPHome Dashboard
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/esphomedashboard
+ExecStart=/opt/esphomedashboard/venv/bin/esphome dashboard /opt/esphomedashboard/config --port 6052
+Restart=always
+User=<replace-with-username> # Dynamically replaced in script
+Environment="PATH=/opt/esphomedashboard/venv/bin"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### **Description:**
This pull request adds the ESPHome dashboard installation and uninstallation feature to the OpenHABian setup. The feature allows users to easily install or uninstall the ESPHome dashboard as part of the OpenHABian configuration process.

### **Changes:**
Added a new option to the OpenHABian configuration menu to install the ESPHome dashboard.
Implemented the ability to uninstall the ESPHome dashboard from the system.
Updated related documentation for the new feature.
Why this is needed:
This update provides users with a streamlined way to manage the ESPHome dashboard directly from the OpenHABian setup, improving the ease of use and flexibility for those integrating ESPHome with OpenHAB.

### **Closes Issue:**
Resolves [#1904](https://github.com/openhab/openhabian/issues/1904).