### PR TITLE
Add CMDLINETXT variable for flexible boot file paths

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -3,6 +3,11 @@
 
 CONFIGFILE="/etc/openhabian.conf"
 
+CONFIGTXT=/boot/config.txt
+if [ -e /boot/firmware/config.txt ] ; then
+  CONFIGTXT=/boot/firmware/config.txt
+fi
+
 # apt/dpkg commands will not try interactive dialogs
 export DEBIAN_FRONTEND="noninteractive"
 export SILENT="1"
@@ -110,7 +115,7 @@ if is_pi && is_bookworm; then
 elif grep -qs "up" /sys/class/net/eth0/operstate; then
   # Actually check if ethernet is working
   echo "$(timestamp) [openHABian] Setting up Ethernet connection... OK"
-elif [[ -n $wifiSSID ]] && grep -qs "openHABian" /etc/wpa_supplicant/wpa_supplicant.conf && ! grep -qsE "^[[:space:]]*dtoverlay=(pi3-)?disable-wifi" /boot/config.txt; then
+elif [[ -n $wifiSSID ]] && grep -qs "openHABian" /etc/wpa_supplicant/wpa_supplicant.conf && ! grep -qsE "^[[:space:]]*dtoverlay=(pi3-)?disable-wifi" "${CONFIGTXT}"; then
   echo -n "$(timestamp) [openHABian] Checking if WiFi is working... "
   if iwlist wlan0 scan |& grep -qs "Interface doesn't support scanning"; then
     ip link set wlan0 up

