### PR TITLE
use /etc/timezone if there over setting in /etc/openhabian.conf

### DIFF
--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -226,7 +226,7 @@ openhab_misc() {
 
   echo -n "$(timestamp) [openHABian] Setting openHAB timezone... "
   # tz sources order: 1) /etc/timezone 2) /etc/openhabian.conf 3) default UTC
-  # tz=$(cat /etc/timezone 2>/dev/null); timezone=${tz:=$timezone}
+  tz=$(cat /etc/timezone 2>/dev/null); timezone=${tz:=$timezone}
   if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*?)(interning=true)?|\1\2 -Duser.timezone=${timezone:-UTC}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -225,7 +225,8 @@ openhab_misc() {
   if cond_redirect sed -i -e 's|^#*.*OPENHAB_HTTPS_PORT=.*$|OPENHAB_HTTPS_PORT=8443|g' /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting openHAB timezone... "
-  if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*?)(interning=true)?|\1\2 -Duser.timezone=${timezone:-Europe/London}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
+  tz=$(cat /etc/timezone 2>/dev/null); timezone=${tz:=$timezone}
+  if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*?)(interning=true)?|\1\2 -Duser.timezone=${timezone:-UTC}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 
 ## Create a openHAB dashboard title and image for the input application.

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -225,7 +225,8 @@ openhab_misc() {
   if cond_redirect sed -i -e 's|^#*.*OPENHAB_HTTPS_PORT=.*$|OPENHAB_HTTPS_PORT=8443|g' /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 
   echo -n "$(timestamp) [openHABian] Setting openHAB timezone... "
-  tz=$(cat /etc/timezone 2>/dev/null); timezone=${tz:=$timezone}
+  # tz sources order: 1) /etc/timezone 2) /etc/openhabian.conf 3) default UTC
+  # tz=$(cat /etc/timezone 2>/dev/null); timezone=${tz:=$timezone}
   if cond_redirect sed -ri "s|^(EXTRA_JAVA_OPTS.*?)(interning=true)?|\1\2 -Duser.timezone=${timezone:-UTC}|g" /etc/default/openhab; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 


### PR DESCRIPTION
Please check a fresh install in your (non-default Berlin) timezone:
* does it ask you to enter tz?
* what does /etc/timezone contain? before and after, eventually?
* what does the timezone=line in openhabian.conf contain?
   If still "Berlin" we should think how to fix that by writing the freshly-set timezone back there.