### PR TITLE
fix installing optionally given oh pkg version

### DIFF
--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -82,7 +82,7 @@ show_main_menu() {
       fi
     fi
     repo=$(apt-cache madison openhab | head -n 1 | awk '{ print $6 }' |cut -d'/' -f1)
-    openhab_setup "${repo:-release}"
+    openhab_setup "${repo:-release}" "${openhabpkgversion}"
 
   elif [[ "$choice" == "04"* ]]; then
     import_openhab_config

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -41,6 +41,7 @@ delayed_rules() {
 
 ## Function to install / upgrade / downgrade the installed openHAB version
 ## Valid argument 1: "release", "milestone" or "testing", or "snapshot" or "unstable"
+## Valid argument 2 (optional): Linux package name to install
 ##
 ##    openhab_setup(String release)
 ##
@@ -94,7 +95,7 @@ openhab_setup() {
     echo -n "$(timestamp) [openHABian] Installing openHAB... "
     if ! apt-get clean --yes -o DPkg::Lock::Timeout="$APTTIMEOUT"; then echo "FAILED (apt cache clean)"; return 1; fi
     cond_redirect apt-get update -o DPkg::Lock::Timeout="$APTTIMEOUT"
-    openhabVersion="${3:-$(apt-cache madison ${ohPkgName} | head -n 1 | cut -d'|' -f2 | xargs)}"
+    openhabVersion="${2:-$(apt-cache madison ${ohPkgName} | head -n 1 | cut -d'|' -f2 | xargs)}"
     if [[ -n $openhabVersion ]]; then
       installVersion="${ohPkgName}=${openhabVersion} ${ohPkgName}-addons=${openhabVersion}"
     else

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -108,7 +108,7 @@ if [[ -n "$UNATTENDED" ]]; then
   add_admin_ssh_key
   firemotd_setup
   java_install "${java_opt:-17}"
-  openhab_setup "release"
+  openhab_setup "release" "${openhabpkgversion}"
   import_openhab_config
   openhab_shell_interfaces && setup_tailscale
   vim_openhab_syntax


### PR DESCRIPTION
option to openhab_setup() wasn't documented but implemented and makes sense to have when we need to go back to an older pkg version for some reason