### PR TITLE
Update openhabian.md: make paths of boot partition clearer

### DIFF
--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -249,6 +249,8 @@ Each of these are included as a part of `openhabian-config` menu option 20.
 
 Many settings are configurable prior to the first boot of openHABian by changing the key value pairs in the `/boot/openhabian.conf` file on the SD card once you have flashed the initial image onto it.
 
+Please note that - in case you use a Windows system for writing the SD card - the `/boot/` partition will be mounted to a drive named `bootfs`. So, e.g. if this drive has the letter `D:`, `/boot/openhabian.conf` will be found as `D:\openhabian.conf`. 
+
 The openHABian configuration file uses key value pairs, essentially a list of `option=value` settings in a plain text file.
 All supported options are already in the file but unused options and optional components are commented out by default.
 Comments are defined by a `#` followed by a space, so any line you want to be ignored needs to start with a `# ` (yes the space is important).
@@ -401,7 +403,8 @@ clonebranch="openHAB"
 
 An initial configuration file to import when setting up openHAB.
 This file must be a `.zip` archive created by `openhab-cli backup`.
-ATTENTION: keep /boot/firmware as the directory if you provide an absolute path
+ATTENTION: keep /boot/firmware as the directory if you provide an absolute path.
+So use the existing `firmware` folder in the boot partition (Windows: on the `bootfs` drive) or create it and place the backup file named `initial.zip` in that folder.
 
 ::: details Example
 ```


### PR DESCRIPTION
As discussed here:

https://community.openhab.org/t/initial-setup-with-boot-firmware-inital-zip/164961?u=schup011

I propose to make it clearer what the /boot/ partition on the SD card looks like on a Windows system.