### PR TITLE
support trixie

### DIFF
--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -333,19 +333,25 @@ is_raspios() {
 }
 # Represents the current OS versions we officially support
 is_supported() {
-  if is_bullseye || is_bookworm || is_jellyfish || is_noble; then return 0; fi
+  if is_bullseye || is_bookworm || is_trixie || is_jellyfish || is_noble; then return 0; fi
   return 1;
 }
-# Debian/Raspbian oldstable
+# Debian/Raspbian oldoldstable
 is_bullseye() {
   if [[ "$osrelease" == "bullseye" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "bullseye" ]]
   return $?
 }
-# Debian/Raspbian stable
+# Debian/Raspbian oldstable
 is_bookworm() {
   if [[ "$osrelease" == "bookworm" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "bookworm" ]]
+  return $?
+}
+# Debian/Raspbian stable
+is_trixie() {
+  if [[ "$osrelease" == "trixie" ]]; then return 0; fi
+  [[ $(cat /etc/*release*) =~ "trixie" ]]
   return $?
 }
 # Debian/Raspbian unstable


### PR DESCRIPTION
While I don't know why current image shows to be trixie nor how to fix that, that currently results in menu option 03 refusing to upgrade so to (technically) support trixie is overdue.
Seems to be breaking menu 03 (Upgrade), too, so I'll quick-fix it without @ecdye waiting for your approval.
Will also build another image.

Eventually will do 1.11 when 32bit Java 21 is in.