### PR TITLE
Remove code specific to unmaintained OS versions

### DIFF
--- a/functions/find.bash
+++ b/functions/find.bash
@@ -142,29 +142,7 @@ go_setup() {
 
   echo -n "$(timestamp) [openHABian] Installing the Go programming language... "
 
-  if is_ubuntu; then
-    if is_bionic; then
-      if ! cond_redirect add-apt-repository ppa:longsleep/golang-backports; then echo "FAILED (add apt repository)"; return 1; fi
-      if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-    fi
-    if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" golang-go; then echo "OK"; else echo "FAILED"; return 1; fi
-  else
-    if is_buster; then
-      echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/golang.list
-      if ! cond_redirect wget -nv -O debian-keyring.deb http://ftp.us.debian.org/debian/pool/main/d/debian-keyring/debian-keyring_2019.02.25_all.deb; then echo "FAILED (get keyring)"; return 1; fi
-      if ! cond_redirect wget -nv -O debian-archive-keyring.deb http://ftp.us.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2019.1+deb10u1_all.deb; then echo "FAILED (get archive keyring)"; return 1; fi
-      if ! cond_redirect dpkg -i debian-keyring.deb; then echo "FAILED (add keyring)"; return 1; fi
-      if ! cond_redirect dpkg -i debian-archive-keyring.deb; then echo "FAILED (add archive keyring)"; return 1; fi
-      rm -f debian-keyring.deb debian-archive-keyring.deb
-
-      echo -e "Package: *\\nPin: release a=buster-backports\\nPin-Priority: 90\\n" > /etc/apt/preferences.d/limit-buster-backports
-
-      if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-      if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" --target-release "buster-backports" golang-go; then echo "OK"; else echo "FAILED"; return 1; fi
-    else
-      if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" golang-go; then echo "OK"; else echo "FAILED"; return 1; fi
-    fi
-  fi
+  if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" golang-go; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 
 ## Function to enable monitor mode on RPi

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -333,7 +333,7 @@ is_raspios() {
 }
 # Represents the current OS versions we officially support
 is_supported() {
-  if is_bullseye || is_bookworm || is_sid || is_jellyfish || is_noble; then return 0; fi
+  if is_bullseye || is_bookworm || is_jellyfish || is_noble; then return 0; fi
   return 1;
 }
 # Debian/Raspbian oldstable

--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -331,17 +331,10 @@ is_raspios() {
   [[ "$(cat /boot/issue.txt)" =~ "Raspberry Pi reference" ]]
   return $?
 }
-# Debian/Raspbian oldoldoldstable
-is_stretch() {
-  if [[ "$osrelease" == "stretch" ]]; then return 0; fi
-  [[ $(cat /etc/*release*) =~ "stretch" ]]
-  return $?
-}
-# Debian/Raspbian oldoldstable
-is_buster() {
-  if [[ "$osrelease" == "buster" ]]; then return 0; fi
-  [[ $(cat /etc/*release*) =~ "buster" ]]
-  return $?
+# Represents the current OS versions we officially support
+is_supported() {
+  if is_bullseye || is_bookworm || is_sid || is_jellyfish || is_noble; then return 0; fi
+  return 1;
 }
 # Debian/Raspbian oldstable
 is_bullseye() {
@@ -361,28 +354,16 @@ is_sid() {
   [[ $(cat /etc/*release*) =~ "sid" ]]
   return $?
 }
-# Ubuntu 16, deprecated
-is_xenial() {
-  if [[ "$osrelease" == "xenial" ]]; then return 0; fi
-  [[ $(cat /etc/*release*) =~ "xenial" ]]
-  return $?
-}
-# Ubuntu 18.04 LTS
-is_bionic() {
-  if [[ "$osrelease" == "bionic" ]]; then return 0; fi
-  [[ $(cat /etc/*release*) =~ "bionic" ]]
-  return $?
-}
-# Ubuntu 20.04 LTS
-is_focal() {
-  if [[ "$osrelease" == "focal" ]]; then return 0; fi
-  [[ $(cat /etc/*release*) =~ "focal" ]]
-  return $?
-}
 # Ubuntu 22.04 LTS
 is_jellyfish() {
   if [[ "$osrelease" == "jellyfish" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "jellyfish" ]]
+  return $?
+}
+# Ubuntu 24.04 LTS
+is_noble() {
+  if [[ "$osrelease" == "noble" ]]; then return 0; fi
+  [[ $(cat /etc/*release*) =~ "noble" ]]
   return $?
 }
 running_in_docker() {

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -68,7 +68,7 @@ show_main_menu() {
 
   elif [[ "$choice" == "03"* ]]; then
     wait_for_apt_to_finish_update
-    if is_buster || is_stretch; then
+    if ! is_supported; then
         whiptail --title "outdated OS" --msgbox "You are running a too old version of your Operating System.\\n\\nOpenHAB 4 and Java 17 require that you upgrade to Debian 11 (bullseye) first." 8 80
         return 255
     fi

--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -132,12 +132,12 @@ openhabian_update_check() {
 
   branch="${clonebranch:-HEAD}"
   introText="Additions, improvements or fixes were added to the openHABian configuration tool. Would you like to update now and benefit from them? The update will not automatically apply changes to your system.\\n\\nUpdating is recommended."
-  unsupportedOSText="You are running an old Linux release that is no longer officially supported.\\nWe recommend upgrading to the most current stable release of your distribution (or current Long Term Support version for distributions that offer LTS).\\nDo you really want to continue using openHABian on this system?"
+  unsupportedOSText="You are running an Linux release that is not officially supported.\\nWe recommend upgrading to the most current stable release of your distribution (or current Long Term Support version for distributions that offer LTS).\\nDo you really want to continue using openHABian on this system?"
 
   echo "$(timestamp) [openHABian] openHABian configuration tool version: $(get_git_revision)"
   echo -n "$(timestamp) [openHABian] Checking for changes in origin branch ${branch}... "
 
-  if is_stretch || is_xenial; then
+  if ! is_supported; then
     if ! (whiptail --title "Unsupported Linux release" --yes-button "Yes, Continue" --no-button "No, Exit" --defaultno --yesno "$unsupportedOSText" 13 80); then echo "SKIP"; exit 0; fi
   fi
 


### PR DESCRIPTION
This finishes the changes that I began making for unrelated reasons in
PR #1991 and uses more consistent identification of supported OS
versions.

Essentially, anything that is no longer maintained by it's respective
author/distributor should not be supported / maintained by us.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>
