### PR TITLE
Replace deprecated grafana-cli by grafana cli

### DIFF
--- a/functions/auth.bash
+++ b/functions/auth.bash
@@ -92,7 +92,7 @@ change_password() {
   fi
   if [[ $chosenAccounts == *"Grafana"* ]]; then
     echo -n "$(timestamp) [openHABian] Changing password for Grafana admininistration account \"admin\"... "
-    if grafana-cli admin reset-admin-password --homepath "/usr/share/grafana" --config "/etc/grafana/grafana.ini" "$pass"; then echo "OK"; else echo "FAILED"; return 1; fi
+    if grafana cli admin reset-admin-password --homepath "/usr/share/grafana" --config "/etc/grafana/grafana.ini" "$pass"; then echo "OK"; else echo "FAILED"; return 1; fi
   fi
 
   if [[ -n $INTERACTIVE ]]; then

--- a/functions/influxdb+grafana.bash
+++ b/functions/influxdb+grafana.bash
@@ -269,7 +269,7 @@ grafana_install(){
   # Password reset required if Grafana password was already set before (not first-time install)
   cond_echo "\\nResetting Grafana admin password... "
   if ! cond_redirect chsh --shell /bin/bash "grafana"; then echo "FAILED (chsh grafana)"; return 1; fi
-  if ! cond_redirect grafana-cli admin reset-admin-password "${adminPassword}"; then echo "FAILED (admin password)"; return 1; fi
+  if ! cond_redirect grafana cli admin reset-admin-password "${adminPassword}"; then echo "FAILED (admin password)"; return 1; fi
 
   cond_echo "\\nUpdating Grafana configuration... "
   if ! cond_redirect sed -i -e '/^# disable user signup \/ registration/ { n ; s/^;allow_sign_up = true/allow_sign_up = false/ }' /etc/grafana/grafana.ini; then echo "FAILED (no user signup)"; return 1; fi


### PR DESCRIPTION
A deprecation warning is shown with current versions of Grafana:

~~~
Deprecation warning: 'grafana-cli' is deprecated and will be removed in a future release. Use the 'grafana cli' subcommand instead.
~~~