### PR TITLE
Update openHAB branch label to 5

### DIFF
--- a/functions/openhabian.bash
+++ b/functions/openhabian.bash
@@ -183,7 +183,7 @@ openhabian_update() {
   if [[ $# == 1 ]]; then
     branch="$1"
   elif [[ -n $INTERACTIVE ]]; then
-    radioOptions=("release" "most recommended version that supports openHAB 4 (openHAB branch)" "OFF")
+    radioOptions=("release" "most recommended version that supports openHAB 5 (openHAB branch)" "OFF")
     radioOptions+=("latest" "the latest of openHABian, not well tested (main branch)" "OFF")
 
     case "$current" in


### PR DESCRIPTION
Updates the menu text in openhabian_update() from openHAB 4 to openHAB 5.