### PR TITLE
Force new config

### DIFF
--- a/functions/helpers.bash
+++ b/functions/helpers.bash
@@ -333,19 +333,25 @@ is_raspios() {
 }
 # Represents the current OS versions we officially support
 is_supported() {
-  if is_bullseye || is_bookworm || is_jellyfish || is_noble; then return 0; fi
+  if is_bullseye || is_bookworm || is_trixie || is_jellyfish || is_noble; then return 0; fi
   return 1;
 }
-# Debian/Raspbian oldstable
+# Debian/Raspbian oldoldstable
 is_bullseye() {
   if [[ "$osrelease" == "bullseye" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "bullseye" ]]
   return $?
 }
-# Debian/Raspbian stable
+# Debian/Raspbian oldstable
 is_bookworm() {
   if [[ "$osrelease" == "bookworm" ]]; then return 0; fi
   [[ $(cat /etc/*release*) =~ "bookworm" ]]
+  return $?
+}
+# Debian/Raspbian stable
+is_trixie() {
+  if [[ "$osrelease" == "trixie" ]]; then return 0; fi
+  [[ $(cat /etc/*release*) =~ "trixie" ]]
   return $?
 }
 # Debian/Raspbian unstable

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -38,7 +38,7 @@ adoptium_fetch_apt() {
   echo "deb [signed-by=/usr/share/keyrings/${keyName}.gpg] https://packages.adoptium.net/artifactory/deb ${osrelease:-bookworm} main" > /etc/apt/sources.list.d/adoptium.list
 
   if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
-  if ! cond_redirect dpkg --configure -a; then echo "FAILED (dpkg)"; return 1; fi
+  if ! cond_redirect dpkg --configure -a --force-confnew; then echo "FAILED (dpkg)"; return 1; fi
   if cond_redirect apt-get install --download-only --yes "temurin-${1}-jre"; then echo "OK"; else echo "FAILED"; return 1; fi
 }
 
@@ -79,10 +79,10 @@ openjdk_fetch_apt() {
     echo -e "Package: *\\nPin: release a=unstable\\nPin-Priority: 90\\n" > /etc/apt/preferences.d/limit-unstable
     if ! cond_redirect apt-get update; then echo "FAILED (update apt lists)"; return 1; fi
 
-    if ! cond_redirect dpkg --configure -a; then echo "FAILED (dpkg)"; return 1; fi
+    if ! cond_redirect dpkg --configure -a --force-confnew; then echo "FAILED (dpkg)"; return 1; fi
     if cond_redirect apt-get install --download-only --yes -t unstable "openjdk-${1}-jre-headless"; then echo "OK"; else echo "FAILED (download)"; return 1; fi
   else
-    if ! cond_redirect dpkg --configure -a; then echo "FAILED (dpkg)"; return 1; fi
+    if ! cond_redirect dpkg --configure -a --force-confnew; then echo "FAILED (dpkg)"; return 1; fi
     if cond_redirect apt-get install --download-only --yes "openjdk-${1}-jre-headless"; then echo "OK"; else echo "FAILED (download)"; return 1; fi
   fi
 }

--- a/functions/openhab.bash
+++ b/functions/openhab.bash
@@ -72,7 +72,7 @@ openhab_setup() {
     rm -f /etc/apt/sources.list.d/openhab*.list
     echo "$repo" > /etc/apt/sources.list.d/openhab.list
 
-    dpkg --configure -a
+    dpkg --configure -a --force-confnew
     echo -n "$(timestamp) [openHABian] Installing openHAB... "
     if ! apt-get clean --yes -o DPkg::Lock::Timeout="$APTTIMEOUT"; then echo "FAILED (apt cache clean)"; return 1; fi
     cond_redirect apt-get update -o DPkg::Lock::Timeout="$APTTIMEOUT"

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -47,7 +47,7 @@ system_upgrade() {
 ##
 basic_packages() {
   echo -n "$(timestamp) [openHABian] Installing basic can't-be-wrong packages (screen, vim, ...)... "
-  dpkg --configure -a  # just in case to ensure apt works
+  dpkg --configure -a --force-confnew  # just in case to ensure apt works
 
   if cond_redirect apt-get -o DPkg::Lock::Timeout="$APTTIMEOUT" install --yes acl arping apt-utils bash-completion bzip2 coreutils \
     curl dirmngr git htop man-db mc multitail nano nmap lsb-release screen software-properties-common \

--- a/functions/wifi.bash
+++ b/functions/wifi.bash
@@ -140,7 +140,7 @@ setup_hotspot() {
     # shellcheck disable=SC2154
     sed -i -e "s|ap_password:.*$|ap_password: ${hotspotpw}|g" /etc/comitup.conf
 
-    DEBIAN_FRONTEND=noninteractive dpkg --configure -a &>/dev/null
+    DEBIAN_FRONTEND=noninteractive dpkg --configure -a --force-confnew &>/dev/null
     DEBIAN_FRONTEND=noninteractive apt install --yes -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' comitup &>/dev/null
     systemctl enable --now comitup
     comitup-cli d


### PR DESCRIPTION
Not sure if we should always use the latest conf file as offer by the package maintainer but I believe for a fresh openHABian this in doubt is the best option (we need to run unattended so have to choose either `--force-confold` or `--force-confnew`).

Unsure, too, if it's sufficient to use in `dpkg --configure -a` 'cleanup checkpoints' as they exist in the code or we should add it to all `apt` install commands, too.

Fixes: #2029 