### PR TITLE
Update sdrsync timer description to 2-hour interval and documentation

### DIFF
--- a/docs/openhabian-backup.md
+++ b/docs/openhabian-backup.md
@@ -42,7 +42,7 @@ We also provide a couple of different options to allow you to backup your system
 For more information on these options, please see [Storage Preparation](#storage-preparation).
 
 Note that the semiannual raw copy reads the SD card at the block level, so any log and persistence data still held in ZRAM (i.e. written since the last ZRAM sync or reboot) will not be part of the raw copy.
-The daily rsync run covers this by copying the live view of those directories, so a mirror card will at most be a day behind on ZRAM-held data.
+The rsync run which runs every 2 hours covers this by copying the live view of those directories, so a mirror card will at most be a couple of hours behind on ZRAM-held data.
 
 ##### Moving the Root Filesystem
 

--- a/includes/SD/sdrsync.timer
+++ b/includes/SD/sdrsync.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run SD rsync daily except semiannually (when a raw dump is made)
+Description=Run SD rsync every 2 hours except semiannually (when a raw dump is made)
 
 [Timer]
 Unit=sdrsync.service


### PR DESCRIPTION
While performing tests of rsync to SD I realized that the SD sync is performed every 2 hours while in the documentation it is still described as daily. It was modified from daily to every two hours in commit fc1bd43e.
I simply updated the description in sdrsync.timer and a few words in openhabian-backup.md