### PR TITLE
Fix comitup repo download

### DIFF
--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -118,7 +118,10 @@ configure_wifi() {
 ##    setup_hotspot(String option)
 ##
 setup_hotspot() {
-  local debfile="davesteele-comitup-apt-source_latest.deb"
+  local debfileurl="https://davesteele.github.io/comitup/latest"
+  local debfile="davesteele-comitup-apt-source"
+  local debfilelatest="latest.deb"
+  local debfilestatic="1.2_all.deb"
 
 
   if [[ $1 == "install" ]]; then
@@ -127,8 +130,8 @@ setup_hotspot() {
     DEBIAN_FRONTEND=noninteractive apt install --yes network-manager &> /dev/null
     systemctl enable --now NetworkManager
 
-    if cond_redirect wget -nv "https://davesteele.github.io/comitup/latest/$debfile"; then
-      cond_redirect dpkg -i --force-all "$debfile"
+    if cond_redirect wget -nv "${debfileurl}/${debfile}_${debfilelatest}" || wget -nv "${debfileurl}/${debfile}_${debfilestatic}"; then
+      cond_redirect dpkg -i --force-all "${debfile}*.deb"
       cond_redirect apt-get --quiet update
     fi
     rm -f "$debfile"


### PR DESCRIPTION
Installing comitup from its repo relied on some link to the "latest" .deb pkg link that now no longer seems to exist
Added fetching a known working backup in case

Fixes: #1961 