### PR TITLE
Update docs for OH5 and 64 bit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,19 @@ Hit tab to unselect buttons and scroll through the text using UP/DOWN or
 PGUP/PGDN. All announcements are stored in `/opt/openhabian/docs/CHANGELOG.md`
 for you to lookup.
 
-## Recommended 32/64 bit Java providers ## July 31, 2025
+## 64 bit OS support only ## Aug 1, 2025
 
-For 64bit, the default in openHABian will Temurin 21.
-For 32 bit, there is no officially version of Java 21 available that
-is known to be well supported and stable. Check your OS for 32/64 bitness
-using getconf LONG_BIT and read the openHAB release notes at
+With openHAB 5, we are sorry but we have to drop support for 32 bit systems.
+There is no officially supported and stable version of Java 21 available that
+runs on ARM hardware with a 32 bit Linux.
+Check your OS for 32/64 bit using getconf LONG_BIT and read the release notes
 https://github.com/openhab/openhab-distro/releases/tag/5.0.0#openhabian
 to find out how to proceed with your openHAB upgrade to version 5.
+Starting with openHABian v1.11, the upgrade menu function (03) will no longer
+work if you are still on an 32 bit system.
+You can still manually select to install Temurin 21 Java and openHAB 
+but be aware that you will be running an unsupported version of openHAB so
+if you run into any trouble, please do not ask for help but upgrade to 64.
 
 
 ## openHAB 5 released ## July 21, 2025

--- a/README.md
+++ b/README.md
@@ -59,18 +59,22 @@ We provide code that is reported "as-is" to run on Ubuntu but we do not support 
 Several optional components such as WireGuard or Homegear are known to expose problems on Ubuntu.
 
 Note with openHAB 4 and Java 17, `buster` and older distros are no longer supported and there'll be issues when you attempt upgrading Java 11->17.
+Note openHAB 5 and Java 21 require a 64 bit image.
 Should you still be running an older distribution, we recommend not to upgrade the distro but to re-install using the latest openHABian image and import your config instead.
 
-### 64 bit?
-RPi 3 and newer have a 64 bit processor. There's openHABian images available in both, 32 and 64 bit.
-Choose yours based on your hardware and primary use case. Please be aware that you cannot change once you decided in favor of either 32 or 64 bit. Should you need to revoke your choice, export/backup your config and install a fresh system, then import your config there.
 
-Use the 64 bit image versions but please be aware that 64 bit always has one major drawback: increased memory usage. That is not a good idea on heavily memory constrained platforms like Raspberries. If you want to go with 64 bit, ensure your RPi has a minimum of 2 GB, 4 will put you on the safe side.
-You can use the 32 bit version for older or non official addons that will not work on 64 bit yet.
-Note there's a known issue on 32 bit, JS rules are reported to be annoyingly slow on first startup and in some Blockly use cases.
-If you consider using the (newer but still experimental) Java version 21, if possible choose 64 bit.
+### on 64 bit
+openHAB 5 requires to run on a 64 bit OS and Java 21 version so the recommended openHABian image is the 64 bit version.
 
-On x86 hardware, it's all 64 bit but that in turn once more increases memory usage. A NUC to run on should have no less than 8 GB.
+Many RPi users are still on a 32 bit based Linux OS. You can check bitness using the command `getconf LONG_BIT`.
+64 bit has one major drawback: increased memory usage. That is not a good idea on heavily memory constrained platforms like older Raspberries. So if you want to go with 64 bit, ensure your RPi has a minimum of 2 GB, 4 will put you on the safe side.
+On x86 hardware, it's all 64 bit but that in turn once more increases memory usage. A NUC to run on should have no less than 4 GB, 8 are better.
+
+You can *temporarily* use the 32 bit version if you want to stay with openHAB 4 or if you cannot upgrade your HW or OS at the very moment, BUT
+ATTENTION: RUNNING openHAB 5 on any 32 bit OS image IS NOT SUPPORTED ANY MORE and known to have issues with some functions like JS scripting.
+Please don't ask for help if you nonetheless run in 32 and hit trouble.
+You cannot change your OS once you decided in favor of either 32 or 64 bit, so should you decide to upgrade, export/backup your config and install a fresh system, then import your config there.
+
 
 
 ## Installation and Setup

