### PR TITLE
Add tryUntil() check to ensure user exists before modification

### DIFF
--- a/build-image/first-boot.bash
+++ b/build-image/first-boot.bash
@@ -75,6 +75,10 @@ if is_raspbian || is_raspios; then
   rm -f "/etc/sudoers.d/010_pi-nopasswd"
 fi
 
+# Wait until user exists
+echo "$(timestamp) [openHABian] Waiting for user creation..."
+tryUntil "id -u $userName >/dev/null 2>&1" 120 1
+
 echo -n "$(timestamp) [openHABian] Changing default username ... "
 # shellcheck disable=SC2154
 if [[ -z ${userName} ]] || ! id "$defaultUserAndGroup" &> /dev/null || id "$userName" &> /dev/null; then


### PR DESCRIPTION
On first boot, the user created via /boot/userconf.txt may not yet be available when openHABian applies username/password modifications.

This adds a tryUntil() loop before the username/passwd handling to ensure the user actually exists before modifications are applied.

Prevents skipped username changes and chpasswd errors.