### PR TITLE
force latest pkg config on dpkg install to avoid hanging in question

### DIFF
--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -47,7 +47,7 @@ adoptium_fetch_apt() {
   if [[ $(getconf LONG_BIT) == 32 ]]; then
     if ! cond_redirect wget -nv -O "${cachedir}/${cachefile}" "${URL}/${pkgfile}"; then echo "FAILED (download JVM pkg)"; rm -f "${cachedir}/${cachefile}"; return 1; fi
   else
-    if ! cond_redirect dpkg --configure -a; then echo "FAILED (dpkg)"; return 1; fi
+    if ! cond_redirect dpkg --configure -a --confnew; then echo "FAILED (dpkg)"; return 1; fi
     if cond_redirect apt-get install --download-only --yes "temurin-${1}-jre"; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 }


### PR DESCRIPTION
force latest pkg config on dpkg install to avoid hanging in question

This is the last place we used dpkg without that --confnew option.
I even had this in earlier and backed it out again but cannot remember why.

@ecdye OTOH users can be affected, depending on the order of them selecting menu options, and some guy on the forum was hit by this so I think we should try again and you're warned just in case so can back it out if needed.
