### PR TITLE
Add `is_trixie` for CMDLINETXT path definition

### DIFF
--- a/openhabian-setup.sh
+++ b/openhabian-setup.sh
@@ -78,7 +78,7 @@ cd /opt || exit 1
 
 CONFIGTXT=/boot/config.txt
 CMDLINETXT=/boot/cmdline.txt
-if is_bookworm; then
+if is_trixie || is_bookworm; then
   CONFIGTXT=/boot/firmware/config.txt
   CMDLINETXT=/boot/firmware/cmdline.txt
 fi


### PR DESCRIPTION
This adds is_trixie as check on file path for like in PR #2080

Extends the CMDLINETXT variable to handle systems where `/boot/cmdline.txt` may reside in `/boot/firmware/cmdline.txt`, similar to CONFIGTXT also for debian 13. It extends the `is_bookworm` check to enable usage for trixie also. 