--- a/build-image/template_rpi-imager-openhab.json
+++ b/build-image/template_rpi-imager-openhab.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "openHABian (32 bit)",
-      "description": "This version can be used for systems with less memory like a RPi 3.",
+      "description": "Fallback version. This version can be used for RPIs with less than 2 GB of memory.\nBe prepared that you might run into issues when you attempt to run openHAB 5.\nParts of 5 requires a 64 bit OS and Java. You can run openHAB 4 with this image.",
       "url": "%url32_latest%",
       "icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMzIgMzIiPgoJPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNmZmYiLz4KCTxwYXRoIGZpbGw9IiNlNjRhMTkiIGQ9Im01LjI0MiAyMS4xMzMgOS4zOS05LjM5OEwxNiAxMC4zNjhsMS4zNjcgMS4zNjcgNi45MzMgNi45MzMtLjAxLjAzNS0uMTM3LjQwMi0uMTU2LjM5NC0uMTc0LjM4My0uMTkyLjM3NC0uMTc1LjMwNEwxNiAxMy4xMDMgNi4yNCAyMi44N2MtLjM3Ny0uNTUzLS43MjUtMS4xMjMtLjk5OC0xLjczOHoiLz4KCTxwYXRoIGZpbGw9IiM0NzQ3NDciIGQ9Ik0xNiA0YzYuNjEgMCAxMiA1LjM5IDEyIDEycy01LjM5IDEyLTEyIDEyYy0zLjYxIDAtNi44NTYtMS42MS05LjA1OS00LjE0N2wuNDI0LS40MjUuMzA4LS4zMDguMzA4LS4zMS4zMDktLjMwNy4wMTMtLjAxM0ExMC4wNTcgMTAuMDU3IDAgMCAwIDE2IDI2LjA3N2M1LjU1IDAgMTAuMDc4LTQuNTI2IDEwLjA3OC0xMC4wNzdTMjEuNTUgNS45MjIgMTYgNS45MjJDMTAuNDQ5IDUuOTIyIDUuOTIyIDEwLjQ1IDUuOTIyIDE2YzAgLjc0Ny4wODMgMS40NzYuMjM5IDIuMTc4bC0uNjY4LjY3LS44OTMuODkzQTExLjkyMiAxMS45MjIgMCAwIDEgNCAxNkM0IDkuMzkgOS4zOSA0IDE2IDR6Ii8+Cjwvc3ZnPgo=",
       "extract_size": %imageE_size32_latest%,

--- a/docs/openhabian.md
+++ b/docs/openhabian.md
@@ -45,7 +45,7 @@ With that being said, we can't and won't stop you from doing whatever you want, 
 
 Our current recommendation is to get a Raspberry Pi model 4 or 5 with 2 or 4 GB of RAM, whatever you can get for a good price.
 Older RPi models (or models with less RAM) can be sufficient to run a smallish openHAB setup.
-Please note that running 64bit mode on RPi's with only 1 GB of RAM tends not to work super well.
+Please note that running 64bit mode on RPi with only 1 GB of RAM tends not to work super well.
 
 You will need an SD card to go along with your Raspberry Pi, SD cards labelled "Endurance" are best for openHABian.
 Cards labelled "Endurance" can handle more write cycles and will typically last longer for openHAB's use conditions.
@@ -58,11 +58,16 @@ This will give you a ready to go drop in replacement in the case of any hardware
 All Raspberry Pi models are supported by openHABian.
 
 ::: tip Note
-With the upcoming openHAB 5 release, we will drop support for anything older than an RPi 3 as openHAB 5 will require a 64 bit processor.
+With openHAB 5 release, we have dropped support for anything older than an RPi 3 as openHAB 5 requires a 64 bit processor.
 :::
