### PR TITLE
various trixie fixes

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -107,18 +107,12 @@ if is_trixie || is_bookworm && is_pi; then	# attention no brackets => left-assoc
   systemctl enable --now NetworkManager
   nmcli g
   nmcli r wifi on
-  nmcli g
-  nmcli r wifi on
-  nmcli g
 
   if [[ -n $wifiSSID ]]; then
     # Setup WiFi via NetworkManager
     # shellcheck source=/etc/openhabian.conf disable=SC2154
     nmcli g
     nmcli -w 30 d wifi connect "${wifiSSID}" password "${wifiPassword}" ifname wlan0
-    nmcli g
-    nmcli -w 30 d wifi connect "${wifiSSID}" password "${wifiPassword}" ifname wlan0
-    nmcli g
   fi
 elif grep -qs "up" /sys/class/net/eth0/operstate; then
   # Actually check if ethernet is working

--- a/functions/system.bash
+++ b/functions/system.bash
@@ -68,18 +68,15 @@ needed_packages() {
   # Install python3/python3-pip/python3-wheel/python3-setuptools - for python packages
   echo -n "$(timestamp) [openHABian] Installing additional needed packages... "
   if cond_redirect apt-get -o DPkg::Lock::Timeout="$APTTIMEOUT" install --yes apt-transport-https avahi-daemon bc jq mbpoll \
-    moreutils python3 python3-pip python3-wheel python3-setuptools sysstat \
-    fontconfig; \
-  then echo "OK"; else echo "FAILED"; return 1; fi
+    moreutils python3 python3-pip python3-wheel python3-setuptools sysstat fontconfig; then echo "OK"; else echo "FAILED"; return 1; fi
   if is_pi_wlan && [[ -z $PREOFFLINE ]]; then
     echo -n "$(timestamp) [openHABian] Installing python3 serial package... "
-    if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" python3-smbus python3-serial; then echo "OK"; else echo "FAILED"; return 1; fi
+    if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" python3-smbus python3-serial; then echo "OK"; else echo "FAILED"; fi
     echo -n "$(timestamp) [openHABian] Installing pigpio package... "
-    if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" pigpio; then echo "OK"; else echo "FAILED"; return 1; fi
+    if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" rgpiod; then echo "OK"; else echo "FAILED"; fi
     echo -n "$(timestamp) [openHABian] Installing additional bluetooth packages... "
     if cond_redirect apt-get install --yes -o DPkg::Lock::Timeout="$APTTIMEOUT" bluez python3-dev libbluetooth-dev \
-      raspberrypi-sys-mods pi-bluetooth; \
-    then echo "OK"; else echo "FAILED"; return 1; fi
+      raspberrypi-sys-mods pi-bluetooth; then echo "OK"; else echo "FAILED"; fi
   fi
 }
 
@@ -455,9 +452,8 @@ change_swapsize() {
   ((size/=1024))
 
   echo -n "$(timestamp) [openHABian] Adjusting swap size to $size MB... "
-  if ! cond_redirect dphys-swapfile swapoff; then echo "FAILED (swapoff)"; return 1; fi
-  if ! cond_redirect sed -i 's|^#*.*CONF_SWAPSIZE=.*$|CONF_SWAPSIZE='"${size}"'|g' /etc/dphys-swapfile; then echo "FAILED (swapfile)"; return 1; fi
-  if cond_redirect dphys-swapfile swapon; then echo "OK (reboot required)"; else echo "FAILED (swapon)"; return 1; fi
+  # TBD
+  # dphys-swapfile is no longer available in trixie
 }
 
 ## Reduce the RPi GPU memory to the minimum to allow for the system to utilize


### PR DESCRIPTION
remove pigpio (no longer available in trixie and said to not work with RPi5), installed rgpiod instead
I vaguely remember homegear needs pigpio so not sure if it will work without, there was one report of a failing homegear install, may or may not be caused by the already missing pigpio pkg. Adding `rgpiod` may or may not fix that, but although I'm using it myself I'm not willing to go down the homegear rabbit hole to figure out.

Removed dphys-swapfile based setting of swapsize (no longer available in trixie) for now.
That's another potential rabbit hole as in trixie this was replaced by the `rpi-swap` pkg which is zram based now.
I've added another issue for that and assigned it to you. Sorry ;-)