### PR TITLE
Confnewfix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,16 @@ Get in contact early in the development to propose your idea.
 Fork the repo and make changes on your fork in a feature branch.
 Then be sure to also provide or update the documentation right when creating or modifying features.
 
+* if adding a new function, see which of the functions/*.bash files it fits in best
+* create install_xxx() routine and make it work with arguments "install" and "remove"
+* Make sure install_xxx() works in interactive as well as non-interactive (unattended) mode
+  If user input is required, create another parameter in openhabian.conf (source for that is in build-image/)
+  To test:
+  source functions/helpers.bash; source functions/packages.bash; set -x
+  install_xxx arg1 arg2 ... argn
+* add BATS tests for "install" and "remove"
+
+
 ### Code architecture
 Always write clean, modular and testable code.
 We have a simple [code-style](#codestyle) which in combination with the static linter [ShellCheck](https://www.shellcheck.net/) works as our coding guidelines.

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -47,7 +47,7 @@ adoptium_fetch_apt() {
   if [[ $(getconf LONG_BIT) == 32 ]]; then
     if ! cond_redirect wget -nv -O "${cachedir}/${cachefile}" "${URL}/${pkgfile}"; then echo "FAILED (download JVM pkg)"; rm -f "${cachedir}/${cachefile}"; return 1; fi
   else
-    if ! cond_redirect dpkg --configure -a; then echo "FAILED (dpkg)"; return 1; fi
+    if ! cond_redirect dpkg --configure -a --confnew; then echo "FAILED (dpkg)"; return 1; fi
     if cond_redirect apt-get install --download-only --yes "temurin-${1}-jre"; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 }


### PR DESCRIPTION
force latest pkg config on dpkg install to avoid hanging in question

This is the last place we used dpkg without that --confnew option.
I even had this in earlier and backed it out again but cannot remember why.
OTOH users can be affected, depending on the order of them selecting menu options, and some guy on the forum was hit by this so I think we should try again and you're warned just in case so can back it out if needed.