+
+
+Running in 64 bit has one major drawback: increased memory usage. That is not a good idea on heavily memory constrained platforms like older Raspberries. Ensure your RPi has a minimum of 2 GB, 4 will put you on the safe side.
+For older hardware, you can attempt to use the 32 bit image we still provide, it should work but we do not support running openHAB 5.
 
 openHABian can run on x86 based systems but you will need to install debian yourself.
 See [installation on other Linux systems](#installation-on-other-linux-systems) for directions on what to do.
+On x86 hardware, it's all 64 bit but that in turn once more increases memory usage. A NUC to run on should have no less than 4 GB, 8 are better.
 
 All other system combinations do not have official support.
 We do not actively prohibit installation on any hardware, including unsupported systems, *but we will **not** offer support for any issues you encounter*.
@@ -72,13 +77,19 @@ This will help you and those you will want to ask for help on the forum focus on
 
 ##### 32/64 Bit Image Support
 
-Any RPi 3 or newer supports 64 bit operation.
-Unless you really know what you are doing and have a compelling reason to do so, stick with the 64 bit image.
-If you do install a 32 bit image, please note that you will be unable to upgrade to openHAB 5 in the future.
+openHAB 5 requires to run on a 64 bit OS and Java 21 version so the recommended openHABian image is the 64 bit version.
 
-On systems with only 1 GB of RAM running the 64 bit image may cause issues as there may not be sufficient RAM.
-If you observe issues please consider upgrading to a model with more that 1 GB of RAM.
+Many RPi users are still on a 32 bit based Linux OS.
+(You can check bitness using the command `getconf LONG_BIT`)
 
+You can *temporarily* use the 32 bit version if you want to stay with openHAB 4 or if you cannot upgrade your HW or OS at the very moment, BUT
+ATTENTION: RUNNING openHAB 5 on any 32 bit OS image IS NOT SUPPORTED ANY MORE.
+You will be having issues with some functions like JS Scripting. Reinstall your OS to 64 bit or stay with openHAB 4.
+Should you decide to upgrade, check the openHAB 5 release notes how to export/backup your config and install a fresh system.
+https://github.com/openhab/openhab-distro/releases/tag/5.0.0#openhabian
+
+
+## Installation and Setup
 ### Networking
 
 You need to connect your Raspberry Pi to the network by Ethernet or configure Wi-Fi settings before first boot.

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -73,7 +73,7 @@ show_main_menu() {
         return 255
     fi
     if is_arm && [[ "$(getconf LONG_BIT)" == "32" ]]; then
-        whiptail --title "32 bit OS" --msgbox "You are running a 32 bit Operating System.\\nOpenHAB 5 and Java 21 require that you upgrade your OS to a 64 bit version.\\nYou can manually install via menus 45 and 41." 9 80
+        whiptail --title "32 bit OS" --msgbox "You are running a 32 bit Operating System.\\nOpenHAB 5 and Java 21 require that you upgrade your OS to a 64 bit version, please read the release notes at\\nhttps://github.com/openhab/openhab-distro/releases/tag/5.0.0#openhabian\\nYou can still manually install via menus 45 and 41." 10 80
         return 255
     fi
 

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -69,7 +69,11 @@ show_main_menu() {
   elif [[ "$choice" == "03"* ]]; then
     wait_for_apt_to_finish_update
     if ! is_supported; then
-        whiptail --title "outdated OS" --msgbox "You are running a too old version of your Operating System.\\n\\nOpenHAB 4 and Java 17 require that you upgrade to Debian 11 (bullseye) first." 8 80
+        whiptail --title "outdated OS" --msgbox "You are running a too old version of your Operating System.\\n\\nYou need to upgrade to be running at least Debian 11 (bullseye).\\nWe do NOT recommend to dist-upgrade but to re-install using the openHABian 64 bit image." 9 80
+        return 255
+    fi
+    if is_arm && [[ "$(getconf LONG_BIT)" == "32" ]]; then
+        whiptail --title "32 bit OS" --msgbox "You are running a 32 bit Operating System.\\n\\nOpenHAB 5 and Java 21 require that you upgrade to a 64 bit version." 8 80
         return 255
     fi
 

--- a/functions/menu.bash
+++ b/functions/menu.bash
@@ -69,11 +69,11 @@ show_main_menu() {
   elif [[ "$choice" == "03"* ]]; then
     wait_for_apt_to_finish_update
     if ! is_supported; then
-        whiptail --title "outdated OS" --msgbox "You are running a too old version of your Operating System.\\n\\nYou need to upgrade to be running at least Debian 11 (bullseye).\\nWe do NOT recommend to dist-upgrade but to re-install using the openHABian 64 bit image." 9 80
+        whiptail --title "outdated OS" --msgbox "You are running a too old version of your Operating System.\\nYou need to upgrade to be running at least Debian 11 (bullseye).\\nWe do NOT recommend to dist-upgrade but to re-install using the openHABian 64 bit image." 9 80
         return 255
     fi
     if is_arm && [[ "$(getconf LONG_BIT)" == "32" ]]; then
-        whiptail --title "32 bit OS" --msgbox "You are running a 32 bit Operating System.\\n\\nOpenHAB 5 and Java 21 require that you upgrade to a 64 bit version." 8 80
+        whiptail --title "32 bit OS" --msgbox "You are running a 32 bit Operating System.\\nOpenHAB 5 and Java 21 require that you upgrade your OS to a 64 bit version.\\nYou can manually install via menus 45 and 41." 9 80
         return 255
     fi
 
@@ -215,11 +215,11 @@ show_main_menu() {
     "42 | Remote Console"                 "Bind the openHAB SSH console to all external interfaces" \
     "43 | Clean cache"                    "Clean the cache for openHAB" \
     "44 | Nginx Proxy"                    "Setup reverse and forward web proxy" \
-    "45 | OpenJDK 17"                     "Install and activate OpenJDK 17 as Java provider (default)" \
-    "   | OpenJDK 21"                     "Install and activate OpenJDK 21 as Java provider (DO NOT USE WILL BREAK SYSTEM - upcoming default when fixed)" \
-    "   | Temurin 17"                     "Install and activate Temurin 17 as Java provider (default alternative)" \
-    "   | Temurin 21"                     "Install and activate Temurin 21 as Java provider (upcoming alternative, currently preferred)" \
-    "   | OpenJDK 11"                     "Install and activate OpenJDK 11 as Java provider (legacy)" \
+    "45 | OpenJDK 17"                     "Install + activate OpenJDK 17 as Java provider (default for OH versions 4 and older)" \
+    "   | OpenJDK 21"                     "Install + activate OpenJDK 21 as Java provider (DO NOT USE WILL BREAK SYSTEM)" \
+    "   | Temurin 17"                     "Install + activate Temurin 17 as Java provider (fallback for OH versions 4 and older)" \
+    "   | Temurin 21"                     "Install + activate Temurin 21 as Java provider (default)" \
+    "   | OpenJDK 11"                     "Install + activate OpenJDK 11 as Java provider (legacy)" \
     "46 | Install openhab-js"             "JS Scripting: Upgrade to latest version of openHAB JavaScript library (advanced)" \
     "   | Uninstall openhab-js"           "JS Scripting: Switch back to included version of openHAB JavaScript library" \
     "47 | Install openhab_rules_tools"    "JS Scripting: Manually install openhab_rules_tools (auto-installed)" \


### PR DESCRIPTION
OHian now refuses to upgrade to OH5 via menu 03 if on 32 bit.
But I've kept manual install via menu 41 / 45 as a backdoor.

I've added some more explanations, warnings and references, please cross-check.
Do you think this is appropriately worded?

This I want to release as v1.11 (so among others it changes the description in Raspi imager, too).

