### PR TITLE
intentionally display console default password when asking to change it

### DIFF
--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -139,8 +139,8 @@ openhab_shell_interfaces() {
 
   if [[ -n $INTERACTIVE ]]; then
     while [[ -z $sshPass ]]; do
-      if ! sshPass1="$(whiptail --title "Authentication setup" --passwordbox "$introText" 15 80 "$sshPass1" 3>&1 1>&2 2>&3)"; then echo "CANCELED"; return 0; fi
-      if ! sshPass2="$(whiptail --title "Authentication setup" --passwordbox "\\nPlease confirm the password:" 9 80 3>&1 1>&2 2>&3)"; then echo "CANCELED"; return 0; fi
+      if ! sshPass1="$(whiptail --title "Authentication setup" --inputbox "$introText" 15 80 "$sshPass1" 3>&1 1>&2 2>&3)"; then echo "CANCELED"; return 0; fi
+      if ! sshPass2="$(whiptail --title "Authentication setup" --inputbox "\\nPlease confirm the password:" 9 80 3>&1 1>&2 2>&3)"; then echo "CANCELED"; return 0; fi
       if [[ $sshPass1 == "$sshPass2" ]] && [[ ${#sshPass1} -ge 7 ]] && [[ ${#sshPass2} -ge 7 ]]; then
         sshPass="$sshPass1"
       else


### PR DESCRIPTION
On installing OH, users are asked for remote console password, plus to confirm they have to fill it in a 2nd time.

Users are mostly unaware what the default pass really is so showing that will ease installing.