--- a/functions/ext-storage.bash
+++ b/functions/ext-storage.bash
@@ -24,7 +24,7 @@ move_root2usb() {
   local srcSize
   local destSize
 
-  rootPart="$(tr ' ' '\n' < /boot/cmdline.txt | grep 'root=PARTUUID=' | cut -d'=' -f2-)"
+  rootPart="$(tr ' ' '\n' < "${CMDLINETXT}" | grep 'root=PARTUUID=' | cut -d'=' -f2-)"
   srcSize="$(blockdev --getsize64 /dev/mmcblk0)"
   destSize="$(blockdev --getsize64 "$newRootDev")"
 
@@ -100,8 +100,8 @@ move_root2usb() {
   if ! cond_redirect sed -i 's|'"${rootPart}"'|'"${newRootPart}"'|' /mnt/etc/fstab; then echo "FAILED (fstab)"; return 1; fi
 
   cond_echo "\\nAdjusting system root in cmdline.txt"
-  if ! cond_redirect cp /boot/cmdline.txt /boot/cmdline.txt.sdcard; then echo "FAILED (backup cmdline.txt)"; return 1; fi
-  if cond_redirect sed -i 's|root='"${rootPart}"'|root='"${newRootPart}"'|' /boot/cmdline.txt; then echo "OK (reboot required)"; else echo "FAILED"; return 1; fi
+  if ! cond_redirect cp "${CMDLINETXT}" "${CMDLINETXT}.sdcard"; then echo "FAILED (backup cmdline.txt)"; return 1; fi
+  if cond_redirect sed -i 's|root='"${rootPart}"'|root='"${newRootPart}"'|' "${CMDLINETXT}"; then echo "OK (reboot required)"; else echo "FAILED"; return 1; fi
 
   whiptail --title "Operation successful" --msgbox "The system root has successfully been moved to the USB. PLEASE REBOOT!\\n\\nIn the unlikely case that the reboot does not succeed, please put the SD card into another device and copy back '/boot/cmdline.txt.sdcard' to '/boot/cmdline.txt'." 11 80
 }

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -561,19 +561,19 @@ prepare_serial_port() {
     else
       if ! (echo "enable_uart=1" >> "${CONFIGTXT}"); then echo "FAILED (uart)"; return 1; fi
     fi
-    if ! cond_redirect cp /boot/cmdline.txt /boot/cmdline.txt.bak; then echo "FAILED (backup cmdline.txt)"; return 1; fi
-    if ! cond_redirect sed -i -e 's|console=tty.*console=tty1|console=tty1|g' /boot/cmdline.txt; then echo "FAILED (console)"; return 1; fi
-    if ! cond_redirect sed -i -e 's|console=serial.*console=tty1|console=tty1|g' /boot/cmdline.txt; then echo "FAILED (serial)"; return 1; fi
+    if ! cond_redirect cp "${CMDLINETXT}" "${CMDLINETXT}.bak"; then echo "FAILED (backup cmdline.txt)"; return 1; fi
+    if ! cond_redirect sed -i -e 's|console=tty.*console=tty1|console=tty1|g' "${CMDLINETXT}"; then echo "FAILED (console)"; return 1; fi
+    if ! cond_redirect sed -i -e 's|console=serial.*console=tty1|console=tty1|g' "${CMDLINETXT}"; then echo "FAILED (serial)"; return 1; fi
     cond_echo "Disabling serial-getty service"
     if ! cond_redirect systemctl disable --now serial-getty@ttyAMA0.service; then echo "FAILED (disable serial-getty@ttyAMA0.service)"; return 1; fi
     if ! cond_redirect systemctl disable --now serial-getty@serial0.service; then echo "FAILED (disable serial-getty@serial0.service)"; return 1; fi
     if cond_redirect systemctl disable --now serial-getty@ttyS0.service; then echo "OK (reboot required)"; else echo "FAILED (disable serial-getty@ttyS0.service)"; return 1; fi
   else
-    if [[ -f /boot/cmdline.txt.bak ]]; then
+    if [[ -f "${CMDLINETXT}.bak" ]]; then
       echo -n "$(timestamp) [openHABian] Disabling serial port and enabling serial console... "
       if ! cond_redirect sed -i -e '/^#*.*enable_uart=.*$/d' "${CONFIGTXT}"; then echo "FAILED (uart)"; return 1; fi
-      if ! cond_redirect cp /boot/cmdline.txt.bak /boot/cmdline.txt; then echo "FAILED (restore cmdline.txt)"; return 1; fi
-      if ! cond_redirect rm -f /boot/cmdline.txt.bak; then echo "FAILED (remove backup)"; return 1; fi
+      if ! cond_redirect cp "${CMDLINETXT}.bak" "${CMDLINETXT}"; then echo "FAILED (restore cmdline.txt)"; return 1; fi
+      if ! cond_redirect rm -f "${CMDLINETXT}.bak"; then echo "FAILED (remove backup)"; return 1; fi
       cond_echo "Enabling serial-getty service"
       if ! cond_redirect systemctl enable --now serial-getty@ttyAMA0.service; then echo "FAILED (enable serial-getty@ttyAMA0.service)"; return 1; fi
       if ! cond_redirect systemctl enable --now serial-getty@serial0.service; then echo "FAILED (enable serial-getty@serial0.service)"; return 1; fi

--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -77,10 +77,13 @@ OLDWD="$(pwd)"
 cd /opt || exit 1
 
 CONFIGTXT=/boot/config.txt
+CMDLINETXT=/boot/cmdline.txt
 if is_bookworm; then
   CONFIGTXT=/boot/firmware/config.txt
+  CMDLINETXT=/boot/firmware/cmdline.txt
 fi
 export CONFIGTXT
+export CMDLINETXT
 
 # update openhabian.conf to have latest set of parameters
 update_openhabian_conf


### PR DESCRIPTION
Introduces the CMDLINETXT variable to handle systems where /boot/cmdline.txt may reside in /boot/firmware/cmdline.txt, similar to CONFIGTXT. Updates all script references to cmdline.txt to use CMDLINETXT. The definition of CMDLINETXT is identical to CONFIGTXT in openhabian-setup.sh (referring to "is_bookworm") to enable future extension for trixie.