### PR TITLE
fix? timezone not being overwritten on openhab pkg updates

### DIFF
--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -225,7 +225,7 @@ openhab_misc() {
   if cond_redirect sed -i -e 's|^#*.*OPENHAB_HTTPS_PORT=.*$|OPENHAB_HTTPS_PORT=8443|g' /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting openHAB timezone... "
-  if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*interning=true)|\1 -Duser.timezone=${timezone:-Europe/London}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*)|\1 -Duser.timezone=${timezone:-Europe/London}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 
 ## Create a openHAB dashboard title and image for the input application.

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -225,7 +225,7 @@ openhab_misc() {
   if cond_redirect sed -i -e 's|^#*.*OPENHAB_HTTPS_PORT=.*$|OPENHAB_HTTPS_PORT=8443|g' /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting openHAB timezone... "
-  if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*)|\1 -Duser.timezone=${timezone:-Europe/London}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
+  if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*?)(interning=true)?|\1\2 -Duser.timezone=${timezone:-Europe/London}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 
 ## Create a openHAB dashboard title and image for the input application.


### PR DESCRIPTION
Hi Ethan,
unsure how to fix this properly.

Existing code is called from within openhab_setup() and assumes the `EXTRA_JAVA_OPTS` line in `/etc/default/openhab` to end with "...interning=true" which it currently only does on fresh installs.
Not on older installations, and not sure how it looks like on non-RPi.

I now removed the ending from the pattern so it now should be replacing `EXTRA_JAVA_OPTS` at any time it calls the routine.

I'm unsure however what the Linux package does to the file. The original open issue was about upgrading openhab pkg on some oldish openHABian box (that was probably installed before and did not have that `interning=true` ending so replacement didn't apply).

PS: do you know how to restrict visibility of GitHub issues or PRs to maintainers (i.e. ourselves) only? According to Google seems we cannot, but I'd like to have a private comms channels
I really disenjoy users to follow every single step of ours and sometimes even tap into discussions, and to be frank, I'm already a little p*ssed off by the tone how it was raised as an issue and keeps being commented on the forum.