### PR TITLE
Fix SD mirroring of zram-managed data and first-boot zram failure

### DIFF
--- a/docs/openhabian-backup.md
+++ b/docs/openhabian-backup.md
@@ -41,6 +41,9 @@ If you can't find the same model, play it safe and buy a model larger than what 
 We also provide a couple of different options to allow you to backup your system to a local NAS, cloud storage, or a second SD card.
 For more information on these options, please see [Storage Preparation](#storage-preparation).
 
+Note that the semiannual raw copy reads the SD card at the block level, so any log and persistence data still held in ZRAM (i.e. written since the last ZRAM sync or reboot) will not be part of the raw copy.
+The daily rsync run covers this by copying the live view of those directories, so a mirror card will at most be a day behind on ZRAM-held data.
+
 ##### Moving the Root Filesystem
 
 Moving your system root to a USB stick or SSD is unsupported and dangerous.

--- a/functions/backup.bash
+++ b/functions/backup.bash
@@ -416,6 +416,9 @@ mirror_SD() {
     if ! cond_redirect dd if="${src}p1" bs=1M of="${dest}1" status=progress; then echo "FAILED (raw device copy of ${dest}1)"; dirty="yes"; fi
     if ! cond_redirect dd if="${src}p2" bs=1M of="${dest}2" status=progress; then echo "FAILED (raw device copy of ${dest}2)"; dirty="yes"; fi
     sfdisk -d ${src} | grep -q "^${src}p3" && if ! cond_redirect dd if="${src}p3" bs=1M of="${dest}3" status=progress; then echo "FAILED (raw device copy of ${dest}3)"; dirty="yes"; fi
+    # flush kernel buffers and let udev settle so blkid/mount see the freshly written partitions
+    cond_redirect sync
+    cond_redirect udevadm settle
     origPartUUID="$(blkid "${src}p2" | sed -n 's|^.*PARTUUID="\(\S\+\)".*|\1|p' | sed -e 's/-02//g')"
     if ! partUUID="$(yes | set-partuuid "${dest}2" random | awk '/^PARTUUID/ { print substr($7,1,length($7) - 3) }')"; then echo "FAILED (set random PARTUUID)"; dirty="yes"; fi
     if ! cond_redirect e2fsck -f -y "${dest}2"; then echo "FAILED (e2fsck)"; dirty="yes"; fi
@@ -428,6 +431,8 @@ mirror_SD() {
     mount "${dest}2" "$syncMount"
     sed -i "s|${origPartUUID}|${partUUID}|g" "$syncMount"/etc/fstab
     [[ -f "${syncMount}/etc/systemd/system/${storageDir}".mount ]] && sed -i 's|^What=.*|What=/dev/mmcblk0p3|g' "${syncMount}/etc/systemd/system/${storageDir}".mount
+    # remove zram state captured from the live system, else zram-config skips device creation on the clone's first boot
+    rm -f "${syncMount}/usr/local/lib/zram-config/zram-device-list"
     umount "$syncMount"
     if ! cond_redirect fsck -y -t ext4 "${dest}2"; then echo "OK (dirty bit on fsck ${dest}2 is normal)"; dirty="yes"; fi
     if [[ "$dirty" == "no" ]]; then
@@ -453,8 +458,12 @@ mirror_SD() {
     mount "$dest" "$syncMount"
     if ! (mountpoint -q "$syncMount"); then echo "FAILED (${dest} is not mounted as ${syncMount})"; return 1; fi
     cond_redirect rsync --one-file-system --exclude={'/etc/fstab','/etc/systemd/system/*.mount','/opt/zram','/srv/*'} --delete -aKRh "/" "$syncMount"
-    cond_redirect rsync --one-file-system --delete -aKh "/var/lib/openhab/persistence/" "${syncMount}/opt/zram/persistence.bind"
-    cond_redirect rsync --one-file-system --delete -aKh "/var/log/" "${syncMount}/opt/zram/log.bind"
+    # sync the live overlay (merged) view into the clone's lower dirs, i.e. the plain paths zram-config
+    # uses as lowerdir on boot; the *.bind mountpoints are shadowed by bind mounts and must not be targets
+    cond_redirect rsync --one-file-system --delete -aKh "/var/lib/openhab/persistence/" "${syncMount}/var/lib/openhab/persistence/"
+    cond_redirect rsync --one-file-system --delete -aKh "/var/log/" "${syncMount}/var/log/"
+    # remove zram state captured from the live system, else zram-config skips device creation on the clone's first boot
+    rm -f "${syncMount}/usr/local/lib/zram-config/zram-device-list"
     if ! (umount "$syncMount" &> /dev/null); then
       sleep 1
       umount -l "$syncMount" &> /dev/null


### PR DESCRIPTION
Fixes #2156

Validates and fixes the findings from the [community test bench report](https://community.openhab.org/t/sd-mirror-zram-in-openhabian-test-bench-findings-and-empirical-fixes-for-live-raw-copy-and-sync-sd/170097).

## Confirmed bugs

### Sync SD wrote zram data where the clone never reads it
`zram-config` bind-mounts the *target* directory (e.g. `/var/log`) onto the `.bind` path and uses that bind as the overlay lowerdir, so on-disk lower data lives at the plain path itself. `mirror_SD "diff"` rsynced live logs/persistence into `${syncMount}/opt/zram/*.bind`, which is shadowed by the bind mount as soon as the clone boots. Additionally, because `/var/log` and the persistence dir are overlay mounts on the running system, the main rsync's `--one-file-system` + `--delete` combination actively emptied those directories on the clone. The two rsyncs now target `${syncMount}/var/log/` and `${syncMount}/var/lib/openhab/persistence/` directly (a harmless no-op when zram is not installed).

### Stale zram-device-list broke the clone's first boot
`/usr/local/lib/zram-config/zram-device-list` lives on the root filesystem and was carried over by both raw copies and syncs. On the clone's first boot `zram-config start` finds the entries and skips device creation entirely. The file is now removed from the target in both the raw and diff paths.

## Hardening

`sync` + `udevadm settle` now run between the `dd` copies and `set-partuuid` to close the window where stale buffers / unsettled udev events caused intermittent PARTUUID assignment failures on loaded systems.

## Docs

Documented that raw (block-level) copies cannot capture data still held in zram; the daily rsync now covers that gap, so a mirror card is at most a day behind. Deliberately did **not** add a forced `zram-config sync` before raw copies since remounting the `/var/log` overlay mid-operation risks the same log4j2 breakage that led to the zsync timer being disabled.

## Testing

- shellcheck clean on `functions/backup.bash`
- Logic validated against `zram-config` (openHAB branch) source: bind direction (`mount --bind $TARGET_DIR $BIND_DIR`, overlay `lowerdir=$BIND_DIR` mounted on `$TARGET_DIR`) and start-skip behavior on existing `zram-device-list` entries
- Hardware test on a mirror setup would be welcome; the forum author offered a test bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)