### PR TITLE
Fix deCONZ install

### DIFF
--- a/functions/packages.bash
+++ b/functions/packages.bash
@@ -708,7 +708,7 @@ deconz_setup() {
   fi
   echo "deb [signed-by=/usr/share/keyrings/${keyName}.gpg${arch}] http://phoscon.de/apt/deconz generic main" > $repo
 
-  if ! cond_redirect mkdir "${appData}" && fix_permissions "${appData}" "${username:-openhabian}:${username:-openhabian}" 664 775 && ln -sf "${appData}" /home/"${username:-openhabian}"/.local; then echo "FAILED (deCONZ database on zram)"; return 1; fi
+  if ! cond_redirect mkdir -p "${appData}" && fix_permissions "${appData}" "${username:-openhabian}:${username:-openhabian}" 664 775 && ln -sf "${appData}" /home/"${username:-openhabian}"/.local; then echo "FAILED (deCONZ database on zram)"; return 1; fi
   echo -n "$(timestamp) [openHABian] Preparing deCONZ repository ... "
   if cond_redirect apt-get update; then echo "OK"; else echo "FAILED (update apt lists)"; fi
   


### PR DESCRIPTION
Use mkdir -p for /var/lib/openhab/persistence/deCONZ so unattended installs don't fail if a backup restore recreated the directory.