### PR TITLE
offline (pre-) install all basic packages

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -64,12 +64,12 @@ jobs:
            echo "image32=$(ls openhabian-raspios32-latest*.img.xz)" >> $GITHUB_OUTPUT
            echo "image64=$(ls openhabian-raspios64-latest*.img.xz)" >> $GITHUB_OUTPUT
            echo "json_image=$(ls rpi-imager-openhab.json)" >> $GITHUB_OUTPUT
-       - name: Archive openHABian 32bit Debian 12 bookworm image
+       - name: Archive openHABian 32bit Debian 12 trixie image
          uses: actions/upload-artifact@v4
          with:
            name: ${{ steps.build.outputs.image32 }}
            path: ${{ steps.build.outputs.image32 }}
-       - name: Archive openHABian 64bit Debian 12 bookworm image
+       - name: Archive openHABian 64bit Debian 12 trixie image
          uses: actions/upload-artifact@v4
          with:
            name: ${{ steps.build.outputs.image64 }}

--- a/build-image/offline-install-modifications.bash
+++ b/build-image/offline-install-modifications.bash
@@ -50,10 +50,8 @@ apt-get --quiet install --download-only --yes
   python3-itsdangerous python3-jinja2 python3-markupsafe \
   python3-networkmanager python3-pyinotify python3-simplejson python3-werkzeug \
   python3 python3-pip python3-wheel python3-setuptools \
-  samba screen sysstat tailscale temurin-21-jre usbutils util-linux \
-  unzip vfu vim wget whiptail xz-utils zip zlib1g
-
-  nmap-common screen telnet vfu vfu-yascreen vim vim-runtime
+  samba screen sysstat tailscale telnet temurin-21-jre usbutils util-linux \
+  unzip vfu vfu-yascreen vim vim-runtime wget whiptail xz-utils zip zlib1g
 
   source /opt/openhabian/functions/nodejs-apps.bash
 nodejs_setup

--- a/build-image/offline-install-modifications.bash
+++ b/build-image/offline-install-modifications.bash
@@ -53,7 +53,7 @@ apt-get --quiet install --download-only --yes
   samba screen sysstat tailscale telnet temurin-21-jre usbutils util-linux \
   unzip vfu vfu-yascreen vim vim-runtime wget whiptail xz-utils zip zlib1g
 
-  source /opt/openhabian/functions/nodejs-apps.bash
+source /opt/openhabian/functions/nodejs-apps.bash
 nodejs_setup
 
 apt-get --quiet autoremove --yes

--- a/build-image/offline-install-modifications.bash
+++ b/build-image/offline-install-modifications.bash
@@ -38,11 +38,14 @@ apt-get --quiet install --download-only --yes
   acl amanda-common amanda-server amanda-client apt-transport-https arping \
   avahi-daemon bash-completion bc bzip2 comitup coreutils curl \
   dnsutils dns-root-data dnsmasq-base dirmngr exim4 fontconfig gdisk git \
-  htop iotop javascript-common jq \
-  libc6 libcairo2 libgudev-1.0-0 libjs-jquery libmbim-glib4 libmbim-proxy \
-  libmm-glib0 libndp0 libnm0 libpixman-1-0 libqmi-glib5 libqmi-proxy libstdc++6 \
-  libteamdctl0 libxcb-render0 libxcb-shm0 libxrender1 \
-  make man-db mc mailutils modemmanager moreutils multitail nano network-manager \
+  htop inetutils-telnet iotop javascript-common jq \
+  libblas3 libc6 libcairo2 libgudev-1.0-0 libjs-jquery libmbim-glib4 libgpm2 \
+  liblinear4 liblua5.4-0 libmbim-proxy \
+  libmm-glib0 libndp0 libnet1 libnm0 libpcre2-32-0 \
+  libpixman-1-0 libqmi-glib5 libqmi-proxy libsodium23i libstdc++6 \
+  libteamdctl0 libxcb-render0 libxcb-shm0 libxrender1 libyascreen0 \
+  make man-db mc mc-data mailcap mailutils modemmanager moreutils multitail \
+  nano network-manager nmap nmap-common \
   python3-blinker python3-cairo python3-click python3-colorama python3-flask \
   python3-itsdangerous python3-jinja2 python3-markupsafe \
   python3-networkmanager python3-pyinotify python3-simplejson python3-werkzeug \
@@ -50,7 +53,9 @@ apt-get --quiet install --download-only --yes
   samba screen sysstat tailscale temurin-21-jre usbutils util-linux \
   unzip vfu vim wget whiptail xz-utils zip zlib1g
 
-source /opt/openhabian/functions/nodejs-apps.bash
+  nmap-common screen telnet vfu vfu-yascreen vim vim-runtime
+
+  source /opt/openhabian/functions/nodejs-apps.bash
 nodejs_setup
 
 apt-get --quiet autoremove --yes

--- a/build-image/offline-install-modifications.bash
+++ b/build-image/offline-install-modifications.bash
@@ -33,8 +33,7 @@ adoptium_fetch_apt
 
 apt-get --quiet update
 apt-get --quiet upgrade --yes --force-confnew
-apt-get --quiet install --download-only --yes
-  openhab openhab-addons \
+apt-get --quiet install --download-only --yes openhab openhab-addons \
   acl amanda-common amanda-server amanda-client apt-transport-https arping \
   avahi-daemon bash-completion bc bzip2 comitup coreutils curl \
   dnsutils dns-root-data dnsmasq-base dirmngr exim4 fontconfig gdisk git \

--- a/functions/java-jre.bash
+++ b/functions/java-jre.bash
@@ -47,7 +47,7 @@ adoptium_fetch_apt() {
   if [[ $1 == "21" ]] && [[ $(getconf LONG_BIT) == 32 ]]; then
     if ! cond_redirect wget -nv -O "${cachedir}/${cachefile}" "${URL}/${pkgfile}"; then echo "FAILED (download JVM pkg)"; rm -f "${cachedir}/${cachefile}"; return 1; fi
   else
-    if ! cond_redirect dpkg --configure -a --confnew; then echo "FAILED (dpkg)"; return 1; fi
+    if ! cond_redirect dpkg --configure -a; then echo "FAILED (dpkg)"; return 1; fi
     if cond_redirect apt-get install --download-only --yes "temurin-${1}-jre"; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 }

--- a/functions/vpn.bash
+++ b/functions/vpn.bash
@@ -197,8 +197,8 @@ install_tailscale() {
   fi
 
   echo "$(timestamp) [openHABian] Installing tailscale VPN... "
-  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
-  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
+  curl -fsSL https://pkgs.tailscale.com/stable/debian/trixie.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+  curl -fsSL https://pkgs.tailscale.com/stable/debian/trixie.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
   cond_redirect apt-get update -o DPkg::Lock::Timeout="$APTTIMEOUT"
 
   # Install tailscale


### PR DESCRIPTION
@ecdye fyi
Yesterday already I made a couple of changes without having you cross-check these to make install succeed based on latest trixie based Raspi OS 
Most notably we had to remove installing the `software-properties-common` package.
Plus I changed the pre-installed Java to Temurin 21 to work with OH5, and sorted the pkgs by name.

This PR now finally adds pkgs to offline install step that otherwise are installed later as 'basic packages'.

Fixes: #1987 