### PR TITLE
Fix persistance of frontail prompt

### DIFF
--- a/build-image/openhabian.conf
+++ b/build-image/openhabian.conf
@@ -80,7 +80,7 @@ java_opt=Temurin21
 # osrelease=
 
 # Remember user frontail choice
-# frontail_remove=true
+frontail_remove=false
 
 # install zram per default, set to "disable" to skip installation
 zraminstall=enable


### PR DESCRIPTION
This should make it such that the frontail prompt is persistant rather that being forgotten every time the tool updates.